### PR TITLE
Add 'Open Jules Settings' command and apply custom prompts

### DIFF
--- a/jules-extension/package.json
+++ b/jules-extension/package.json
@@ -51,7 +51,7 @@
           "minimum": 10,
           "description": "Auto-refresh interval in seconds (minimum: 10)"
         },
-        "jules-extension.customPrompts": {
+        "jules-extension.customPrompt": {
           "type": "string",
           "default": "",
           "description": "A custom prompt to automatically prepend to every message sent to Jules. This acts as a persistent instruction.",

--- a/jules-extension/src/extension.ts
+++ b/jules-extension/src/extension.ts
@@ -106,9 +106,7 @@ function buildFinalPrompt(userPrompt: string): string {
   const customPrompt = vscode.workspace
     .getConfiguration("jules-extension")
     .get<string>("customPrompt", "");
-  return customPrompt
-    ? `${customPrompt}\n\n${userPrompt}`
-    : userPrompt;
+  return customPrompt ? `${customPrompt}\n\n${userPrompt}` : userPrompt;
 }
 
 function resolveSessionId(
@@ -1212,7 +1210,7 @@ export function activate(context: vscode.ExtensionContext) {
   const openSettingsDisposable = vscode.commands.registerCommand(
     "jules-extension.openSettings",
     () => {
-      vscode.commands.executeCommand(
+      return vscode.commands.executeCommand(
         "workbench.action.openSettings",
         "@ext:HirokiMukai.jules-extension"
       );


### PR DESCRIPTION
Introduce a command to open the Jules settings and integrate custom prompts into message sending and session creation processes. Enhance input validation for empty messages.