### PR TITLE
feat: Jules セッション用 TreeView を追加し、リフレッシュ機能を実装

### DIFF
--- a/jules-extention/package.json
+++ b/jules-extention/package.json
@@ -42,8 +42,32 @@
       {
         "command": "jules-extention.createSession",
         "title": "Create Jules Session"
+      },
+      {
+        "command": "jules-extention.refreshSessions",
+        "title": "Refresh Jules Sessions",
+        "icon": "$(refresh)"
       }
-    ]
+    ],
+    "views": {
+      "explorer": [
+        {
+          "id": "julesSessionsView",
+          "name": "Jules Sessions",
+          "icon": "$(robot)",
+          "contextualTitle": "Jules Sessions"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "jules-extention.refreshSessions",
+          "when": "view == julesSessionsView",
+          "group": "navigation"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",


### PR DESCRIPTION
<img width="374" height="51" alt="image" src="https://github.com/user-attachments/assets/96c613a6-a42f-4c3c-a4b7-8e9448d18fda" />

- 達成事項:
    1. **TreeViewプロバイダー実装**: `JulesSessionsProvider`クラスを作成
        - `TreeDataProvider`インターフェース実装
        - API呼び出しでセッション一覧取得
        - データ変更イベントハンドリング
    2. **TreeItem実装**: `SessionTreeItem`クラスを作成
        - セッションタイトルと状態を表示
        - 状態に応じたアイコン表示
            - `RUNNING`: スピンアイコン（進行中）
            - `COMPLETED`: チェックアイコン（完了）
            - `FAILED`: エラーアイコン（失敗）
            - `CANCELLED`: クローズアイコン（キャンセル）
    3. **UI統合**: package.jsonにTreeView登録
        - サイドバー「Jules Sessions」ビュー追加
        - リフレッシュボタン（viewTitle menu）追加
    4. **リフレッシュ機能**: `refreshSessions`コマンド実装
        - 手動でセッション一覧を最新化
        - TreeViewを再描画
    5. **API統合**: Jules API `/v1alpha/sessions` GET呼び出し
    6. **TypeScript型定義**: `Session`, `SessionsResponse` インターフェース定義
    7. **エラーハンドリング**:
        - API Key未設定時は空リスト表示
        - ネットワークエラー処理
        - エラー時にエラーメッセージを表示
    8. **コード品質**: TypeScriptコンパイル成功，テスト通過（100%）