### PR TITLE
[codex] document E2E smoke test workflow

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -135,7 +135,7 @@ If tests fail, check:
 Mocha TDD interface doesn't support `.only` easily, but you can:
 ```bash
 # Run specific test file
-pnpm run compile-tests && mocha out/test/securityUtils.unit.test.js
+pnpm run compile-tests && pnpm exec mocha --ui tdd --require source-map-support/register --require out/test/vscodeMock.js out/test/securityUtils.unit.test.js
 ```
 
 ## Security Considerations

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,18 +1,51 @@
-# Testing Guide - Security Utils
+# Testing Guide
 
 ## Quick Reference
 
 ### Running Tests
 ```bash
-# Run only unit tests for security utils
-npm run test:unit
+# Run only unit tests
+pnpm run test:unit
 
-# Run all tests
-npm test
+# Run the VS Code extension test suite
+pnpm test
 
 # Compile tests first
-npm run compile-tests
+pnpm run compile-tests
+
+# Run the Playwright-backed VS Code UI smoke test
+pnpm run test:e2e
 ```
+
+## VS Code UI Smoke Test
+
+### Test File Location
+`src/test/createSession.e2e.ts`
+
+### Coverage
+- Launches a second VS Code instance with `@vscode/test-electron`
+- Opens the command palette and runs `Create Jules Session`
+- Verifies the `No source selected. Please list and select a source first.` toast
+
+### Local Debugging
+The smoke test pins `JULES_E2E_VSCODE_VERSION=1.113.0` by default because it relies on workbench selectors that are validated against a known VS Code build.
+
+If the smoke test starts failing after a VS Code update:
+
+1. Re-run with Playwright debug mode enabled:
+   ```bash
+   PWDEBUG=1 JULES_E2E_VSCODE_VERSION=<candidate> pnpm run test:e2e
+   ```
+2. Re-check the selectors in `src/test/createSession.e2e.ts`, especially:
+   - `[aria-label="Open Quick Access"]`
+   - `input[aria-label="Type the name of a command to run."]`
+   - `.quick-input-list .monaco-list-row`
+3. Prefer stable role, aria-label, or visible-text selectors before falling back to Monaco-specific CSS hooks.
+
+### CI Scope
+The broad cross-platform test matrix already comes from `pnpm test` on Linux, macOS, and Windows. The additional UI smoke test runs only on macOS + Node 20 to keep the second-VS-Code launch deterministic and CI cost bounded.
+
+## Security Utils
 
 ### Test File Location
 `src/test/securityUtils.unit.test.ts`
@@ -102,7 +135,7 @@ If tests fail, check:
 Mocha TDD interface doesn't support `.only` easily, but you can:
 ```bash
 # Run specific test file
-npm run compile-tests && mocha out/test/securityUtils.unit.test.js
+pnpm run compile-tests && mocha out/test/securityUtils.unit.test.js
 ```
 
 ## Security Considerations


### PR DESCRIPTION
## Summary
- document the new `pnpm run test:e2e` smoke test flow in `TESTING_GUIDE.md`
- explain the pinned VS Code version, local `PWDEBUG=1` troubleshooting flow, and the macOS-only CI scope
- align the guide examples with `pnpm` commands used in this repo

## Verification
- docs-only change
- `git diff --check`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは`TESTING_GUIDE.md`にPlaywright E2Eスモークテスト（`pnpm run test:e2e`）のドキュメントを追加し、既存の`npm`コマンドを`pnpm`に統一するドキュメントのみの変更です。

- `npm` → `pnpm` コマンドへの全面的な統一（`package.json`の`packageManager`フィールドと整合）
- 新規セクション「VS Code UI Smoke Test」の追加（テストファイルの場所、カバレッジ内容、ローカルデバッグ方法、CIスコープを網羅）
- タイトルを「Testing Guide - Security Utils」から「Testing Guide」に変更し、ガイドの内容範囲を正確に反映
- ファイル末尾の改行欠落を修正

E2Eテストのバージョンピン（`JULES_E2E_VSCODE_VERSION=1.113.0`）、CIのmacOS限定スコープ、使用するPlaywrightセレクターの説明はいずれも実際の実装（`src/test/createSession.e2e.ts`および`.github/workflows/test.yml`）と一致しています。

ただし、カバレッジ説明の「`@vscode/test-electron` で第2のVS Codeインスタンスを起動する」という記述は若干不正確です。実際は `@vscode/test-electron` はVS Codeのダウンロードのみに使用され、起動とUI操作は `playwright-core` のElectron APIが担っています。
</details>

<h3>Confidence Score: 5/5</h3>

- ドキュメントのみの変更であり、マージは安全です。
- コードの変更はなく、ドキュメントの内容は実装とほぼ整合しています。唯一の指摘（`@vscode/test-electron`の説明）はP2レベルの軽微な不正確さであり、動作に影響しません。
- 特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| TESTING_GUIDE.md | ドキュメントのみの変更。npm → pnpm への統一、E2E スモークテストセクションの追加は概ね正確だが、「`@vscode/test-electron` でVS Codeを起動する」という記述は実装と一致しない（実際の起動はPlaywrightのElectron APIが担う）。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as 開発者 / CI (macOS+Node20)
    participant Mocha as Mocha テストランナー
    participant TVSCE as @vscode/test-electron
    participant PW as playwright-core (Electron)
    participant VSCode as VS Code インスタンス

    Dev->>Mocha: pnpm run test:e2e
    Mocha->>TVSCE: downloadAndUnzipVSCode("1.113.0")
    TVSCE-->>Mocha: executablePath
    Mocha->>PW: electron.launch(executablePath, args)
    PW-->>VSCode: 起動 (--extensionDevelopmentPath 付き)
    VSCode-->>PW: firstWindow()
    PW-->>Mocha: page
    Mocha->>VSCode: Ctrl/Cmd+Shift+P でコマンドパレット開く
    Mocha->>VSCode: "Create Jules Session" を入力・実行
    VSCode-->>Mocha: ".notifications-toasts" にエラートースト表示
    Mocha->>Mocha: トーストのテキストを検証
    Mocha->>PW: app.close()
    PW-->>VSCode: シャットダウン
    Mocha->>Dev: テスト結果を返す
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: TESTING_GUIDE.md
Line: 26

Comment:
**`@vscode/test-electron` の説明が不正確**

ドキュメントでは「`@vscode/test-electron` で第2のVS Codeインスタンスを起動する」と記載されていますが、実際のテストコード（`src/test/createSession.e2e.ts`）を確認すると、`@vscode/test-electron` は VS Code のダウンロード（`downloadAndUnzipVSCode`）のみに使用されており、実際の起動とUI操作は `playwright-core` の Electron API（`_electron.launch()`）が担っています。

```typescript
// createSession.e2e.ts
import { downloadAndUnzipVSCode } from "@vscode/test-electron"; // ダウンロードのみ
import { _electron as electron } from "playwright-core";       // 起動・操作はこちら
```

より正確な記述に修正することをお勧めします：

```suggestion
- `@vscode/test-electron` で VS Code をダウンロードし、Playwright の Electron API で VS Code インスタンスを起動する
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix unit test command example"](https://github.com/hiroki-org/jules-extension/commit/f3e4d4175f96f5b3ef983d08e94690f5eb4e1b3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26845066)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->