### PR TITLE
feat: createSession コマンドを追加して Jules セッション作成を実装

### DIFF
--- a/jules-extention/package.json
+++ b/jules-extention/package.json
@@ -38,6 +38,10 @@
       {
         "command": "jules-extention.listSources",
         "title": "List Jules Sources"
+      },
+      {
+        "command": "jules-extention.createSession",
+        "title": "Create Jules Session"
       }
     ]
   },


### PR DESCRIPTION
- 達成事項:
実際に拡張機能からjulesに委任して作成されたpr https://github.com/is0692vs/jules-extention/pull/17
    1. **コマンド実装**: `Create Jules Session` コマンドを追加，コマンドパレットから実行可能
    2. **UI実装**:
        - InputBox: タスクの説明を入力
        - InputBox: セッションタイトルを入力（オプション）
        - QuickPick: 自動PR作成のYes/No選択
    3. **API統合**: Jules API `/v1alpha/sessions` POST エンドポイント呼び出し実装
    4. **リクエスト構造**: 公式ドキュメント準拠の形式
        - `sourceContext`: Issue #3で選択したSource情報
        - `automationMode`: PR作成の自動化設定
        - `prompt`: ユーザー入力のタスク説明
        - `title`: セッションタイトル（オプション）
    5. **セッションID保存**: `context.globalState`に`active-session-id`として保存
    6. **TypeScript型定義**: `SessionRequest`, `SessionResponse` インターフェース定義
    7. **進捗通知**: API呼び出し中の進捗表示とセッション作成完了通知
    8. **エラーハンドリング**:
        - API Key未設定チェック
        - Source未選択チェック
        - ネットワークエラー処理
        - API レスポンスエラー処理
    9. **コード品質**: ESLintエラー修正，TypeScriptコンパイル成功，テスト通過

**技術的メモ**:

- **エンドポイント**: `632`
- **保存キー**: `active-session-id` (globalState)
- **Source取得**: Issue #3で保存した`selected-source`を使用
- **UI/UX**: 段階的な入力フローで直感的な操作体験