### PR TITLE
[codex] add VS Code UI smoke test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,8 @@ jobs:
   integration:
     needs: [test-unit, build-check]
     runs-on: ${{ matrix.os }}
+    env:
+      JULES_E2E_VSCODE_VERSION: "1.113.0"
     strategy:
       fail-fast: false
       matrix:
@@ -100,7 +102,7 @@ jobs:
             ~/.vscode-test
             ~/.vscode
             .vscode-test
-          key: ${{ runner.os }}-vscode-test
+          key: ${{ runner.os }}-vscode-test-${{ env.JULES_E2E_VSCODE_VERSION }}
           restore-keys: |
             ${{ runner.os }}-vscode-test-
 
@@ -124,6 +126,10 @@ jobs:
         shell: bash
         run: pnpm test
 
+      # The regular integration matrix already exercises the extension host across
+      # Linux, macOS, and Windows. Keep this second-VS-Code smoke narrow to the
+      # most stable lane so CI cost stays bounded and the UI selectors remain
+      # deterministic.
       - name: Run E2E smoke test (macOS)
         if: runner.os == 'macOS' && matrix.node-version == 20
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,7 @@ jobs:
           path: |
             ~/.vscode-test
             ~/.vscode
+            .vscode-test
           key: ${{ runner.os }}-vscode-test
           restore-keys: |
             ${{ runner.os }}-vscode-test-
@@ -122,3 +123,8 @@ jobs:
         if: runner.os != 'Linux'
         shell: bash
         run: pnpm test
+
+      - name: Run E2E smoke test (macOS)
+        if: runner.os == 'macOS' && matrix.node-version == 20
+        shell: bash
+        run: pnpm run test:e2e

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@octokit/rest": "^22.0.1",
         "@shikijs/markdown-it": "^4.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-glob": "^4.0.3",
         "markdown-it": "^14.1.1",
         "shiki": "^4.0.2",
@@ -31,6 +32,7 @@
         "eslint": "^9.36.0",
         "mocha": "^11.7.5",
         "npm-run-all": "^4.1.5",
+        "playwright-core": "^1.58.2",
         "sinon": "^17.0.0",
         "source-map-support": "^0.5.21",
         "typescript": "^5.9.3"
@@ -3387,7 +3389,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5165,6 +5166,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "gemini"
   ],
   "engines": {
-    "vscode": "^1.105.0"
+    "vscode": "^1.105.0",
+    "node": ">=18"
   },
   "categories": [
     "Other"

--- a/package.json
+++ b/package.json
@@ -366,6 +366,8 @@
     "test": "vscode-test",
     "pretest:unit": "npm run compile-tests",
     "test:unit": "mocha --ui tdd --require source-map-support/register --require out/test/vscodeMock.js \"out/test/*.unit.test.js\"",
+    "pretest:e2e": "npm run compile-tests && npm run compile",
+    "test:e2e": "mocha --ui tdd --timeout 180000 --require source-map-support/register \"out/test/*.e2e.js\"",
     "pretest:coverage": "npm run pretest:unit",
     "test:coverage": "c8 --all --src src --exclude \"src/test/**\" --exclude-after-remap --reporter=text-summary --reporter=json-summary --reporter=lcov mocha --ui tdd --require source-map-support/register --require out/test/vscodeMock.js \"out/test/*.unit.test.js\""
   },
@@ -379,14 +381,15 @@
     "@typescript-eslint/parser": "^8.45.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
+    "c8": "^10.1.3",
     "esbuild": "^0.25.10",
     "eslint": "^9.36.0",
     "mocha": "^11.7.5",
     "npm-run-all": "^4.1.5",
+    "playwright-core": "^1.58.2",
     "sinon": "^17.0.0",
     "source-map-support": "^0.5.21",
-    "typescript": "^5.9.3",
-    "c8": "^10.1.3"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "@octokit/rest": "^22.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      playwright-core:
+        specifier: ^1.58.2
+        version: 1.58.2
       sinon:
         specifier: ^17.0.0
         version: 17.0.2
