### PR TITLE
テスト強化: errorUtilsの単体テストを追加

### DIFF
--- a/src/test/errorUtils.unit.test.ts
+++ b/src/test/errorUtils.unit.test.ts
@@ -29,11 +29,12 @@ suite('ErrorUtils Unit Test Suite', () => {
         const lines = result.split('\n');
         // sanitizeError returns: message + '\n' + stackLine1 + '\n' + stackLine2 ...
         // So we expect 4 lines: message, then the 3 lines of stack
-        assert.strictEqual(lines.length, 4);
-        assert.strictEqual(lines[0], 'error with stack');
-        assert.strictEqual(lines[1], 'Error: error with stack');
-        assert.strictEqual(lines[2], '    at func1 (file.ts:1:1)');
-        assert.strictEqual(lines[3], '    at func2 (file.ts:2:2)');
+        assert.deepStrictEqual(lines, [
+            'error with stack',
+            'Error: error with stack',
+            '    at func1 (file.ts:1:1)',
+            '    at func2 (file.ts:2:2)'
+        ]);
     });
 
     test('sanitizeError handles non-Error objects (string)', () => {
@@ -56,8 +57,6 @@ suite('ErrorUtils Unit Test Suite', () => {
         const error = new Error(longMessage);
         const result = sanitizeError(error);
 
-        // sanitizeForLogging defaults to 500 chars
-        assert.ok(result.length <= 500 + (error.stack ? error.stack.length : 1000)); // check message part roughly
         // The message part specifically should be truncated
         const firstLine = result.split('\n')[0];
         assert.ok(firstLine.endsWith('...'));


### PR DESCRIPTION
`src/errorUtils.ts` 内の `sanitizeError` 関数のための単体テスト `src/test/errorUtils.unit.test.ts` を追加しました。
標準エラー、スタックトレースのサニタイズ、非エラーオブジェクトの処理、および長いメッセージの切り捨てなど、主要なケースをカバーしています。

---
*PR created automatically by Jules for task [5701291848829716477](https://jules.google.com/task/5701291848829716477) started by @is0692vs*