### PR TITLE
Remove debug logging for API response

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1152,13 +1152,6 @@ export class JulesSessionsProvider
         return;
       }
 
-      // デバッグ: APIレスポンスの生データを確認
-      logChannel.appendLine(`Jules: Debug - Raw API response sample (first 3 sessions):`);
-      data.sessions.slice(0, 3).forEach((s: any, i: number) => {
-        logChannel.appendLine(`  [${i}] name=${s.name}, state=${s.state}, title=${sanitizeForLogging(s.title)}`);
-        logChannel.appendLine(`      updateTime=${s.updateTime}`);
-      });
-
       logChannel.appendLine(`Jules: Found ${data.sessions.length} total sessions`);
 
       // Filter out sessions that are currently being deleted to prevent race conditions


### PR DESCRIPTION
Removed debug logging of raw API response data in `src/extension.ts` to prevent verbose output in production. This includes removing the `logChannel.appendLine` calls that were outputting raw session data. Verified that the removal did not affect core functionality or compilation.

---
*PR created automatically by Jules for task [11386757020089505165](https://jules.google.com/task/11386757020089505165) started by @is0692vs*