### PR TITLE
Fix TimeoutError in fetchAndProcessSessions / セッション取得時のタイムアウトエラーを修正

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1312,6 +1312,7 @@ async function fetchAllSessionsPaginated(
             "X-Goog-Api-Key": apiKey,
             "Content-Type": "application/json",
           },
+          timeout: 60000,
         },
       );
 


### PR DESCRIPTION
Fixes a bug where fetching and processing sessions causes a `TimeoutError`. This was due to the default 30-second timeout of `fetchWithTimeout`. The fix increases this to 60 seconds for paginated fetches.

セッションの取得と処理で発生する`TimeoutError`を修正しました。`fetchWithTimeout`のデフォルトの30秒のタイムアウトが原因だったため、ページネーションの取得処理においてこれを60秒に延長しました。

---
*PR created automatically by Jules for task [3494091110480371502](https://jules.google.com/task/3494091110480371502) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、`fetchAllSessionsPaginated` 内の `fetchWithTimeout` 呼び出しにタイムアウト値を明示的に60秒（60000ms）として渡すことで、セッション一覧取得時に発生していた `TimeoutError` を修正します。デフォルトの30秒では、ページ数の多いユーザー環境でAPIレスポンスが間に合わないケースがあったため、必要な対処です。

- **変更内容**: `fetchAllSessionsPaginated` の `fetchWithTimeout` 呼び出しに `timeout: 60000` オプションを追加（1行の変更）
- **修正の妥当性**: `fetchUtils.ts` の実装を確認したところ、`timeout` オプションは正しくAbortSignalに変換されており、変更は正しく機能します
- **未対処の類似箇所**: 同じくページネーションを行う `fetchSessionActivitiesPaginated` 関数は引き続きデフォルトの30秒タイムアウトを使用しており、同様の問題が潜在する可能性があります
- **テストなし**: AGENTS.md では変更に対応するテストの追加を推奨していますが、本PRにはテストが含まれていません
</details>


<h3>Confidence Score: 5/5</h3>

変更は1行のみで影響範囲が限定的であり、マージしても安全です。

残存する指摘はすべてP2（スタイル・改善提案）レベルであり、マージをブロックするものではありません。変更自体は正しく機能し、報告されたバグを修正しています。

特に注意が必要なファイルはありませんが、`fetchSessionActivitiesPaginated` への同様の適用を検討してください。

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/extension.ts | `fetchAllSessionsPaginated` のタイムアウトを30秒から60秒に延長する1行の変更。ただし、類似するページネーション関数 `fetchSessionActivitiesPaginated` には同じ修正が適用されていない。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Ext as extension.ts
    participant FU as fetchWithTimeout
    participant API as Jules API

    Ext->>FU: timeout: 60000ms (旧: 30000ms)
    Note over FU: AbortSignal を60秒でセット
    FU->>API: GET sessions list (ページごと)
    alt 60秒以内にレスポンス
        API-->>FU: 200 OK (sessions data)
        FU-->>Ext: Response
        Note over Ext: nextPage があれば繰り返し
    else タイムアウト超過
        FU-->>Ext: TimeoutError (修正前は30秒で発生)
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/extension.ts`, line 1375-1386 ([link](https://github.com/hiroki-org/jules-extension/blob/69de68b005a069a688498ec876e9d32a600a015e/src/extension.ts#L1375-L1386)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **アクティビティ取得でも同様のタイムアウト設定が未適用**

   `fetchAllSessionsPaginated` に `timeout: 60000` が追加されましたが、同じくページネーションを行う `fetchSessionActivitiesPaginated`（1375行目）には適用されていません。セッション数の多いユーザーと同様に、アクティビティ数の多いセッションでも同じ `TimeoutError` が発生し得ます。一貫性のために同様の修正を適用することを推奨します。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/extension.ts
   Line: 1375-1386

   Comment:
   **アクティビティ取得でも同様のタイムアウト設定が未適用**

   `fetchAllSessionsPaginated` に `timeout: 60000` が追加されましたが、同じくページネーションを行う `fetchSessionActivitiesPaginated`（1375行目）には適用されていません。セッション数の多いユーザーと同様に、アクティビティ数の多いセッションでも同じ `TimeoutError` が発生し得ます。一貫性のために同様の修正を適用することを推奨します。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/extension.ts
Line: 1375-1386

Comment:
**アクティビティ取得でも同様のタイムアウト設定が未適用**

`fetchAllSessionsPaginated` に `timeout: 60000` が追加されましたが、同じくページネーションを行う `fetchSessionActivitiesPaginated`（1375行目）には適用されていません。セッション数の多いユーザーと同様に、アクティビティ数の多いセッションでも同じ `TimeoutError` が発生し得ます。一貫性のために同様の修正を適用することを推奨します。

```suggestion
      const response = await fetchWithTimeout(
        buildActivitiesListEndpoint(JULES_API_BASE_URL, sessionId, {
          pageToken,
        }),
        {
          method: "GET",
          headers: {
            "X-Goog-Api-Key": apiKey,
            "Content-Type": "application/json",
          },
          timeout: 60000,
        },
      );
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: increase fetch timeout for sessions..."](https://github.com/hiroki-org/jules-extension/commit/69de68b005a069a688498ec876e9d32a600a015e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26573073)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->