### PR TITLE
Implement 9-state icon mapping for session tree items

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -817,13 +817,13 @@ export class JulesSessionsProvider
   implements vscode.TreeDataProvider<vscode.TreeItem> {
   private static silentOutputChannel: vscode.OutputChannel = {
     name: 'silent-channel',
-    append: () => {},
-    appendLine: () => {},
-    replace: () => {},
-    clear: () => {},
-    show: () => {},
-    hide: () => {},
-    dispose: () => {},
+    append: () => { },
+    appendLine: () => { },
+    replace: () => { },
+    clear: () => { },
+    show: () => { },
+    hide: () => { },
+    dispose: () => { },
   };
 
   private _onDidChangeTreeData: vscode.EventEmitter<
@@ -1081,7 +1081,7 @@ export class JulesSessionsProvider
 }
 
 export class SessionTreeItem extends vscode.TreeItem {
-  // API state to icon mapping for 9 states
+  // API state to icon mapping for 10 states
   private static readonly stateIconMap: Record<string, vscode.ThemeIcon> = {
     'STATE_UNSPECIFIED': new vscode.ThemeIcon('question'),
     'QUEUED': new vscode.ThemeIcon('watch'),


### PR DESCRIPTION
### **User description**
Introduce a detailed mapping of API states to VSCode standard icons for session tree items, enhancing user experience with tooltips that provide human-readable state descriptions. Maintain backward compatibility with existing notification logic while simplifying the icon retrieval process. All tests pass successfully.


___

### **PR Type**
Enhancement


___

### **Description**
- Maps all 9 API states to VSCode standard icons with tooltips

- Simplifies icon retrieval using direct rawState mapping

- Adds human-readable state descriptions in session tooltips

- Maintains backward compatibility with existing notification logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["9 API States"] -->|stateIconMap| B["VSCode ThemeIcons"]
  A -->|stateDescriptionMap| C["Human-readable Descriptions"]
  B --> D["SessionTreeItem Icon"]
  C --> E["Tooltip Display"]
  F["getIcon Method"] -->|simplified| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>extension.ts</strong><dd><code>Implement 9-state icon and description mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/extension.ts

<ul><li>Added <code>stateIconMap</code> static mapping for all 9 API states to VSCode <br>ThemeIcons<br> <li> Added <code>stateDescriptionMap</code> static mapping for state descriptions in <br>tooltips<br> <li> Updated tooltip generation to include state description from <code>rawState</code><br> <li> Simplified <code>getIcon()</code> method to use direct <code>rawState</code> mapping instead of <br>intermediate state<br> <li> Removed legacy switch statement handling RUNNING, CANCELLED states</ul>


</details>


  </td>
  <td><a href="https://github.com/is0692vs/jules-extension/pull/253/files#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626">+39/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

