### PR TITLE
fix(chat): auto-refreshでチャットビューのpolling更新を復旧

### DIFF
--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         args: '. --sarif --output results.sarif'
     - name: Upload njsscan report
-      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: github/codeql-action/upload-sarif@38b3b7bf288d49ccf58644769dc7a6afdccd05eb
+      if: always() && steps.njsscan.outcome == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: results.sarif

--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -30,6 +30,6 @@ jobs:
         args: '. --sarif --output results.sarif'
     - name: Upload njsscan report
       if: always() && steps.njsscan.outcome == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@38b3b7bf288d49ccf58644769dc7a6afdccd05eb
       with:
         sarif_file: results.sarif

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,6 +177,7 @@ function loadPreviousSessionStates(context: vscode.ExtensionContext): void {
 }
 let autoRefreshInterval: NodeJS.Timeout | undefined;
 let isFetchingSensitiveData = false;
+let isRefreshingActiveChatSession = false;
 
 // Helper functions
 
@@ -1145,7 +1146,7 @@ async function refreshSessionActivitiesCacheFromApi(
   const previousLatestCreateTime =
     context.globalState.get<string>(latestCreateTimeKey);
   const cachedActivities = sessionActivitiesCache.get(sessionId) || [];
-  const useDeltaFetch =
+  const shouldMergeWithCache =
     !!previousLatestCreateTime && cachedActivities.length > 0;
 
   const newActivities = await fetchSessionActivitiesPaginated(
@@ -1156,7 +1157,7 @@ async function refreshSessionActivitiesCacheFromApi(
     },
   );
 
-  const mergedActivities = useDeltaFetch
+  const mergedActivities = shouldMergeWithCache
     ? mergeActivitiesByIdentity(cachedActivities, newActivities)
     : mergeActivitiesByIdentity([], newActivities);
 
@@ -1172,72 +1173,85 @@ export async function refreshActiveChatSessionFromAutoRefresh(
   context: vscode.ExtensionContext,
   chatViewProvider: Pick<JulesChatViewProvider, "updateSession">,
 ): Promise<void> {
-  const activeSessionId = context.globalState.get<string>("active-session-id");
-  if (!activeSessionId || !isValidSessionId(activeSessionId)) {
-    return;
-  }
-
-  const apiKey = await context.secrets.get("jules-api-key");
-  if (!apiKey) {
-    return;
-  }
-
-  const sessionResponse = await fetchWithTimeout(
-    `${JULES_API_BASE_URL}/${activeSessionId}`,
-    {
-      method: "GET",
-      headers: {
-        "X-Goog-Api-Key": apiKey,
-        "Content-Type": "application/json",
-      },
-    },
-  );
-  if (!sessionResponse.ok) {
-    const errorText = await sessionResponse.text();
-    throw new Error(
-      `Failed to fetch active session for chat polling: ${sessionResponse.status} ${sessionResponse.statusText} - ${errorText}`,
+  if (isRefreshingActiveChatSession) {
+    logChannel.appendLine(
+      "Jules: Active chat session refresh already in progress. Skipping.",
     );
+    return;
   }
 
-  const sessionDetails = (await sessionResponse.json()) as {
-    state?: string;
-    title?: string;
-    createTime?: string;
-  };
+  isRefreshingActiveChatSession = true;
+  try {
+    const activeSessionId = context.globalState.get<string>("active-session-id");
+    if (!activeSessionId || !isValidSessionId(activeSessionId)) {
+      return;
+    }
 
-  const latestCreateTimeKey = getActivitiesLatestCreateTimeKey(activeSessionId);
-  const previousLatestCreateTime =
-    context.globalState.get<string>(latestCreateTimeKey);
-  const cachedActivities = sessionActivitiesCache.get(activeSessionId) || [];
-  const useDeltaFetch =
-    !!previousLatestCreateTime && cachedActivities.length > 0;
+    const apiKey = await context.secrets.get("jules-api-key");
+    if (!apiKey) {
+      return;
+    }
 
-  const newActivities = await fetchSessionActivitiesPaginated(
-    apiKey,
-    activeSessionId,
-    {
-      showPaginationProgress: false,
-    },
-  );
+    const sessionResponse = await fetchWithTimeout(
+      `${JULES_API_BASE_URL}/${activeSessionId}`,
+      {
+        method: "GET",
+        headers: {
+          "X-Goog-Api-Key": apiKey,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    if (!sessionResponse.ok) {
+      const errorText = await sessionResponse.text();
+      throw new Error(
+        `Failed to fetch active session for chat polling: ${sessionResponse.status} ${sessionResponse.statusText} - ${errorText}`,
+      );
+    }
 
-  const mergedActivities = useDeltaFetch
-    ? mergeActivitiesByIdentity(cachedActivities, newActivities)
-    : mergeActivitiesByIdentity([], newActivities);
+    const sessionDetails = (await sessionResponse.json()) as {
+      state?: string;
+      title?: string;
+      createTime?: string;
+    };
 
-  addToActivitiesCache(activeSessionId, mergedActivities);
+    const latestCreateTimeKey =
+      getActivitiesLatestCreateTimeKey(activeSessionId);
+    const previousLatestCreateTime =
+      context.globalState.get<string>(latestCreateTimeKey);
+    const cachedActivities = sessionActivitiesCache.get(activeSessionId) || [];
+    const shouldMergeWithCache =
+      !!previousLatestCreateTime && cachedActivities.length > 0;
 
-  const latestCreateTime = getLatestActivityCreateTime(mergedActivities);
-  if (latestCreateTime) {
-    await context.globalState.update(latestCreateTimeKey, latestCreateTime);
+    const newActivities = await fetchSessionActivitiesPaginated(
+      apiKey,
+      activeSessionId,
+      {
+        showPaginationProgress: false,
+      },
+    );
+
+    const mergedActivities = shouldMergeWithCache
+      ? mergeActivitiesByIdentity(cachedActivities, newActivities)
+      : mergeActivitiesByIdentity([], newActivities);
+
+    addToActivitiesCache(activeSessionId, mergedActivities);
+
+    const latestCreateTime = getLatestActivityCreateTime(mergedActivities);
+    if (latestCreateTime) {
+      await context.globalState.update(latestCreateTimeKey, latestCreateTime);
+    }
+
+    chatViewProvider.updateSession(
+      activeSessionId,
+      mergedActivities,
+      sessionDetails.state,
+      sessionDetails.title,
+      sessionDetails.createTime,
+    );
+  } finally {
+    isRefreshingActiveChatSession = false;
   }
-
-  chatViewProvider.updateSession(
-    activeSessionId,
-    mergedActivities,
-    sessionDetails.state,
-    sessionDetails.title,
-    sessionDetails.createTime,
-  );
 }
 
 function getActivitiesLatestCreateTimeKey(sessionId: string): string {
@@ -3051,7 +3065,7 @@ export function activate(context: vscode.ExtensionContext) {
         const previousLatestCreateTime =
           context.globalState.get<string>(latestCreateTimeKey);
         const cachedActivities = sessionActivitiesCache.get(sessionId) || [];
-        const useDeltaFetch =
+        const shouldMergeWithCache =
           !!previousLatestCreateTime && cachedActivities.length > 0;
 
         const newActivities = await fetchSessionActivitiesPaginated(
@@ -3062,7 +3076,7 @@ export function activate(context: vscode.ExtensionContext) {
           },
         );
 
-        const mergedActivities = useDeltaFetch
+        const mergedActivities = shouldMergeWithCache
           ? mergeActivitiesByIdentity(cachedActivities, newActivities)
           : mergeActivitiesByIdentity([], newActivities);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,6 +178,7 @@ function loadPreviousSessionStates(context: vscode.ExtensionContext): void {
 let autoRefreshInterval: NodeJS.Timeout | undefined;
 let isFetchingSensitiveData = false;
 let isRefreshingActiveChatSession = false;
+let isAutoRefreshPipelineRunning = false;
 
 // Helper functions
 
@@ -1036,16 +1037,25 @@ function startAutoRefresh(
   }
 
   autoRefreshInterval = setInterval(() => {
+    if (isAutoRefreshPipelineRunning) {
+      logChannel.appendLine("Jules: Auto-refresh pipeline already in progress. Skipping.");
+      return;
+    }
+    isAutoRefreshPipelineRunning = true;
     logChannel.appendLine("Jules: Auto-refresh triggered");
-    sessionsProvider.refresh(true); // Pass true for background refresh
-    void refreshActiveChatSessionFromAutoRefresh(
-      context,
-      chatViewProvider,
-    ).catch((error: unknown) => {
-      logChannel.appendLine(
-        `Jules: Failed to refresh active chat session during auto-refresh: ${sanitizeError(error)}`,
-      );
-    });
+    void sessionsProvider
+      .refresh(true) // Pass true for background refresh
+      .then(async () => {
+        await refreshActiveChatSessionFromAutoRefresh(context, chatViewProvider);
+      })
+      .catch((error: unknown) => {
+        logChannel.appendLine(
+          `Jules: Auto-refresh pipeline failed: ${sanitizeError(error)}`,
+        );
+      })
+      .finally(() => {
+        isAutoRefreshPipelineRunning = false;
+      });
   }, interval);
 }
 
@@ -1054,6 +1064,7 @@ function stopAutoRefresh(): void {
     clearInterval(autoRefreshInterval);
     autoRefreshInterval = undefined;
   }
+  isAutoRefreshPipelineRunning = false;
 }
 
 function resetAutoRefresh(
@@ -1234,6 +1245,15 @@ export async function refreshActiveChatSessionFromAutoRefresh(
     const mergedActivities = shouldMergeWithCache
       ? mergeActivitiesByIdentity(cachedActivities, newActivities)
       : mergeActivitiesByIdentity([], newActivities);
+
+    const currentActiveSessionId =
+      context.globalState.get<string>("active-session-id");
+    if (currentActiveSessionId !== activeSessionId) {
+      logChannel.appendLine(
+        "Jules: Discarding stale active chat refresh result.",
+      );
+      return;
+    }
 
     addToActivitiesCache(activeSessionId, mergedActivities);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1009,6 +1009,7 @@ export async function updatePreviousStates(
 function startAutoRefresh(
   context: vscode.ExtensionContext,
   sessionsProvider: JulesSessionsProvider,
+  chatViewProvider: Pick<JulesChatViewProvider, "updateSession">,
 ): void {
   const config = vscode.workspace.getConfiguration(
     "jules-extension.autoRefresh",
@@ -1036,6 +1037,14 @@ function startAutoRefresh(
   autoRefreshInterval = setInterval(() => {
     logChannel.appendLine("Jules: Auto-refresh triggered");
     sessionsProvider.refresh(true); // Pass true for background refresh
+    void refreshActiveChatSessionFromAutoRefresh(
+      context,
+      chatViewProvider,
+    ).catch((error: unknown) => {
+      logChannel.appendLine(
+        `Jules: Failed to refresh active chat session during auto-refresh: ${sanitizeError(error)}`,
+      );
+    });
   }, interval);
 }
 
@@ -1049,9 +1058,10 @@ function stopAutoRefresh(): void {
 function resetAutoRefresh(
   context: vscode.ExtensionContext,
   sessionsProvider: JulesSessionsProvider,
+  chatViewProvider: Pick<JulesChatViewProvider, "updateSession">,
 ): void {
   stopAutoRefresh();
-  startAutoRefresh(context, sessionsProvider);
+  startAutoRefresh(context, sessionsProvider, chatViewProvider);
 }
 
 interface SessionsResponse {
@@ -1156,6 +1166,78 @@ async function refreshSessionActivitiesCacheFromApi(
   if (latestCreateTime) {
     await context.globalState.update(latestCreateTimeKey, latestCreateTime);
   }
+}
+
+export async function refreshActiveChatSessionFromAutoRefresh(
+  context: vscode.ExtensionContext,
+  chatViewProvider: Pick<JulesChatViewProvider, "updateSession">,
+): Promise<void> {
+  const activeSessionId = context.globalState.get<string>("active-session-id");
+  if (!activeSessionId || !isValidSessionId(activeSessionId)) {
+    return;
+  }
+
+  const apiKey = await context.secrets.get("jules-api-key");
+  if (!apiKey) {
+    return;
+  }
+
+  const sessionResponse = await fetchWithTimeout(
+    `${JULES_API_BASE_URL}/${activeSessionId}`,
+    {
+      method: "GET",
+      headers: {
+        "X-Goog-Api-Key": apiKey,
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  if (!sessionResponse.ok) {
+    const errorText = await sessionResponse.text();
+    throw new Error(
+      `Failed to fetch active session for chat polling: ${sessionResponse.status} ${sessionResponse.statusText} - ${errorText}`,
+    );
+  }
+
+  const sessionDetails = (await sessionResponse.json()) as {
+    state?: string;
+    title?: string;
+    createTime?: string;
+  };
+
+  const latestCreateTimeKey = getActivitiesLatestCreateTimeKey(activeSessionId);
+  const previousLatestCreateTime =
+    context.globalState.get<string>(latestCreateTimeKey);
+  const cachedActivities = sessionActivitiesCache.get(activeSessionId) || [];
+  const useDeltaFetch =
+    !!previousLatestCreateTime && cachedActivities.length > 0;
+
+  const newActivities = await fetchSessionActivitiesPaginated(
+    apiKey,
+    activeSessionId,
+    {
+      showPaginationProgress: false,
+    },
+  );
+
+  const mergedActivities = useDeltaFetch
+    ? mergeActivitiesByIdentity(cachedActivities, newActivities)
+    : mergeActivitiesByIdentity([], newActivities);
+
+  addToActivitiesCache(activeSessionId, mergedActivities);
+
+  const latestCreateTime = getLatestActivityCreateTime(mergedActivities);
+  if (latestCreateTime) {
+    await context.globalState.update(latestCreateTimeKey, latestCreateTime);
+  }
+
+  chatViewProvider.updateSession(
+    activeSessionId,
+    mergedActivities,
+    sessionDetails.state,
+    sessionDetails.title,
+    sessionDetails.createTime,
+  );
 }
 
 function getActivitiesLatestCreateTimeKey(sessionId: string): string {
@@ -2490,7 +2572,7 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       isFetchingSensitiveData = true;
-      resetAutoRefresh(context, sessionsProvider);
+      resetAutoRefresh(context, sessionsProvider, chatViewProvider);
 
       try {
         const cacheKey = "jules.sources";
@@ -2632,7 +2714,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showErrorMessage(`Failed to list sources: ${message}`);
       } finally {
         isFetchingSensitiveData = false;
-        resetAutoRefresh(context, sessionsProvider);
+        resetAutoRefresh(context, sessionsProvider, chatViewProvider);
       }
     },
   );
@@ -2668,7 +2750,7 @@ export function activate(context: vscode.ExtensionContext) {
       const apiClient = new JulesApiClient(apiKey, JULES_API_BASE_URL);
 
       isFetchingSensitiveData = true;
-      resetAutoRefresh(context, sessionsProvider);
+      resetAutoRefresh(context, sessionsProvider, chatViewProvider);
       try {
         // ブランチ選択ロジック（メッセージ入力前に移動）
         const {
@@ -2862,7 +2944,7 @@ export function activate(context: vscode.ExtensionContext) {
         );
       } finally {
         isFetchingSensitiveData = false;
-        resetAutoRefresh(context, sessionsProvider);
+        resetAutoRefresh(context, sessionsProvider, chatViewProvider);
       }
     },
   );
@@ -2871,7 +2953,7 @@ export function activate(context: vscode.ExtensionContext) {
   console.log("Jules: Starting initial refresh...");
   sessionsProvider.refresh();
 
-  startAutoRefresh(context, sessionsProvider);
+  startAutoRefresh(context, sessionsProvider, chatViewProvider);
 
   const onDidChangeConfiguration = vscode.workspace.onDidChangeConfiguration(
     (event) => {
@@ -2884,7 +2966,7 @@ export function activate(context: vscode.ExtensionContext) {
           .getConfiguration("jules-extension.autoRefresh")
           .get<boolean>("enabled");
         if (autoRefreshEnabled) {
-          startAutoRefresh(context, sessionsProvider);
+          startAutoRefresh(context, sessionsProvider, chatViewProvider);
         }
       }
     },

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -877,6 +877,68 @@ suite("Extension Test Suite", () => {
 
       assert.strictEqual(updateSessionStub.callCount, 0);
     });
+
+    test("should discard stale result when active session changes during in-flight refresh", async () => {
+      let activeSessionId = "sessions/slow";
+      const updateSessionStub = sandbox.stub();
+      const updateGlobalStateStub = sandbox.stub().resolves();
+
+      let resolveActivitiesFetch: ((value: unknown) => void) | undefined;
+      const activitiesFetchPromise = new Promise((resolve) => {
+        resolveActivitiesFetch = resolve;
+      });
+
+      fetchStub.onFirstCall().resolves({
+        ok: true,
+        json: async () => ({
+          state: "IN_PROGRESS",
+          title: "Slow Session",
+          createTime: "2026-03-01T00:00:00Z",
+        }),
+      } as any);
+      fetchStub.onSecondCall().returns(activitiesFetchPromise as any);
+
+      const context = {
+        globalState: {
+          get: sandbox.stub().callsFake((key: string) => {
+            if (key === "active-session-id") {
+              return activeSessionId;
+            }
+            return undefined;
+          }),
+          update: updateGlobalStateStub,
+        },
+        secrets: {
+          get: sandbox.stub().resolves("api-key"),
+        },
+      } as any as vscode.ExtensionContext;
+
+      const refreshPromise = refreshActiveChatSessionFromAutoRefresh(context, {
+        updateSession: updateSessionStub,
+      });
+
+      // Simulate user switching active session while the first refresh is in flight.
+      activeSessionId = "sessions/newer";
+
+      resolveActivitiesFetch?.({
+        ok: true,
+        json: async () => ({
+          activities: [
+            {
+              id: "1",
+              name: "activities/1",
+              createTime: "2026-03-01T00:01:00Z",
+              agentMessaged: { agentMessage: "stale" },
+            },
+          ],
+        }),
+      } as any);
+
+      await refreshPromise;
+
+      assert.strictEqual(updateSessionStub.callCount, 0);
+      assert.strictEqual(updateGlobalStateStub.callCount, 0);
+    });
   });
 
   suite("areSessionListsEqual", () => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -16,6 +16,7 @@ import {
   getSourceDisplayName,
   getSourceIsPrivate,
   handleOpenInWebApp,
+  refreshActiveChatSessionFromAutoRefresh,
   Session,
   SessionOutput,
   createRemoteBranch,
@@ -714,6 +715,170 @@ suite("Extension Test Suite", () => {
     });
   });
 
+  suite("Chat polling auto refresh", () => {
+    let sandbox: sinon.SinonSandbox;
+    let fetchStub: sinon.SinonStub;
+
+    setup(() => {
+      sandbox = sinon.createSandbox();
+      fetchStub = sandbox.stub(fetchUtils, "fetchWithTimeout");
+    });
+
+    teardown(() => {
+      sandbox.restore();
+    });
+
+    test("should skip polling when no active session id", async () => {
+      const updateSessionStub = sandbox.stub();
+      const context = {
+        globalState: {
+          get: sandbox.stub().withArgs("active-session-id").returns(undefined),
+          update: sandbox.stub().resolves(),
+        },
+        secrets: {
+          get: sandbox.stub().resolves("api-key"),
+        },
+      } as any as vscode.ExtensionContext;
+
+      await refreshActiveChatSessionFromAutoRefresh(context, {
+        updateSession: updateSessionStub,
+      });
+
+      assert.strictEqual(fetchStub.callCount, 0);
+      assert.strictEqual(updateSessionStub.callCount, 0);
+    });
+
+    test("should skip polling when active session id is invalid", async () => {
+      const updateSessionStub = sandbox.stub();
+      const context = {
+        globalState: {
+          get: sandbox
+            .stub()
+            .withArgs("active-session-id")
+            .returns("sessions/../invalid"),
+          update: sandbox.stub().resolves(),
+        },
+        secrets: {
+          get: sandbox.stub().resolves("api-key"),
+        },
+      } as any as vscode.ExtensionContext;
+
+      await refreshActiveChatSessionFromAutoRefresh(context, {
+        updateSession: updateSessionStub,
+      });
+
+      assert.strictEqual(fetchStub.callCount, 0);
+      assert.strictEqual(updateSessionStub.callCount, 0);
+    });
+
+    test("should refresh active chat session from API and update chat state", async () => {
+      const activeSessionId = "sessions/abc123";
+      const latestCreateTimeKey = `jules.activities.latestCreateTime.${activeSessionId}`;
+      const updateSessionStub = sandbox.stub();
+      const updateGlobalStateStub = sandbox.stub().resolves();
+      const getGlobalStateStub = sandbox
+        .stub()
+        .withArgs("active-session-id")
+        .returns(activeSessionId);
+      getGlobalStateStub.withArgs(latestCreateTimeKey).returns(undefined);
+
+      fetchStub.onFirstCall().resolves({
+        ok: true,
+        json: async () => ({
+          state: "IN_PROGRESS",
+          title: "Session Title",
+          createTime: "2026-03-01T00:00:00Z",
+        }),
+      } as any);
+      fetchStub.onSecondCall().resolves({
+        ok: true,
+        json: async () => ({
+          activities: [
+            {
+              id: "2",
+              name: "activities/2",
+              createTime: "2026-03-01T00:02:00Z",
+              agentMessaged: { agentMessage: "second" },
+            },
+            {
+              id: "1",
+              name: "activities/1",
+              createTime: "2026-03-01T00:01:00Z",
+              userMessaged: { userMessage: "first" },
+            },
+          ],
+        }),
+      } as any);
+
+      const context = {
+        globalState: {
+          get: getGlobalStateStub,
+          update: updateGlobalStateStub,
+        },
+        secrets: {
+          get: sandbox.stub().resolves("api-key"),
+        },
+      } as any as vscode.ExtensionContext;
+
+      await refreshActiveChatSessionFromAutoRefresh(context, {
+        updateSession: updateSessionStub,
+      });
+
+      assert.strictEqual(fetchStub.callCount, 2);
+      assert.ok(String(fetchStub.getCall(0).args[0]).includes(`/${activeSessionId}`));
+      assert.ok(
+        String(fetchStub.getCall(1).args[0]).includes(`/${activeSessionId}/activities?pageSize=100`),
+      );
+
+      assert.strictEqual(updateSessionStub.callCount, 1);
+      const updateArgs = updateSessionStub.getCall(0).args;
+      assert.strictEqual(updateArgs[0], activeSessionId);
+      assert.strictEqual(updateArgs[2], "IN_PROGRESS");
+      assert.strictEqual(updateArgs[3], "Session Title");
+      assert.strictEqual(updateArgs[4], "2026-03-01T00:00:00Z");
+      assert.strictEqual(updateArgs[1].length, 2);
+      assert.strictEqual(updateArgs[1][0].name, "activities/1");
+      assert.strictEqual(updateArgs[1][1].name, "activities/2");
+
+      assert.ok(
+        updateGlobalStateStub.calledWith(
+          latestCreateTimeKey,
+          "2026-03-01T00:02:00Z",
+        ),
+      );
+    });
+
+    test("should throw when active session fetch fails", async () => {
+      const updateSessionStub = sandbox.stub();
+      fetchStub.onFirstCall().resolves({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: async () => "boom",
+      } as any);
+
+      const context = {
+        globalState: {
+          get: sandbox.stub().withArgs("active-session-id").returns("sessions/fail"),
+          update: sandbox.stub().resolves(),
+        },
+        secrets: {
+          get: sandbox.stub().resolves("api-key"),
+        },
+      } as any as vscode.ExtensionContext;
+
+      await assert.rejects(
+        () =>
+          refreshActiveChatSessionFromAutoRefresh(context, {
+            updateSession: updateSessionStub,
+          }),
+        /Failed to fetch active session for chat polling/,
+      );
+
+      assert.strictEqual(updateSessionStub.callCount, 0);
+    });
+  });
+
   suite("areSessionListsEqual", () => {
     test("should return true for same sessions in different order", () => {
       const s1 = { name: "1", title: "t1", state: "RUNNING", rawState: "RUNNING", outputs: [] } as Session;
@@ -969,4 +1134,3 @@ suite("Extension Test Suite", () => {
     });
   });
 });
-


### PR DESCRIPTION
## 概要
チャットビューで polling による更新（新規メッセージ/typing状態）が進まない問題を修正しました。

## 原因
- 既存の auto-refresh は sessionsProvider.refresh(true) のみ実行しており、チャットビュー updateSession が定期実行されていませんでした。
- そのため、ツリーは更新されてもチャットの表示状態が追従しないケースが発生していました。

## 変更内容
- src/extension.ts
  - startAutoRefresh / resetAutoRefresh に chatViewProvider を注入
  - auto-refresh tick 時に refreshActiveChatSessionFromAutoRefresh を実行
  - refreshActiveChatSessionFromAutoRefresh を追加
- src/test/extension.test.ts
  - polling helper のユニットテストを追加

## 検証
- pnpm run check-types
- pnpm run lint
- pnpm run test:unit（266 passing）

## 影響範囲
- auto-refresh 時のチャット更新経路のみ
- 手動 showActivities / sendMessage の動作は維持

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、チャットビューの polling 更新（新規メッセージ/typing状態）が auto-refresh tick で実行されていなかった問題を修正します。`startAutoRefresh` / `resetAutoRefresh` に `chatViewProvider` を注入し、各 tick で `refreshActiveChatSessionFromAutoRefresh` を呼び出すことでチャット表示状態をツリービューと同期させます。\n\n**主な変更点:**\n- `startAutoRefresh` / `resetAutoRefresh` のシグネチャに `chatViewProvider` 引数を追加（既存の呼び出し箇所もすべて更新済み）\n- `refreshActiveChatSessionFromAutoRefresh` を新規追加：アクティブセッションのセッション詳細＋全アクティビティをフェッチし、キャッシュを更新後 `chatViewProvider.updateSession` を呼び出す\n- 既存の `refreshSessionActivitiesCacheFromApi` と同じマージ戦略（`mergeActivitiesByIdentity`）を踏襲しており、パターンは一貫している\n- 4つのユニットテスト（スキップケース2件、正常系1件、エラー系1件）が追加されており、カバレッジは適切
</details>

<h3>Confidence Score: 5/5</h3>

マージ可能。残存する指摘はいずれも P2（スタイル・将来的な堅牢性の改善）であり、現時点でのランタイムエラーや機能破壊リスクはありません。

すべての残存コメントは P2 レベル（同時実行ガードの欠如・変数名の改善）であり、マージをブロックするものではありません。変更範囲は auto-refresh 経路のみに限定されており、手動操作パスへの影響はありません。テストカバレッジも適切に追加されています。

src/extension.ts の `refreshActiveChatSessionFromAutoRefresh` 関数（同時実行ガードの追加を検討）

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `startAutoRefresh` / `resetAutoRefresh` に `chatViewProvider` を注入し、auto-refresh tick ごとに `refreshActiveChatSessionFromAutoRefresh` を実行するよう修正。同時実行ガードが未実装という P2 懸念あり。 |
| src/test/extension.test.ts | `refreshActiveChatSessionFromAutoRefresh` に対する4つのユニットテスト（スキップ・正常系・エラー系）を追加。カバレッジは十分。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Timer as setInterval (autoRefresh)
    participant SP as sessionsProvider
    participant Ext as refreshActiveChatSessionFromAutoRefresh
    participant API as Jules API
    participant Cache as sessionActivitiesCache
    participant Chat as JulesChatViewProvider

    Timer->>SP: refresh(true)
    SP-->>Timer: (async, tree view update)

    Timer->>Ext: void call (fire & forget)
    Ext->>Ext: get activeSessionId from globalState
    alt activeSessionId が無効/未設定
        Ext-->>Timer: return (no-op)
    else 有効なセッションID
        Ext->>API: GET /{activeSessionId} (session details)
        API-->>Ext: { state, title, createTime }
        Ext->>API: GET /{activeSessionId}/activities (paginated)
        API-->>Ext: activities[]
        Ext->>Cache: mergeActivitiesByIdentity & addToActivitiesCache
        Ext->>Ext: globalState.update(latestCreateTimeKey)
        Ext->>Chat: updateSession(sessionId, activities, state, title, createTime)
        Chat-->>Ext: (UI updated)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/extension.ts
Line: 1037-1048

Comment:
**同時実行ガードが不足している**

`refreshActiveChatSessionFromAutoRefresh` には、`fetchAndProcessSessions` の `isFetching` のような同時実行防止ガードがありません。ポーリング間隔（最短 `fastInterval` = 30 秒）よりもアクティビティの取得（複数ページのページネーション）に時間がかかる場合、2つの呼び出しが並列実行されます。先に開始された古い呼び出しが後から完了し、キャッシュと `chatViewProvider.updateSession` が古いデータで上書きされる可能性があります。

既存の `fetchAndProcessSessions` と同様に、モジュールスコープのフラグ追加を検討してください：

```typescript
let isRefreshingActiveChatSession = false;

export async function refreshActiveChatSessionFromAutoRefresh(...): Promise<void> {
  if (isRefreshingActiveChatSession) {
    logChannel.appendLine("Jules: Chat session refresh already in progress. Skipping.");
    return;
  }
  isRefreshingActiveChatSession = true;
  try {
    // ... 既存のロジック ...
  } finally {
    isRefreshingActiveChatSession = false;
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/extension.ts
Line: 1208-1225

Comment:
**`useDeltaFetch` はフェッチ動作を変えない**

`useDeltaFetch` という変数名は「デルタ取得（差分取得）」を示唆していますが、実際には API コールの内容に何も影響を与えません（`fetchSessionActivitiesPaginated` は常に全件フェッチします）。この変数はマージ戦略のみを制御しており、`true` の場合はキャッシュと新規データのマージ、`false` の場合はキャッシュを無視して新規データのみ使用、という違いです。

これは既存の `refreshSessionActivitiesCacheFromApi` と同じパターンなので一貫性はありますが、変数名が意図を誤解させます。`mergeWithCache` のようなより正確な名前への変更、または2つの分岐の一本化を検討してください：

```typescript
// フルフェッチなので既存キャッシュは常にマージ対象とするだけで十分
const mergedActivities = mergeActivitiesByIdentity(cachedActivities, newActivities);
```

（この場合 `previousLatestCreateTime` と `useDeltaFetch` の計算も不要になります）

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chat): refresh active chat session o..."](https://github.com/hiroki-org/jules-extension/commit/bbeb70c7f200174b32635e5f80d1d3a8773ea1ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26577257)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->