@@ -1513,6 +1516,11 @@ packages:
   pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3519,6 +3527,8 @@ snapshots:
   pidtree@0.3.1: {}
 
   pify@3.0.0: {}
+
+  playwright-core@1.58.2: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/test/createSession.e2e.ts
+++ b/src/test/createSession.e2e.ts
@@ -1,4 +1,3 @@
-import * as assert from "assert";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -7,7 +6,14 @@ import { _electron as electron, ElectronApplication, Page } from "playwright-cor
 
 const COMMAND_LABEL = "Create Jules Session";
 const ERROR_MESSAGE = "No source selected. Please list and select a source first.";
-// Keep the default VS Code build pinned because the selector strategy is tied to a tested workbench version.
+// Keep the default VS Code build pinned because this smoke test reaches into
+// workbench selectors such as `[aria-label="Open Quick Access"]`,
+// `input[aria-label="Type the name of a command to run."]`, and
+// `.quick-input-list .monaco-list-row`.
+// If a VS Code update breaks them, rerun with
+// `PWDEBUG=1 JULES_E2E_VSCODE_VERSION=<candidate> pnpm run test:e2e`, inspect the
+// DOM in Playwright, and prefer stable role/aria/text selectors before falling
+// back to Monaco-specific CSS hooks.
 const VSCODE_VERSION = process.env.JULES_E2E_VSCODE_VERSION || "1.113.0";
 
 type LaunchResult = {
@@ -110,8 +116,6 @@ suite("VS Code UI Smoke Tests", () => {
         .getByText(ERROR_MESSAGE, { exact: true })
         .first();
       await notification.waitFor({ state: "visible", timeout: 15_000 });
-
-      assert.strictEqual(await notification.textContent(), ERROR_MESSAGE);
     } finally {
       if (app) {
         await closeApp(app);

--- a/src/test/createSession.e2e.ts
+++ b/src/test/createSession.e2e.ts
@@ -7,6 +7,7 @@ import { _electron as electron, ElectronApplication, Page } from "playwright-cor
 
 const COMMAND_LABEL = "Create Jules Session";
 const ERROR_MESSAGE = "No source selected. Please list and select a source first.";
+// Keep the default VS Code build pinned because the selector strategy is tied to a tested workbench version.
 const VSCODE_VERSION = process.env.JULES_E2E_VSCODE_VERSION || "1.113.0";
 
 type LaunchResult = {

--- a/src/test/createSession.e2e.ts
+++ b/src/test/createSession.e2e.ts
@@ -1,0 +1,121 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { downloadAndUnzipVSCode } from "@vscode/test-electron";
+import { _electron as electron, ElectronApplication, Page } from "playwright-core";
+
+const COMMAND_LABEL = "Create Jules Session";
+const ERROR_MESSAGE = "No source selected. Please list and select a source first.";
+const VSCODE_VERSION = process.env.JULES_E2E_VSCODE_VERSION || "1.113.0";
+
+type LaunchResult = {
+  app: ElectronApplication;
+  page: Page;
+  tempDirs: string[];
+};
+
+function getWorkspaceRoot(): string {
+  return path.resolve(__dirname, "../..");
+}
+
+function getCommandPaletteShortcut(): string {
+  return process.platform === "darwin" ? "Meta+Shift+P" : "Control+Shift+P";
+}
+
+async function launchExtensionHost(): Promise<LaunchResult> {
+  const workspaceRoot = getWorkspaceRoot();
+  const executablePath = await downloadAndUnzipVSCode(VSCODE_VERSION);
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "jules-e2e-user-"));
+  const extensionsDir = fs.mkdtempSync(path.join(os.tmpdir(), "jules-e2e-ext-"));
+
+  const app = await electron.launch({
+    executablePath,
+    args: [
+      workspaceRoot,
+      `--extensionDevelopmentPath=${workspaceRoot}`,
+      `--user-data-dir=${userDataDir}`,
+      `--extensions-dir=${extensionsDir}`,
+      "--disable-extensions",
+      "--disable-gpu",
+      "--disable-workspace-trust",
+      "--no-sandbox",
+      "--skip-release-notes",
+      "--skip-welcome",
+    ],
+    timeout: 60_000,
+  });
+
+  const page = await app.firstWindow();
+  await page.locator('[aria-label="Open Quick Access"]').waitFor({
+    state: "visible",
+    timeout: 30_000,
+  });
+
+  return {
+    app,
+    page,
+    tempDirs: [userDataDir, extensionsDir],
+  };
+}
+
+async function openCommandPalette(page: Page, commandLabel: string): Promise<void> {
+  await page.keyboard.press(getCommandPaletteShortcut());
+
+  const quickInput = page.locator(
+    'input[aria-label="Type the name of a command to run."]',
+  );
+  await quickInput.waitFor({ state: "visible", timeout: 15_000 });
+  await quickInput.fill(`>${commandLabel}`);
+
+  const commandRow = page
+    .locator(".quick-input-list .monaco-list-row")
+    .filter({ hasText: commandLabel })
+    .first();
+  await commandRow.waitFor({ state: "visible", timeout: 15_000 });
+  await page.keyboard.press("Enter");
+}
+
+async function closeApp(app: ElectronApplication): Promise<void> {
+  try {
+    await app.close();
+  } catch {
+    // VS Code shutdown can race with the test runner; ignore cleanup errors.
+  }
+}
+
+function cleanupTempDirs(tempDirs: string[]): void {
+  for (const tempDir of tempDirs) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+suite("VS Code UI Smoke Tests", () => {
+  test("Create Jules Session shows an error toast when no source is selected", async function () {
+    this.timeout(180_000);
+
+    let app: ElectronApplication | undefined;
+    let tempDirs: string[] = [];
+
+    try {
+      const launched = await launchExtensionHost();
+      app = launched.app;
+      tempDirs = launched.tempDirs;
+
+      await openCommandPalette(launched.page, COMMAND_LABEL);
+
+      const notification = launched.page
+        .locator(".notifications-toasts")
+        .getByText(ERROR_MESSAGE, { exact: true })
+        .first();
+      await notification.waitFor({ state: "visible", timeout: 15_000 });
+
+      assert.strictEqual(await notification.textContent(), ERROR_MESSAGE);
+    } finally {
+      if (app) {
+        await closeApp(app);
+      }
+      cleanupTempDirs(tempDirs);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated `test:e2e` script that launches a second VS Code instance through Electron
- add a smoke test that runs `Create Jules Session` from the command palette and verifies the `No source selected...` error toast
- run the new smoke test on macOS in CI and cache the local `.vscode-test` download directory

## Why
The existing test setup validates extension logic inside `vscode-test`, but it does not exercise a real workbench UI flow. This adds one stable command-palette-to-notification path so regressions in command registration or UI wiring are caught before release.

## Validation
- `pnpm run compile-tests`
- `pnpm run lint`
- `pnpm run test:e2e`
- `pnpm test`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `playwright-core` と `@vscode/test-electron` を組み合わせて実際の VS Code ワークベンチ UI を起動し、コマンドパレットから「Create Jules Session」を実行してエラートーストが表示されることを検証する E2E スモークテストを追加します。また、CI の `integration` ジョブに macOS + Node 20 限定の E2E テストステップと `.vscode-test` キャッシュ設定も追加されています。

主な変更点と指摘事項:

- **`https-proxy-agent` が production `dependencies` に誤って追加されている** (`package.json` L397): テスト専用の依存関係であるため `devDependencies` に移すべきです。
- **キャッシュキーに VS Code バージョンが含まれていない** (`.github/workflows/test.yml`): バージョン変更時に古いキャッシュが再利用される可能性があります。
- **UI セレクターのバージョン依存性** (`createSession.e2e.ts`): `aria-label` や Monaco CSS クラスは VS Code バージョン間で変わる可能性があります。
- `--disable-extensions` と `--extensionDevelopmentPath` の組み合わせは VS Code の仕様上、開発中拡張機能には影響しないため問題ありません。
</details>


<h3>Confidence Score: 4/5</h3>

`https-proxy-agent` の production 依存化という P1 問題が残っているため、修正後のマージを推奨します。

`https-proxy-agent` が `devDependencies` ではなく `dependencies` に追加されており、esbuild のバンドルや拡張機能のパッケージングに意図しない影響を与える可能性があります。その他の指摘は P2 レベルです。

`package.json` の `dependencies` セクションおよび `package-lock.json` の `https-proxy-agent` エントリ

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | E2E テスト用スクリプト (`test:e2e`) を追加し `playwright-core` を devDependencies に追加。ただし `https-proxy-agent` が誤って production `dependencies` に追加されており、バンドルへの不要な依存混入リスクがある。 |
| src/test/createSession.e2e.ts | 新規追加の E2E スモークテスト。`playwright-core` と `@vscode/test-electron` を用いて実際の VS Code インスタンスを起動し、「Create Jules Session」コマンドのエラートーストを検証する。UI セレクターが VS Code バージョンに依存しており、将来のバージョンアップで壊れる可能性がある。 |
| .github/workflows/test.yml | macOS + Node 20 のみで E2E テストを実行するステップを追加。キャッシュキーに VS Code バージョンが含まれていないため、バージョン変更時に古いバイナリが再利用される可能性がある。 |
| package-lock.json | `playwright-core@1.58.2` を追加、`https-proxy-agent` から `"dev": true` フラグが削除されて production 依存関係として扱われるようになった。 |
| pnpm-lock.yaml | `playwright-core@1.58.2` のロックエントリが追加された。通常の lockfile 更新であり問題なし。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as GitHub Actions (macOS / Node 20)
    participant Mocha as Mocha (test:e2e)
    participant TestElectron as @vscode/test-electron
    participant VSCode as VS Code (Electron)
    participant Playwright as playwright-core

    CI->>Mocha: pnpm run test:e2e
    Mocha->>TestElectron: downloadAndUnzipVSCode("1.113.0")
    TestElectron-->>Mocha: executablePath
    Mocha->>Playwright: electron.launch(executablePath, args)
    Playwright->>VSCode: 起動 (--extensionDevelopmentPath, --disable-extensions, ...)
    VSCode-->>Playwright: ElectronApplication
    Playwright->>VSCode: firstWindow()
    VSCode-->>Playwright: Page
    Playwright->>VSCode: waitFor('[aria-label="Open Quick Access"]')
    Playwright->>VSCode: keyboard.press(Meta+Shift+P)
    Playwright->>VSCode: quickInput.fill(">Create Jules Session")
    Playwright->>VSCode: keyboard.press("Enter")
    VSCode-->>Playwright: notifications-toasts に "No source selected..." 表示
    Playwright->>Mocha: assert.strictEqual(textContent, ERROR_MESSAGE)
    Mocha->>VSCode: app.close()
    Mocha->>CI: テスト結果を返す
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `package.json`, line 397 ([link](https://github.com/hiroki-org/jules-extension/blob/2cf095af392110ac841afb2cb7699579cdd461ef/package.json#L397)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`https-proxy-agent` が production `dependencies` に誤って追加されている**

   `https-proxy-agent` はテスト実行時に VS Code バイナリをダウンロードするために `@vscode/test-electron` が内部的に利用するものです。E2E テスト専用の依存関係であるため、`dependencies` ではなく `devDependencies` に置くべきです。

   `dependencies` に含まれると、`vsce package` によるパッケージングや esbuild のバンドリング時に不要な依存が拡張機能に混入するリスクがあります。この行を `devDependencies` セクションに移動してください。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: package.json
   Line: 397

   Comment:
   **`https-proxy-agent` が production `dependencies` に誤って追加されている**

   `https-proxy-agent` はテスト実行時に VS Code バイナリをダウンロードするために `@vscode/test-electron` が内部的に利用するものです。E2E テスト専用の依存関係であるため、`dependencies` ではなく `devDependencies` に置くべきです。

   `dependencies` に含まれると、`vsce package` によるパッケージングや esbuild のバンドリング時に不要な依存が拡張機能に混入するリスクがあります。この行を `devDependencies` セクションに移動してください。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `.github/workflows/test.yml`, line 96-105 ([link](https://github.com/hiroki-org/jules-extension/blob/2cf095af392110ac841afb2cb7699579cdd461ef/.github/workflows/test.yml#L96-L105)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **キャッシュキーに VS Code バージョンが含まれていない**

   現在のキャッシュキーは `${{ runner.os }}-vscode-test` のみです。`JULES_E2E_VSCODE_VERSION` 環境変数や `createSession.e2e.ts` のデフォルト値（`"1.113.0"`）が変更された場合、古い VS Code バイナリが再利用されてテストが正しいバージョンで動作しない可能性があります。

   キャッシュキーに VS Code バージョンを含めることを検討してください:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/test.yml
   Line: 96-105

   Comment:
   **キャッシュキーに VS Code バージョンが含まれていない**

   現在のキャッシュキーは `${{ runner.os }}-vscode-test` のみです。`JULES_E2E_VSCODE_VERSION` 環境変数や `createSession.e2e.ts` のデフォルト値（`"1.113.0"`）が変更された場合、古い VS Code バイナリが再利用されてテストが正しいバージョンで動作しない可能性があります。

   キャッシュキーに VS Code バージョンを含めることを検討してください:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: package.json
Line: 397

Comment:
**`https-proxy-agent` が production `dependencies` に誤って追加されている**

`https-proxy-agent` はテスト実行時に VS Code バイナリをダウンロードするために `@vscode/test-electron` が内部的に利用するものです。E2E テスト専用の依存関係であるため、`dependencies` ではなく `devDependencies` に置くべきです。

`dependencies` に含まれると、`vsce package` によるパッケージングや esbuild のバンドリング時に不要な依存が拡張機能に混入するリスクがあります。この行を `devDependencies` セクションに移動してください。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/test.yml
Line: 96-105

Comment:
**キャッシュキーに VS Code バージョンが含まれていない**

現在のキャッシュキーは `${{ runner.os }}-vscode-test` のみです。`JULES_E2E_VSCODE_VERSION` 環境変数や `createSession.e2e.ts` のデフォルト値（`"1.113.0"`）が変更された場合、古い VS Code バイナリが再利用されてテストが正しいバージョンで動作しない可能性があります。

キャッシュキーに VS Code バージョンを含めることを検討してください:

```suggestion
      - name: Cache VS Code Test Downloads (.vscode-test)
        uses: actions/cache@v5
        with:
          path: |
            ~/.vscode-test
            ~/.vscode
            .vscode-test
          key: ${{ runner.os }}-vscode-test-1.113.0
          restore-keys: |
            ${{ runner.os }}-vscode-test-
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/test/createSession.e2e.ts
Line: 49-53

Comment:
**UI セレクターのバージョン依存性**

`'[aria-label="Open Quick Access"]'` のような aria ラベルは VS Code のバージョン間で変更される可能性があります。同様に、`openCommandPalette` 内の `'input[aria-label="Type the name of a command to run."]'` や `.quick-input-list .monaco-list-row` などの CSS クラスも内部実装に依存しています。

テストが対象とする VS Code バージョン（現在 `"1.113.0"`）との対応をコメントで明示しておくと保守性が向上します。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/test/createSession.e2e.ts
Line: 12-16

Comment:
**`LaunchResult.page` フィールドの設計について**

`LaunchResult` 型に `page: Page` フィールドが定義されており、テスト本体では `launched.page` としてアクセスされています。型定義として問題はありませんが、将来的に `page` を型から除いて戻り値を明示的に分離する設計も検討できます。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add VS Code UI smoke test"](https://github.com/hiroki-org/jules-extension/commit/2cf095af392110ac841afb2cb7699579cdd461ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26790790)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->