### PR TITLE
Update GitHub Actions for release process simplification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
 
@@ -34,84 +34,8 @@ jobs:
         run: vsce package
 
       - name: Create Release
-        uses: actions/github-script@v8
+        uses: softprops/action-gh-release@v2
         with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-
-            const vsixDir = './';
-            const files = fs.readdirSync(vsixDir);
-            const vsixFile = files.find((file) => file.endsWith('.vsix'));
-
-            if (!vsixFile) {
-              throw new Error('VSIX file not found. Ensure vsce package succeeded.');
-            }
-
-            const vsixPath = path.join(vsixDir, vsixFile);
-            const vsixData = fs.readFileSync(vsixPath);
-            const tagName = context.ref.replace('refs/tags/', '');
-
-            async function ensureRelease() {
-              try {
-                const created = await github.rest.repos.createRelease({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  tag_name: tagName,
-                  name: `Release ${tagName}`,
-                  draft: false,
-                  prerelease: false,
-                  generate_release_notes: true
-                });
-                core.info(`Created new release for ${tagName}`);
-                return created.data;
-              } catch (error) {
-                if (error.status !== 422) {
-                  throw error;
-                }
-
-                core.info(`Release for ${tagName} already exists. Reusing existing release.`);
-                const existing = await github.rest.repos.getReleaseByTag({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  tag: tagName
-                });
-                return existing.data;
-              }
-            }
-
-            const release = await ensureRelease();
-
-            const assets = await github.paginate(github.rest.repos.listReleaseAssets, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: release.id,
-              per_page: 100
-            });
-
-            const existingAsset = assets.find(asset => asset.name === vsixFile);
-            if (existingAsset) {
-              core.info(`Deleting existing asset ${existingAsset.name} (id: ${existingAsset.id})`);
-              await github.rest.repos.deleteReleaseAsset({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                asset_id: existingAsset.id
-              });
-            }
-
-            await github.rest.repos.uploadReleaseAsset({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: release.id,
-              name: vsixFile,
-              data: vsixData,
-              headers: {
-                'content-type': 'application/octet-stream',
-                'content-length': Buffer.byteLength(vsixData)
-              }
-            });
-
-            core.info(`Release ready at ${release.html_url}`);
-            core.info(`Uploaded VSIX asset ${vsixFile}`);
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: "*.vsix"
+          generate_release_notes: true
+          fail_on_unmatched_files: true


### PR DESCRIPTION
### **User description**
Downgrade versions of checkout and setup-node actions, and replace the release creation script with action-gh-release to streamline the release process.


___

### **PR Type**
Enhancement


___

### **Description**
- Downgrade GitHub Actions versions for compatibility

- Replace custom release script with action-gh-release

- Simplify release creation and asset upload process


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["checkout@v6.0.1<br/>setup-node@v6"] -->|Downgrade| B["checkout@v4<br/>setup-node@v4"]
  C["Custom github-script<br/>with 80+ lines"] -->|Replace| D["softprops/action-gh-release<br/>with simple config"]
  D -->|Streamlined| E["Release creation<br/>and asset upload"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Downgrade actions and replace release script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Downgrade <code>actions/checkout</code> from v6.0.1 to v4<br> <li> Downgrade <code>actions/setup-node</code> from v6 to v4<br> <li> Replace 80-line custom <code>actions/github-script</code> with <br><code>softprops/action-gh-release@v2</code><br> <li> Simplify release configuration to use <code>files</code>, <code>generate_release_notes</code>, <br>and <code>fail_on_unmatched_files</code> parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/jules-extension/pull/299/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+6/-82</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

