### PR TITLE
Refactor chat webview assets out of minified literals

### DIFF
--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -29,8 +29,12 @@ let markdownRenderer: MarkdownIt | null = null;
 let markdownRendererInit: Promise<void> | null = null;
 
 export async function initMarkdownRenderer(): Promise<void> {
-  if (markdownRenderer) return;
-  if (markdownRendererInit) return markdownRendererInit;
+  if (markdownRenderer) {
+    return;
+  }
+  if (markdownRendererInit) {
+    return markdownRendererInit;
+  }
 
   markdownRendererInit = (async () => {
     try {
@@ -107,7 +111,9 @@ export async function initMarkdownRenderer(): Promise<void> {
 }
 
 export function renderChatMarkdown(markdown: string): string {
-  if (!markdownRenderer) return escapeHtml(markdown);
+  if (!markdownRenderer) {
+    return escapeHtml(markdown);
+  }
   return markdownRenderer.render(markdown);
 }
 
@@ -120,7 +126,9 @@ const GENERATING_SESSION_STATES: ReadonlySet<string> = new Set([
 export function isGeneratingSessionState(
   rawState: string | undefined,
 ): boolean {
-  if (!rawState) return false;
+  if (!rawState) {
+    return false;
+  }
   return GENERATING_SESSION_STATES.has(rawState);
 }
 
@@ -205,36 +213,39 @@ export function buildChatMessagesFromActivities(
       getActivityLabelPrefix(activity) +
       getActivitySummaryText(activity);
     let detailsHtml = "";
-    if (activity.sessionFailed?.reason)
+    if (activity.sessionFailed?.reason) {
       detailsHtml +=
         '<details class="activity-details"><summary>View Error Details</summary><div class="details-content code-block"><pre><code>' +
         escapeHtml(activity.sessionFailed.reason) +
         "</code></pre></div></details>";
-    if (activity.planGenerated?.plan)
+    }
+    if (activity.planGenerated?.plan) {
       detailsHtml +=
         '<details class="activity-details"><summary>View Plan</summary><div class="details-content">' +
         renderChatMarkdown(formatFullPlan(activity.planGenerated.plan)) +
         "</div></details>";
+    }
     if ((activity as any).gitPatch?.diff) {
       const diff = (activity as any).gitPatch.diff;
-      if (typeof diff === "string" && diff.trim().length > 0)
+      if (typeof diff === "string" && diff.trim().length > 0) {
         detailsHtml +=
           '<details class="activity-details"><summary>View Diff</summary><div class="details-content">' +
           renderChatMarkdown("```diff\n" + diff + "\n```") +
           "</div></details>";
+      }
     }
     if (activity.artifacts && activity.artifacts.length > 0) {
       activity.artifacts.forEach((artifact, i) => {
         if (artifact.changeSet) {
           const diffData = (artifact.changeSet as any).gitPatch?.unidiffPatch;
-          if (diffData && typeof diffData === "string")
+          if (diffData && typeof diffData === "string") {
             detailsHtml +=
               '<details class="activity-details"><summary>View ChangeSet (' +
               (i + 1) +
               ')</summary><div class="details-content">' +
               renderChatMarkdown("```diff\n" + diffData + "\n```") +
               "</div></details>";
-          else {
+          } else {
             let raw = "";
             try {
               raw = JSON.stringify(artifact.changeSet, null, 2);
@@ -320,11 +331,15 @@ export class JulesChatViewProvider implements vscode.WebviewViewProvider {
         this.postState();
         return;
       }
-      if (message?.type !== "sendMessage") return;
+      if (message?.type !== "sendMessage") {
+        return;
+      }
       const sessionId =
         typeof message.sessionId === "string" ? message.sessionId : "";
       const text = typeof message.text === "string" ? message.text.trim() : "";
-      if (!sessionId || !text) return;
+      if (!sessionId || !text) {
+        return;
+      }
       try {
         await this.onSendMessage(sessionId, text);
       } catch (error) {
@@ -334,12 +349,13 @@ export class JulesChatViewProvider implements vscode.WebviewViewProvider {
         );
       }
     });
-    if (this.state.sessionId)
+    if (this.state.sessionId) {
       this.state.messages = buildChatMessagesFromActivities(
         this.activities,
         this.sessionTitle,
         this.sessionCreateTime,
       );
+    }
     this.postState();
   }
   updateSession(
@@ -364,7 +380,9 @@ export class JulesChatViewProvider implements vscode.WebviewViewProvider {
     this.postState();
   }
   private postState(): void {
-    if (!this.view) return;
+    if (!this.view) {
+      return;
+    }
     void Promise.resolve(
       this.view.webview.postMessage({ type: "chatState", payload: this.state }),
     ).catch((err: unknown) =>

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -1,3 +1,4 @@
+import { CHAT_CSS, CHAT_JS } from "./webview/chatAssets";
 import * as crypto from "crypto";
 import * as vscode from "vscode";
 import MarkdownIt from "markdown-it";
@@ -40,9 +41,21 @@ export async function initMarkdownRenderer(): Promise<void> {
       });
 
       const defaultFence = md.renderer.rules.fence?.bind(md.renderer.rules);
-      md.renderer.rules.fence = (tokens: any[], idx: number, options: any, env: any, self: any) => {
-        const rendered = defaultFence ? defaultFence(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options);
-        return '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code">Copy</button>' + rendered + '</div>';
+      md.renderer.rules.fence = (
+        tokens: any[],
+        idx: number,
+        options: any,
+        env: any,
+        self: any,
+      ) => {
+        const rendered = defaultFence
+          ? defaultFence(tokens, idx, options, env, self)
+          : self.renderToken(tokens, idx, options);
+        return (
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code">Copy</button>' +
+          rendered +
+          "</div>"
+        );
       };
 
       try {
@@ -50,10 +63,34 @@ export async function initMarkdownRenderer(): Promise<void> {
         const { default: Shiki } = await import("@shikijs/markdown-it");
         // @ts-ignore
         const { createCssVariablesTheme } = await import("shiki");
-        const cssVariablesTheme = createCssVariablesTheme({ name: "css-variables", variablePrefix: "--shiki-", variableDefaults: {}, fontStyle: true });
+        const cssVariablesTheme = createCssVariablesTheme({
+          name: "css-variables",
+          variablePrefix: "--shiki-",
+          variableDefaults: {},
+          fontStyle: true,
+        });
         const shikiPlugin = await Shiki({
           themes: { light: cssVariablesTheme, dark: cssVariablesTheme },
-          langs: ["typescript", "javascript", "tsx", "jsx", "python", "java", "go", "csharp", "cpp", "c", "diff", "json", "yaml", "markdown", "bash", "shell", "html", "css"],
+          langs: [
+            "typescript",
+            "javascript",
+            "tsx",
+            "jsx",
+            "python",
+            "java",
+            "go",
+            "csharp",
+            "cpp",
+            "c",
+            "diff",
+            "json",
+            "yaml",
+            "markdown",
+            "bash",
+            "shell",
+            "html",
+            "css",
+          ],
           fallbackLanguage: "markdown",
         });
         md.use(shikiPlugin);
@@ -74,27 +111,41 @@ export function renderChatMarkdown(markdown: string): string {
   return markdownRenderer.render(markdown);
 }
 
-const GENERATING_SESSION_STATES: ReadonlySet<string> = new Set(["IN_PROGRESS", "QUEUED", "PLANNING"]);
+const GENERATING_SESSION_STATES: ReadonlySet<string> = new Set([
+  "IN_PROGRESS",
+  "QUEUED",
+  "PLANNING",
+]);
 
-export function isGeneratingSessionState(rawState: string | undefined): boolean {
+export function isGeneratingSessionState(
+  rawState: string | undefined,
+): boolean {
   if (!rawState) return false;
   return GENERATING_SESSION_STATES.has(rawState);
 }
 
-export function buildChatMessagesFromActivities(activities: Activity[], initialPrompt?: string, initialTime?: string): ChatMessageItem[] {
-  const customPrompt = vscode.workspace.getConfiguration("jules-extension").get<string>("customPrompt", "");
-  const sortedActivities = [...activities].sort((a, b) => (a.createTime ?? "").localeCompare(b.createTime ?? ""));
+export function buildChatMessagesFromActivities(
+  activities: Activity[],
+  initialPrompt?: string,
+  initialTime?: string,
+): ChatMessageItem[] {
+  const customPrompt = vscode.workspace
+    .getConfiguration("jules-extension")
+    .get<string>("customPrompt", "");
+  const sortedActivities = [...activities].sort((a, b) =>
+    (a.createTime ?? "").localeCompare(b.createTime ?? ""),
+  );
   let hasLabeledCustomPrompt = false;
 
   function formatMessage(message: string): string {
     if (customPrompt && message.includes(customPrompt)) {
       const baseMessage = message
-        .replace(customPrompt + '\n\n', "")
-        .replace('\n\n' + customPrompt, "")
+        .replace(customPrompt + "\n\n", "")
+        .replace("\n\n" + customPrompt, "")
         .trim();
       if (!hasLabeledCustomPrompt) {
         hasLabeledCustomPrompt = true;
-        return baseMessage + '\n\n**[custom prompt]**\n' + customPrompt;
+        return baseMessage + "\n\n**[custom prompt]**\n" + customPrompt;
       }
       return baseMessage;
     }
@@ -102,43 +153,100 @@ export function buildChatMessagesFromActivities(activities: Activity[], initialP
   }
 
   const messages: ChatMessageItem[] = [];
-  const firstUserActivity = sortedActivities.find(a => !!pickFirstNonEmpty(a.userMessaged?.userMessage));
-  const firstUserMsgText = firstUserActivity ? pickFirstNonEmpty(firstUserActivity.userMessaged?.userMessage) : null;
-  const isInitialPromptRedundant = initialPrompt && firstUserMsgText && (firstUserMsgText === initialPrompt || firstUserMsgText.startsWith(initialPrompt));
+  const firstUserActivity = sortedActivities.find(
+    (a) => !!pickFirstNonEmpty(a.userMessaged?.userMessage),
+  );
+  const firstUserMsgText = firstUserActivity
+    ? pickFirstNonEmpty(firstUserActivity.userMessaged?.userMessage)
+    : null;
+  const isInitialPromptRedundant =
+    initialPrompt &&
+    firstUserMsgText &&
+    (firstUserMsgText === initialPrompt ||
+      firstUserMsgText.startsWith(initialPrompt));
 
   if (initialPrompt && !isInitialPromptRedundant) {
     const formatted = formatMessage(initialPrompt);
-    messages.push({ id: "session-initial-prompt", role: "user", createTime: initialTime, html: renderChatMarkdown(formatted) });
+    messages.push({
+      id: "session-initial-prompt",
+      role: "user",
+      createTime: initialTime,
+      html: renderChatMarkdown(formatted),
+    });
   }
 
   sortedActivities.forEach((activity) => {
     const userMessage = pickFirstNonEmpty(activity.userMessaged?.userMessage);
     if (userMessage) {
       const formatted = formatMessage(userMessage);
-      messages.push({ id: activity.id ?? activity.name, role: "user", createTime: activity.createTime, html: renderChatMarkdown(formatted) });
+      messages.push({
+        id: activity.id ?? activity.name,
+        role: "user",
+        createTime: activity.createTime,
+        html: renderChatMarkdown(formatted),
+      });
       return;
     }
-    const agentMessage = pickFirstNonEmpty(activity.agentMessaged?.agentMessage);
+    const agentMessage = pickFirstNonEmpty(
+      activity.agentMessaged?.agentMessage,
+    );
     if (agentMessage) {
-      messages.push({ id: activity.id ?? activity.name, role: "assistant", createTime: activity.createTime, html: renderChatMarkdown(agentMessage) });
+      messages.push({
+        id: activity.id ?? activity.name,
+        role: "assistant",
+        createTime: activity.createTime,
+        html: renderChatMarkdown(agentMessage),
+      });
       return;
     }
-    const combinedText = getActivityIcon(activity) + ' ' + getActivityLabelPrefix(activity) + getActivitySummaryText(activity);
+    const combinedText =
+      getActivityIcon(activity) +
+      " " +
+      getActivityLabelPrefix(activity) +
+      getActivitySummaryText(activity);
     let detailsHtml = "";
-    if (activity.sessionFailed?.reason) detailsHtml += '<details class="activity-details"><summary>View Error Details</summary><div class="details-content code-block"><pre><code>' + escapeHtml(activity.sessionFailed.reason) + '</code></pre></div></details>';
-    if (activity.planGenerated?.plan) detailsHtml += '<details class="activity-details"><summary>View Plan</summary><div class="details-content">' + renderChatMarkdown(formatFullPlan(activity.planGenerated.plan)) + '</div></details>';
+    if (activity.sessionFailed?.reason)
+      detailsHtml +=
+        '<details class="activity-details"><summary>View Error Details</summary><div class="details-content code-block"><pre><code>' +
+        escapeHtml(activity.sessionFailed.reason) +
+        "</code></pre></div></details>";
+    if (activity.planGenerated?.plan)
+      detailsHtml +=
+        '<details class="activity-details"><summary>View Plan</summary><div class="details-content">' +
+        renderChatMarkdown(formatFullPlan(activity.planGenerated.plan)) +
+        "</div></details>";
     if ((activity as any).gitPatch?.diff) {
       const diff = (activity as any).gitPatch.diff;
-      if (typeof diff === "string" && diff.trim().length > 0) detailsHtml += '<details class="activity-details"><summary>View Diff</summary><div class="details-content">' + renderChatMarkdown('```diff\n' + diff + '\n```') + '</div></details>';
+      if (typeof diff === "string" && diff.trim().length > 0)
+        detailsHtml +=
+          '<details class="activity-details"><summary>View Diff</summary><div class="details-content">' +
+          renderChatMarkdown("```diff\n" + diff + "\n```") +
+          "</div></details>";
     }
     if (activity.artifacts && activity.artifacts.length > 0) {
       activity.artifacts.forEach((artifact, i) => {
         if (artifact.changeSet) {
           const diffData = (artifact.changeSet as any).gitPatch?.unidiffPatch;
-          if (diffData && typeof diffData === "string") detailsHtml += '<details class="activity-details"><summary>View ChangeSet (' + (i + 1) + ')</summary><div class="details-content">' + renderChatMarkdown('```diff\n' + diffData + '\n```') + '</div></details>';
+          if (diffData && typeof diffData === "string")
+            detailsHtml +=
+              '<details class="activity-details"><summary>View ChangeSet (' +
+              (i + 1) +
+              ')</summary><div class="details-content">' +
+              renderChatMarkdown("```diff\n" + diffData + "\n```") +
+              "</div></details>";
           else {
-            let raw = ""; try { raw = JSON.stringify(artifact.changeSet, null, 2); } catch { raw = String(artifact.changeSet); }
-            detailsHtml += '<details class="activity-details"><summary>View ChangeSet Details (' + (i + 1) + ')</summary><div class="details-content">' + renderChatMarkdown('```json\n' + raw + '\n```') + '</div></details>';
+            let raw = "";
+            try {
+              raw = JSON.stringify(artifact.changeSet, null, 2);
+            } catch {
+              raw = String(artifact.changeSet);
+            }
+            detailsHtml +=
+              '<details class="activity-details"><summary>View ChangeSet Details (' +
+              (i + 1) +
+              ')</summary><div class="details-content">' +
+              renderChatMarkdown("```json\n" + raw + "\n```") +
+              "</div></details>";
           }
         }
         if (artifact.bashOutput) {
@@ -151,13 +259,34 @@ export function buildChatMessagesFromActivities(activities: Activity[], initialP
           const stdout = outRec.stdout;
           const stderr = outRec.stderr;
           if (commandLine || stdout || stderr) {
-            const out = ('> ' + (commandLine || "Command") + '\n' + (stdout || "") + '\n' + (stderr || "")).trim();
-            detailsHtml += '<details class="activity-details"><summary>View Bash Output (' + (i + 1) + ')</summary><div class="details-content">' + renderChatMarkdown('```bash\n' + out + '\n```') + '</div></details>';
+            const out = (
+              "> " +
+              (commandLine || "Command") +
+              "\n" +
+              (stdout || "") +
+              "\n" +
+              (stderr || "")
+            ).trim();
+            detailsHtml +=
+              '<details class="activity-details"><summary>View Bash Output (' +
+              (i + 1) +
+              ')</summary><div class="details-content">' +
+              renderChatMarkdown("```bash\n" + out + "\n```") +
+              "</div></details>";
           }
         }
       });
     }
-    messages.push({ id: activity.id ?? activity.name, role: "assistant", createTime: activity.createTime, html: '<div class="activity-log"><em>' + escapeHtml(combinedText) + '</em></div>' + detailsHtml });
+    messages.push({
+      id: activity.id ?? activity.name,
+      role: "assistant",
+      createTime: activity.createTime,
+      html:
+        '<div class="activity-log"><em>' +
+        escapeHtml(combinedText) +
+        "</em></div>" +
+        detailsHtml,
+    });
   });
   return messages;
 }
@@ -167,121 +296,106 @@ export class JulesChatViewProvider implements vscode.WebviewViewProvider {
   private activities: Activity[] = [];
   private sessionTitle?: string;
   private sessionCreateTime?: string;
-  private state: ChatStatePayload = { sessionId: null, messages: [], isTyping: false };
-  constructor(private readonly onSendMessage: (sessionId: string, message: string) => Promise<void>) {}
+  private state: ChatStatePayload = {
+    sessionId: null,
+    messages: [],
+    isTyping: false,
+  };
+  constructor(
+    private readonly onSendMessage: (
+      sessionId: string,
+      message: string,
+    ) => Promise<void>,
+  ) {}
   async resolveWebviewView(webviewView: vscode.WebviewView): Promise<void> {
     await initMarkdownRenderer();
     this.view = webviewView;
     webviewView.webview.options = { enableScripts: true };
-    webviewView.webview.html = getChatWebviewHtml(webviewView.webview, getNonce());
+    webviewView.webview.html = getChatWebviewHtml(
+      webviewView.webview,
+      getNonce(),
+    );
     webviewView.webview.onDidReceiveMessage(async (message) => {
-      if (message?.type === "requestInitialState") { this.postState(); return; }
+      if (message?.type === "requestInitialState") {
+        this.postState();
+        return;
+      }
       if (message?.type !== "sendMessage") return;
-      const sessionId = typeof message.sessionId === "string" ? message.sessionId : "";
+      const sessionId =
+        typeof message.sessionId === "string" ? message.sessionId : "";
       const text = typeof message.text === "string" ? message.text.trim() : "";
       if (!sessionId || !text) return;
-      try { await this.onSendMessage(sessionId, text); } catch (error) { vscode.window.showErrorMessage('Failed to send message: ' + (error instanceof Error ? error.message : "Unknown error")); }
+      try {
+        await this.onSendMessage(sessionId, text);
+      } catch (error) {
+        vscode.window.showErrorMessage(
+          "Failed to send message: " +
+            (error instanceof Error ? error.message : "Unknown error"),
+        );
+      }
     });
-    if (this.state.sessionId) this.state.messages = buildChatMessagesFromActivities(this.activities, this.sessionTitle, this.sessionCreateTime);
+    if (this.state.sessionId)
+      this.state.messages = buildChatMessagesFromActivities(
+        this.activities,
+        this.sessionTitle,
+        this.sessionCreateTime,
+      );
     this.postState();
   }
-  updateSession(sessionId: string, activities: Activity[], rawState?: string, sessionTitle?: string, sessionCreateTime?: string): void {
-    this.activities = activities; this.sessionTitle = sessionTitle; this.sessionCreateTime = sessionCreateTime;
-    this.state = { sessionId, messages: buildChatMessagesFromActivities(activities, sessionTitle, sessionCreateTime), isTyping: isGeneratingSessionState(rawState) };
+  updateSession(
+    sessionId: string,
+    activities: Activity[],
+    rawState?: string,
+    sessionTitle?: string,
+    sessionCreateTime?: string,
+  ): void {
+    this.activities = activities;
+    this.sessionTitle = sessionTitle;
+    this.sessionCreateTime = sessionCreateTime;
+    this.state = {
+      sessionId,
+      messages: buildChatMessagesFromActivities(
+        activities,
+        sessionTitle,
+        sessionCreateTime,
+      ),
+      isTyping: isGeneratingSessionState(rawState),
+    };
     this.postState();
   }
   private postState(): void {
     if (!this.view) return;
-    void Promise.resolve(this.view.webview.postMessage({ type: "chatState", payload: this.state })).catch((err: unknown) => console.error("Jules: Failed to post state to chat view:", err));
+    void Promise.resolve(
+      this.view.webview.postMessage({ type: "chatState", payload: this.state }),
+    ).catch((err: unknown) =>
+      console.error("Jules: Failed to post state to chat view:", err),
+    );
   }
 }
 
-export function getChatWebviewHtml(webview: vscode.Webview, nonce: string): string {
-  const css = '* { box-sizing: border-box; } body { margin: 0; padding: 10px; color: var(--vscode-editor-foreground); background: var(--vscode-editor-background); font-family: var(--vscode-font-family); height: 100vh; display: flex; flex-direction: column; gap: 10px; } #chat { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 10px; padding-right: 2px; } .message { display: flex; flex-direction: column; max-width: 92%; animation: slide-in .18s ease-out; gap: 4px; } .message.user { margin-left: auto; align-items: flex-end; } .message.assistant { margin-right: auto; align-items: flex-start; } .bubble { border: 1px solid var(--vscode-widget-border, transparent); border-radius: 12px; padding: 10px 12px; backdrop-filter: blur(8px); box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12); line-height: 1.5; overflow-wrap: anywhere; } .user .bubble { background: color-mix(in srgb, var(--vscode-button-background) 28%, transparent); border-color: var(--vscode-button-background); } .assistant .bubble { background: color-mix(in srgb, var(--vscode-editorHoverWidget-background) 75%, transparent); } .meta { color: var(--vscode-descriptionForeground); font-size: 11px; padding: 0 4px; } blockquote { margin: 8px 0; border-left: 3px solid var(--vscode-textBlockQuote-border); padding-left: 10px; color: var(--vscode-textBlockQuote-foreground); background: color-mix(in srgb, var(--vscode-editorHoverWidget-background) 35%, transparent); border-radius: 6px; } ul, ol { padding-left: 18px; margin: 6px 0; } p { margin: 0 0 8px; } .code-block { position: relative; margin: 8px 0; } .code-block pre { margin: 0; padding: 10px; border-radius: 8px; background: var(--vscode-textCodeBlock-background); overflow-x: auto; border: 1px solid var(--vscode-widget-border, transparent); } .code-block code { font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); } .copy-code-button { position: absolute; top: 6px; right: 6px; opacity: 0; transition: opacity .15s ease; border: 1px solid var(--vscode-button-border, transparent); border-radius: 4px; background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); cursor: pointer; font-size: 11px; padding: 2px 8px; } .code-block:hover .copy-code-button, .copy-code-button:focus-visible { opacity: 1; } .typing { display: none; align-items: center; gap: 4px; color: var(--vscode-descriptionForeground); padding: 0 4px; } .typing.visible { display: flex; } .typing-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--vscode-textLink-foreground); animation: pulse 1s infinite ease-in-out; } .typing-dot:nth-child(2) { animation-delay: .15s; } .typing-dot:nth-child(3) { animation-delay: .3s; } #composer { border-top: 1px solid var(--vscode-panel-border, var(--vscode-widget-border)); padding-top: 10px; display: grid; gap: 8px; } #messageInput { width: 100%; resize: vertical; min-height: 64px; max-height: 180px; border: 1px solid var(--vscode-input-border); background: var(--vscode-input-background); color: var(--vscode-input-foreground); border-radius: 6px; padding: 8px; font: inherit; } #messageInput:focus-visible { outline: 1px solid var(--vscode-focusBorder); } .composer-actions { display: flex; justify-content: space-between; align-items: center; gap: 8px; } .session-label { color: var(--vscode-descriptionForeground); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 70%; } #sendButton { border: 1px solid var(--vscode-button-border, transparent); background: var(--vscode-button-background); color: var(--vscode-button-foreground); border-radius: 4px; padding: 6px 12px; cursor: pointer; } #sendButton:hover { background: var(--vscode-button-hoverBackground); } #sendButton:disabled { opacity: .5; cursor: not-allowed; } .activity-log { font-size: 0.9em; opacity: 0.75; margin-bottom: 2px; } .activity-details { margin-top: 4px; font-size: 0.9em; } .activity-details summary { cursor: pointer; user-select: none; font-weight: 600; opacity: 0.8; padding: 2px 0; outline: none; } .activity-details summary:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; } .activity-details summary:hover { opacity: 1; text-decoration: underline; } .details-content { margin-top: 6px; padding: 10px; background: var(--vscode-editor-background); border: 1px solid var(--vscode-widget-border); border-radius: 6px; max-height: 350px; overflow-y: auto; } .details-content pre { margin: 0; white-space: pre-wrap; word-break: break-all; } .shiki { background-color: transparent !important; } .shiki span { color: var(--shiki-light); } [data-vscode-theme-kind="vscode-dark"] .shiki span { color: var(--shiki-dark); } [data-vscode-theme-kind="vscode-high-contrast"] .shiki span { color: var(--shiki-dark); } @keyframes pulse { 0%, 80%, 100% { transform: translateY(0); opacity: .35; } 40% { transform: translateY(-4px); opacity: 1; } } @keyframes slide-in { from { transform: translateY(6px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }';
-  const js = `(function() {
-    const vscode = typeof acquireVsCodeApi === "function"
-      ? acquireVsCodeApi()
-      : { postMessage: (m) => console.warn("VSCode API unavailable", m) };
-
-    const chatContainer = document.getElementById("chat");
-    const typingIndicator = document.getElementById("typing");
-    const messageInput = document.getElementById("messageInput");
-    const sendButton = document.getElementById("sendButton");
-    const sessionLabel = document.getElementById("sessionLabel");
-
-    let state = { sessionId: null, messages: [], isTyping: false };
-
-    function updateUI() {
-      const hasSession = !!state.sessionId;
-      sendButton.disabled = !hasSession || messageInput.value.trim().length === 0;
-      sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
-    }
-
-    function formatTime(timestamp) {
-      if (!timestamp) return "";
-      const date = new Date(timestamp);
-      return isNaN(date.getTime()) ? "" : date.toLocaleString();
-    }
-
-    function renderMessages() {
-      chatContainer.innerHTML = state.messages.map(m => \`
-        <div class="message \${m.role}">
-          <div class="bubble">\${m.html}</div>
-          <div class="meta">\${formatTime(m.createTime)}</div>
-        </div>
-      \`).join("");
-      typingIndicator.classList.toggle("visible", !!state.isTyping);
-      chatContainer.scrollTop = chatContainer.scrollHeight;
-      updateUI();
-    }
-
-    messageInput.addEventListener("input", updateUI);
-    messageInput.addEventListener("keydown", e => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-        e.preventDefault();
-        if (!sendButton.disabled) {
-          const text = messageInput.value.trim();
-          vscode.postMessage({ type: "sendMessage", sessionId: state.sessionId, text });
-          messageInput.value = "";
-          updateUI();
-        }
-      }
-    });
-
-    document.getElementById("composer").addEventListener("submit", e => {
-      e.preventDefault();
-      const text = messageInput.value.trim();
-      if (state.sessionId && text) {
-        vscode.postMessage({ type: "sendMessage", sessionId: state.sessionId, text });
-        messageInput.value = "";
-        updateUI();
-      }
-    });
-
-    chatContainer.addEventListener("click", async e => {
-      const copyButton = e.target.closest(".copy-code-button");
-      if (!copyButton) return;
-      const code = copyButton.closest(".code-block").querySelector("code").innerText;
-      try {
-        await navigator.clipboard.writeText(code);
-        const originalText = copyButton.textContent;
-        copyButton.textContent = "Copied";
-        setTimeout(() => copyButton.textContent = originalText, 1200);
-      } catch {
-        copyButton.textContent = "Failed";
-      }
-    });
-
-    window.addEventListener("message", e => {
-      if (e.data.type === "chatState") {
-        state = e.data.payload || state;
-        renderMessages();
-      }
-    });
-
-    vscode.postMessage({ type: "requestInitialState" });
-  })()`;
-  return '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src ' + webview.cspSource + ' \'nonce-' + nonce + '\'; script-src \'nonce-' + nonce + '\';" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Jules Chat</title><style nonce="' + nonce + '">' + css + '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' + nonce + '">' + js + '</script></body></html>';
+export function getChatWebviewHtml(
+  webview: vscode.Webview,
+  nonce: string,
+): string {
+  return (
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src ' +
+    webview.cspSource +
+    " 'nonce-" +
+    nonce +
+    "'; script-src 'nonce-" +
+    nonce +
+    '\';" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Jules Chat</title><style nonce="' +
+    nonce +
+    '">' +
+    CHAT_CSS +
+    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
+    nonce +
+    '">' +
+    CHAT_JS +
+    "</script></body></html>"
+  );
 }
 
-function getNonce(): string { return crypto.randomBytes(16).toString("hex"); }
+function getNonce(): string {
+  return crypto.randomBytes(16).toString("hex");
+}

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -30,4 +30,31 @@ suite("chatAssets unit tests", () => {
     assert.ok(CHAT_CSS.includes("max-height: 350px"));
     assert.ok(CHAT_CSS.includes("overflow-y: auto"));
   });
+
+  test("CHAT_CSS should keep shiki theme variable selectors", () => {
+    assert.ok(CHAT_CSS.includes(".shiki { background-color: transparent !important; }"));
+    assert.ok(CHAT_CSS.includes(".shiki span { color: var(--shiki-light); }"));
+    assert.ok(
+      CHAT_CSS.includes(
+        '[data-vscode-theme-kind="vscode-dark"] .shiki span { color: var(--shiki-dark); }',
+      ),
+    );
+    assert.ok(
+      CHAT_CSS.includes(
+        '[data-vscode-theme-kind="vscode-high-contrast"] .shiki span { color: var(--shiki-dark); }',
+      ),
+    );
+  });
+
+  test("CHAT_CSS should keep session label truncation safeguards", () => {
+    assert.ok(CHAT_CSS.includes(".session-label"));
+    assert.ok(CHAT_CSS.includes("max-width: 70%"));
+    assert.ok(CHAT_CSS.includes("text-overflow: ellipsis"));
+    assert.ok(CHAT_CSS.includes("white-space: nowrap"));
+  });
+
+  test("CHAT_JS should reset copy button text after failure", () => {
+    assert.ok(CHAT_JS.includes('copyButton.textContent = "Failed"'));
+    assert.ok(CHAT_JS.includes("setTimeout(() => copyButton.textContent = originalText, 1200)"));
+  });
 });

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -55,6 +55,15 @@ suite("chatAssets unit tests", () => {
 
   test("CHAT_JS should reset copy button text after failure", () => {
     assert.ok(CHAT_JS.includes('copyButton.textContent = "Failed"'));
-    assert.ok(CHAT_JS.includes("setTimeout(() => copyButton.textContent = originalText, 1200)"));
+    const resetCount = (
+      CHAT_JS.match(
+        /setTimeout\(\(\) => copyButton\.textContent = originalText, 1200\)/g,
+      ) ?? []
+    ).length;
+    assert.strictEqual(
+      resetCount,
+      2,
+      "both success and failure paths should reset button text",
+    );
   });
 });

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -23,4 +23,11 @@ suite("chatAssets unit tests", () => {
     assert.ok(CHAT_JS.includes("copy-code-button"));
     assert.ok(CHAT_JS.includes("navigator.clipboard.writeText"));
   });
+
+  test("CHAT_CSS should include activity details layout styles", () => {
+    assert.ok(CHAT_CSS.includes(".activity-details"));
+    assert.ok(CHAT_CSS.includes(".details-content"));
+    assert.ok(CHAT_CSS.includes("max-height: 350px"));
+    assert.ok(CHAT_CSS.includes("overflow-y: auto"));
+  });
 });

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,0 +1,26 @@
+import * as assert from "assert";
+import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
+
+suite("chatAssets unit tests", () => {
+  test("CHAT_CSS should keep accessibility-focused selectors", () => {
+    assert.ok(
+      CHAT_CSS.includes(
+        ".code-block:hover .copy-code-button, .copy-code-button:focus-visible",
+      ),
+    );
+    assert.ok(CHAT_CSS.includes("#messageInput:focus-visible"));
+  });
+
+  test("CHAT_CSS should target typing-dot delays for rendered structure", () => {
+    assert.ok(CHAT_CSS.includes(".typing-dot:nth-child(2)"));
+    assert.ok(CHAT_CSS.includes(".typing-dot:nth-child(3)"));
+    assert.ok(!CHAT_CSS.includes(".typing-dot:nth-child(1)"));
+  });
+
+  test("CHAT_JS should include key webview message and copy handlers", () => {
+    assert.ok(CHAT_JS.includes("requestInitialState"));
+    assert.ok(CHAT_JS.includes('type: "sendMessage"'));
+    assert.ok(CHAT_JS.includes("copy-code-button"));
+    assert.ok(CHAT_JS.includes("navigator.clipboard.writeText"));
+  });
+});

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -1,0 +1,121 @@
+export const CHAT_CSS = `
+* { box-sizing: border-box; }
+body { margin: 0; padding: 10px; color: var(--vscode-editor-foreground); background: var(--vscode-editor-background); font-family: var(--vscode-font-family); height: 100vh; display: flex; flex-direction: column; gap: 10px; }
+#chat { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 10px; padding-right: 2px; }
+.message { display: flex; flex-direction: column; max-width: 92%; animation: slide-in .18s ease-out; gap: 4px; }
+.message.user { margin-left: auto; align-items: flex-end; }
+.message.assistant { margin-right: auto; align-items: flex-start; }
+.bubble { border: 1px solid var(--vscode-widget-border, transparent); border-radius: 12px; padding: 10px 12px; backdrop-filter: blur(8px); box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12); line-height: 1.5; overflow-wrap: anywhere; }
+.user .bubble { background: color-mix(in srgb, var(--vscode-button-background) 28%, transparent); border-color: var(--vscode-button-background); }
+.assistant .bubble { background: color-mix(in srgb, var(--vscode-editorHoverWidget-background) 75%, transparent); }
+.meta { color: var(--vscode-descriptionForeground); font-size: 11px; padding: 0 4px; }
+blockquote { margin: 8px 0; border-left: 3px solid var(--vscode-textBlockQuote-border); padding-left: 10px; color: var(--vscode-textBlockQuote-foreground); background: color-mix(in srgb, var(--vscode-editorHoverWidget-background) 35%, transparent); border-radius: 6px; }
+ul, ol { padding-left: 18px; margin: 6px 0; }
+p { margin: 0 0 8px; }
+.code-block { position: relative; margin: 8px 0; }
+.code-block pre { margin: 0; padding: 10px; border-radius: 8px; background: var(--vscode-textCodeBlock-background); overflow-x: auto; border: 1px solid var(--vscode-widget-border, transparent); }
+.code-block code { font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); }
+.copy-code-button { position: absolute; top: 6px; right: 6px; opacity: 0; transition: opacity .15s ease; border: 1px solid var(--vscode-button-border, transparent); background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 11px; }
+.code-block:hover .copy-code-button { opacity: 1; }
+.copy-code-button:hover { background: var(--vscode-button-secondaryHoverBackground); }
+.copy-code-button:active { transform: scale(0.96); }
+@keyframes slide-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+.typing { display: none; align-items: center; gap: 4px; color: var(--vscode-descriptionForeground); font-size: 12px; font-style: italic; padding: 0 8px 8px; }
+.typing.visible { display: flex; }
+.typing-dot { width: 4px; height: 4px; background: currentColor; border-radius: 50%; animation: typing 1.4s infinite ease-in-out both; }
+.typing-dot:nth-child(1) { animation-delay: -0.32s; }
+.typing-dot:nth-child(2) { animation-delay: -0.16s; }
+@keyframes typing { 0%, 80%, 100% { transform: scale(0); } 40% { transform: scale(1); } }
+#composer { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: var(--vscode-editor-background); border-top: 1px solid var(--vscode-widget-border, transparent); }
+#messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: vertical; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; }
+#messageInput:focus { border-color: var(--vscode-focusBorder); }
+.composer-actions { display: flex; justify-content: space-between; align-items: center; }
+.session-label { color: var(--vscode-descriptionForeground); font-size: 11px; user-select: none; }
+#sendButton { padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }
+#sendButton:hover:not(:disabled) { background: var(--vscode-button-hoverBackground); }
+#sendButton:disabled { opacity: 0.5; cursor: not-allowed; }
+`;
+
+export const CHAT_JS = `(function() {
+  const vscode = typeof acquireVsCodeApi === "function"
+    ? acquireVsCodeApi()
+    : { postMessage: (m) => console.warn("VSCode API unavailable", m) };
+
+  const chatContainer = document.getElementById("chat");
+  const typingIndicator = document.getElementById("typing");
+  const messageInput = document.getElementById("messageInput");
+  const sendButton = document.getElementById("sendButton");
+  const sessionLabel = document.getElementById("sessionLabel");
+
+  let state = { sessionId: null, messages: [], isTyping: false };
+
+  function updateUI() {
+    const hasSession = !!state.sessionId;
+    sendButton.disabled = !hasSession || messageInput.value.trim().length === 0;
+    sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
+  }
+
+  function formatTime(timestamp) {
+    if (!timestamp) return "";
+    const date = new Date(timestamp);
+    return isNaN(date.getTime()) ? "" : date.toLocaleString();
+  }
+
+  function renderMessages() {
+    chatContainer.innerHTML = state.messages.map(m => \`
+      <div class="message \${m.role}">
+        <div class="bubble">\${m.html}</div>
+        <div class="meta">\${formatTime(m.createTime)}</div>
+      </div>
+    \`).join("");
+    typingIndicator.classList.toggle("visible", !!state.isTyping);
+    chatContainer.scrollTop = chatContainer.scrollHeight;
+    updateUI();
+  }
+
+  messageInput.addEventListener("input", updateUI);
+  messageInput.addEventListener("keydown", e => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      if (!sendButton.disabled) {
+        const text = messageInput.value.trim();
+        vscode.postMessage({ type: "sendMessage", sessionId: state.sessionId, text });
+        messageInput.value = "";
+        updateUI();
+      }
+    }
+  });
+
+  document.getElementById("composer").addEventListener("submit", e => {
+    e.preventDefault();
+    const text = messageInput.value.trim();
+    if (state.sessionId && text) {
+      vscode.postMessage({ type: "sendMessage", sessionId: state.sessionId, text });
+      messageInput.value = "";
+      updateUI();
+    }
+  });
+
+  chatContainer.addEventListener("click", async e => {
+    const copyButton = e.target.closest(".copy-code-button");
+    if (!copyButton) return;
+    const code = copyButton.closest(".code-block").querySelector("code").innerText;
+    try {
+      await navigator.clipboard.writeText(code);
+      const originalText = copyButton.textContent;
+      copyButton.textContent = "Copied";
+      setTimeout(() => copyButton.textContent = originalText, 1200);
+    } catch {
+      copyButton.textContent = "Failed";
+    }
+  });
+
+  window.addEventListener("message", e => {
+    if (e.data.type === "chatState") {
+      state = e.data.payload || state;
+      renderMessages();
+    }
+  });
+
+  vscode.postMessage({ type: "requestInitialState" });
+})();`;

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -111,13 +111,12 @@ export const CHAT_JS = `(function() {
     const copyButton = e.target.closest(".copy-code-button");
     if (!copyButton) return;
     const code = copyButton.closest(".code-block").querySelector("code").innerText;
+    const originalText = copyButton.textContent;
     try {
       await navigator.clipboard.writeText(code);
-      const originalText = copyButton.textContent;
       copyButton.textContent = "Copied";
       setTimeout(() => copyButton.textContent = originalText, 1200);
     } catch {
-      const originalText = copyButton.textContent;
       copyButton.textContent = "Failed";
       setTimeout(() => copyButton.textContent = originalText, 1200);
     }

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -30,7 +30,7 @@ p { margin: 0 0 8px; }
 #messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: vertical; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; }
 #messageInput:focus-visible { border-color: var(--vscode-focusBorder); }
 .composer-actions { display: flex; justify-content: space-between; align-items: center; }
-.session-label { color: var(--vscode-descriptionForeground); font-size: 11px; user-select: none; }
+.session-label { color: var(--vscode-descriptionForeground); font-size: 11px; user-select: none; max-width: 70%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #sendButton { padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }
 #sendButton:hover:not(:disabled) { background: var(--vscode-button-hoverBackground); }
 #sendButton:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -41,6 +41,10 @@ p { margin: 0 0 8px; }
 .activity-details summary:hover { opacity: 1; text-decoration: underline; }
 .details-content { margin-top: 6px; padding: 10px; background: var(--vscode-editor-background); border: 1px solid var(--vscode-widget-border); border-radius: 6px; max-height: 350px; overflow-y: auto; }
 .details-content pre { margin: 0; white-space: pre-wrap; word-break: break-all; }
+.shiki { background-color: transparent !important; }
+.shiki span { color: var(--shiki-light); }
+[data-vscode-theme-kind="vscode-dark"] .shiki span { color: var(--shiki-dark); }
+[data-vscode-theme-kind="vscode-high-contrast"] .shiki span { color: var(--shiki-dark); }
 `;
 
 export const CHAT_JS = `(function() {
@@ -113,7 +117,9 @@ export const CHAT_JS = `(function() {
       copyButton.textContent = "Copied";
       setTimeout(() => copyButton.textContent = originalText, 1200);
     } catch {
+      const originalText = copyButton.textContent;
       copyButton.textContent = "Failed";
+      setTimeout(() => copyButton.textContent = originalText, 1200);
     }
   });
 

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -16,19 +16,19 @@ p { margin: 0 0 8px; }
 .code-block pre { margin: 0; padding: 10px; border-radius: 8px; background: var(--vscode-textCodeBlock-background); overflow-x: auto; border: 1px solid var(--vscode-widget-border, transparent); }
 .code-block code { font-family: var(--vscode-editor-font-family); font-size: var(--vscode-editor-font-size); }
 .copy-code-button { position: absolute; top: 6px; right: 6px; opacity: 0; transition: opacity .15s ease; border: 1px solid var(--vscode-button-border, transparent); background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 11px; }
-.code-block:hover .copy-code-button { opacity: 1; }
+.code-block:hover .copy-code-button, .copy-code-button:focus-visible { opacity: 1; }
 .copy-code-button:hover { background: var(--vscode-button-secondaryHoverBackground); }
 .copy-code-button:active { transform: scale(0.96); }
 @keyframes slide-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 .typing { display: none; align-items: center; gap: 4px; color: var(--vscode-descriptionForeground); font-size: 12px; font-style: italic; padding: 0 8px 8px; }
 .typing.visible { display: flex; }
 .typing-dot { width: 4px; height: 4px; background: currentColor; border-radius: 50%; animation: typing 1.4s infinite ease-in-out both; }
-.typing-dot:nth-child(1) { animation-delay: -0.32s; }
-.typing-dot:nth-child(2) { animation-delay: -0.16s; }
+.typing-dot:nth-child(2) { animation-delay: -0.32s; }
+.typing-dot:nth-child(3) { animation-delay: -0.16s; }
 @keyframes typing { 0%, 80%, 100% { transform: scale(0); } 40% { transform: scale(1); } }
 #composer { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: var(--vscode-editor-background); border-top: 1px solid var(--vscode-widget-border, transparent); }
 #messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: vertical; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; }
-#messageInput:focus { border-color: var(--vscode-focusBorder); }
+#messageInput:focus-visible { border-color: var(--vscode-focusBorder); }
 .composer-actions { display: flex; justify-content: space-between; align-items: center; }
 .session-label { color: var(--vscode-descriptionForeground); font-size: 11px; user-select: none; }
 #sendButton { padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -34,6 +34,13 @@ p { margin: 0 0 8px; }
 #sendButton { padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }
 #sendButton:hover:not(:disabled) { background: var(--vscode-button-hoverBackground); }
 #sendButton:disabled { opacity: 0.5; cursor: not-allowed; }
+.activity-log { font-size: 0.9em; opacity: 0.75; margin-bottom: 2px; }
+.activity-details { margin-top: 4px; font-size: 0.9em; }
+.activity-details summary { cursor: pointer; user-select: none; font-weight: 600; opacity: 0.8; padding: 2px 0; outline: none; }
+.activity-details summary:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
+.activity-details summary:hover { opacity: 1; text-decoration: underline; }
+.details-content { margin-top: 6px; padding: 10px; background: var(--vscode-editor-background); border: 1px solid var(--vscode-widget-border); border-radius: 6px; max-height: 350px; overflow-y: auto; }
+.details-content pre { margin: 0; white-space: pre-wrap; word-break: break-all; }
 `;
 
 export const CHAT_JS = `(function() {


### PR DESCRIPTION
Resolves #419

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRはチャットWebviewのCSSとJavaScriptを、`chatView.ts` 内のミニファイされたインラインリテラルから `src/webview/chatAssets.ts` の独立した定数（`CHAT_CSS`、`CHAT_JS`）に分離するリファクタリングです。これにより可読性・保守性が大幅に向上し、ユニットテスト（`src/test/chatAssets.unit.test.ts`）による回帰防止も追加されています。過去のレビューで指摘されたタイピングドットの CSS セレクター不整合、コピーボタンのアクセシビリティ、Shiki CSS 変数の欠落、`originalText` の競合状態なども本PRで対応済みです。

**主な変更点:**
- `src/webview/chatAssets.ts` を新規作成し、`CHAT_CSS` と `CHAT_JS` をモジュール定数として分離
- `src/chatView.ts` の `getChatWebviewHtml` を `CHAT_CSS`/`CHAT_JS` を参照するよう更新し、コード全体のフォーマットを改善（ブロック形式の `if`/`else`、長い行の折り返し）
- `src/test/chatAssets.unit.test.ts` を新規追加し、アクセシビリティセレクター・Shiki CSS 変数・コピーボタンの成功/失敗両パスのリセット動作などを検証

**気になる点:**
- `#messageInput:focus-visible` のフォーカス表示が `outline: 1px solid var(--vscode-focusBorder)` から `border-color: var(--vscode-focusBorder)` に変わっており、テーマによって視認性が低下する可能性がある
- `#sendButton` のボーダーが `border: 1px solid var(--vscode-button-border, transparent)` から `border: none` に変わっており、ハイコントラストテーマでの視認性への影響が懸念される
</details>

<h3>Confidence Score: 4/5</h3>

- 過去の指摘事項がすべて対応済みであり、リファクタリングの品質は高い。CSS の微細な視覚的変更が2点あるが、機能的な回帰リスクは低い。
- コアロジックの変更はなく、CSS と JS を定数として分離するリファクタリングが主目的。以前のレビュー指摘（Shiki CSS、タイピングドット、コピーボタン競合状態など）はすべて適切に対応されており、ユニットテストによる回帰防止も追加されている。残存する懸念は `#messageInput:focus-visible` のフォーカス表示スタイル変更と `#sendButton` のボーダー削除のみで、どちらもスタイル面の軽微な問題にとどまる。
- src/webview/chatAssets.ts の CSS スタイル変更（`#messageInput:focus-visible` と `#sendButton` のボーダー）に軽微な注意が必要。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | 新規ファイル。CSS・JS を独立した定数として分離しており、以前の指摘（Shiki CSS、タイピングドット、コピーボタンなど）は適切に対応済み。ただし `#messageInput:focus-visible` が `outline` から `border-color` に変わった点と、`#sendButton` から VS Code ボーダートークンが削除された点は軽微な懸念。 |
| src/chatView.ts | CSS・JS を `CHAT_CSS`/`CHAT_JS` に委譲するよう `getChatWebviewHtml` を更新。コードフォーマットの改善（単一行の if/else をブロック形式に展開）が主な変更。ロジックの変更はなく安全。 |
| src/test/chatAssets.unit.test.ts | 新規テストファイル。アクセシビリティセレクター、Shiki CSS 変数、コピーボタンのリセット回数（2回）など主要な回帰テストを網羅。ただし `#messageInput:focus-visible` のプロパティ値（`outline` vs `border-color`）まではテストしていない。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant EXT as "chatView.ts (Extension)"
    participant ASSETS as "chatAssets.ts"
    participant WV as "WebviewView"
    participant UI as "Browser DOM"

    EXT->>ASSETS: "import CHAT_CSS, CHAT_JS"
    EXT->>WV: "getChatWebviewHtml(webview, nonce)"
    WV->>UI: "HTML render (style + script injected)"
    UI->>EXT: "postMessage: requestInitialState"
    EXT->>UI: "postMessage: chatState payload"
    UI->>UI: "renderMessages() -> innerHTML"
    UI->>EXT: "postMessage: sendMessage"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/webview/chatAssets.ts
Line: 30-31

Comment:
**フォーカスリングが `outline` から `border-color` に変わり視認性が低下する可能性**

旧 CSS では `#messageInput:focus-visible` に対して `outline: 1px solid var(--vscode-focusBorder)` を使用していましたが、新しい CSS では：

1. ベーススタイルで `outline: none` を明示的に設定し、
2. `:focus-visible` では `border-color: var(--vscode-focusBorder)` のみ変更しています。

`outline` はボックスモデルの外側に描画されるため要素のサイズに影響せず、アクセシビリティガイドライン（WCAG 2.1 Success Criterion 2.4.11）でも推奨されています。一方、`border-color` の変化はテーマによっては視覚的なコントラストが不十分になる可能性があります。また、単体テストでは `#messageInput:focus-visible` の存在のみを確認しており、実際のフォーカス表示方法（`outline` か `border-color` か）は検証されていません。

```suggestion
#messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: vertical; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; }
#messageInput:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 1px; }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/webview/chatAssets.ts
Line: 34

Comment:
**`#sendButton` から VS Code テーマ対応のボーダートークンが削除された**

旧 CSS では `#sendButton` に `border: 1px solid var(--vscode-button-border, transparent)` が設定されており、VS Code のデザインシステムに準拠したボタン境界線を表示していました。新しい CSS では `border: none` となっており、`--vscode-button-border` トークンを使用しているテーマ（例: ハイコントラストテーマ）でボタンの視認性が低下する可能性があります。

```suggestion
#sendButton { padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: 1px solid var(--vscode-button-border, transparent); border-radius: 4px; cursor: pointer; font-weight: 500; }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: harden copy button reset and streng..."](https://github.com/hiroki-org/jules-extension/commit/bfddf4d0824827e240e1e19b84e3d3ada2b498cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25965300)</sub>

<!-- /greptile_comment -->