### PR TITLE
fix: await extension host activation in E2E smoke test

### DIFF
--- a/src/test/createSession.e2e.ts
+++ b/src/test/createSession.e2e.ts
@@ -43,43 +43,69 @@ async function launchExtensionHost(): Promise<LaunchResult> {
     path.join(os.tmpdir(), "jules-e2e-ext-"),
   );
 
-  const app = await electron.launch({
-    executablePath,
-    args: [
-      workspaceRoot,
-      `--extensionDevelopmentPath=${workspaceRoot}`,
-      `--user-data-dir=${userDataDir}`,
-      `--extensions-dir=${extensionsDir}`,
-      "--disable-extensions",
-      "--disable-gpu",
-      "--disable-workspace-trust",
-      "--no-sandbox",
-      "--skip-release-notes",
-      "--skip-welcome",
-    ],
-    timeout: 60_000,
-  });
+  let app: ElectronApplication | undefined;
+  try {
+    app = await electron.launch({
+      executablePath,
+      args: [
+        workspaceRoot,
+        `--extensionDevelopmentPath=${workspaceRoot}`,
+        `--user-data-dir=${userDataDir}`,
+        `--extensions-dir=${extensionsDir}`,
+        "--disable-extensions",
+        "--disable-gpu",
+        "--disable-workspace-trust",
+        "--no-sandbox",
+        "--skip-release-notes",
+        "--skip-welcome",
+      ],
+      timeout: 60_000,
+    });
 
-  const page = await app.firstWindow();
-  await page.locator('[aria-label="Open Quick Access"]').waitFor({
-    state: "visible",
-    timeout: 30_000,
-  });
+    const page = await app.firstWindow();
+    await page.locator('[aria-label="Open Quick Access"]').waitFor({
+      state: "visible",
+      timeout: 30_000,
+    });
 
-  // Give the extension host time to finish activation so that all commands
-  // are registered before the test interacts with the command palette.
-  // The extension uses implicit activation (activationEvents: null), meaning
-  // VS Code activates it lazily on first command invocation. On slower CI
-  // runners the full activate() lifecycle can take several seconds, so we
-  // wait here to avoid a race where the notification never appears because
-  // the command handler has not yet been registered.
-  await page.waitForTimeout(10_000);
+    // Wait for the extension host to finish activation so that all commands
+    // are registered before the test interacts with the command palette.
+    // The extension uses implicit activation (activationEvents: null), meaning
+    // VS Code activates it lazily on the first contributed-command invocation.
+    // We first try a condition-based wait (Jules status bar item) which is
+    // faster when it works, then fall back to a fixed wait to guard against
+    // VS Code DOM changes across versions.
+    try {
+      await page
+        .locator(".statusbar-item")
+        .filter({ hasText: "Jules:" })
+        .first()
+        .waitFor({ state: "visible", timeout: 30_000 });
+    } catch {
+      // Status bar selector may differ across VS Code versions; fall back to
+      // a fixed delay that is sufficient for extension activation on CI.
+      await page.waitForTimeout(10_000);
+    }
 
-  return {
-    app,
-    page,
-    tempDirs: [userDataDir, extensionsDir],
-  };
+    return {
+      app,
+      page,
+      tempDirs: [userDataDir, extensionsDir],
+    };
+  } catch (err) {
+    // Clean up temp directories and the Electron process if launch fails so
+    // we do not leak resources when the test setup throws.
+    if (app) {
+      try {
+        await app.close();
+      } catch {
+        // ignore shutdown errors during cleanup
+      }
+    }
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(extensionsDir, { recursive: true, force: true });
+    throw err;
+  }
 }
 
 async function openCommandPalette(

--- a/src/test/createSession.e2e.ts
+++ b/src/test/createSession.e2e.ts
@@ -66,9 +66,14 @@ async function launchExtensionHost(): Promise<LaunchResult> {
     timeout: 30_000,
   });
 
-  // Give extension host time to activate so commands are registered before
-  // the test opens the command palette.
-  await page.waitForTimeout(5000);
+  // Give the extension host time to finish activation so that all commands
+  // are registered before the test interacts with the command palette.
+  // The extension uses implicit activation (activationEvents: null), meaning
+  // VS Code activates it lazily on first command invocation. On slower CI
+  // runners the full activate() lifecycle can take several seconds, so we
+  // wait here to avoid a race where the notification never appears because
+  // the command handler has not yet been registered.
+  await page.waitForTimeout(10_000);
 
   return {
     app,
@@ -129,7 +134,10 @@ suite("VS Code UI Smoke Tests", () => {
         .locator(".notifications-toasts")
         .getByText(ERROR_MESSAGE, { exact: true })
         .first();
-      await notification.waitFor({ state: "visible", timeout: 15_000 });
+      // Use a generous timeout: after Enter is pressed VS Code may still need
+      // to finish activating the extension (implicit activation) and then
+      // execute the command handler before the toast appears.
+      await notification.waitFor({ state: "visible", timeout: 60_000 });
     } finally {
       if (app) {
         await closeApp(app);

--- a/src/test/createSession.e2e.ts
+++ b/src/test/createSession.e2e.ts
@@ -2,10 +2,15 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { downloadAndUnzipVSCode } from "@vscode/test-electron";
-import { _electron as electron, ElectronApplication, Page } from "playwright-core";
+import {
+  _electron as electron,
+  ElectronApplication,
+  Page,
+} from "playwright-core";
 
 const COMMAND_LABEL = "Create Jules Session";
-const ERROR_MESSAGE = "No source selected. Please list and select a source first.";
+const ERROR_MESSAGE =
+  "No source selected. Please list and select a source first.";
 // Keep the default VS Code build pinned because this smoke test reaches into
 // workbench selectors such as `[aria-label="Open Quick Access"]`,
 // `input[aria-label="Type the name of a command to run."]`, and
@@ -34,7 +39,9 @@ async function launchExtensionHost(): Promise<LaunchResult> {
   const workspaceRoot = getWorkspaceRoot();
   const executablePath = await downloadAndUnzipVSCode(VSCODE_VERSION);
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "jules-e2e-user-"));
-  const extensionsDir = fs.mkdtempSync(path.join(os.tmpdir(), "jules-e2e-ext-"));
+  const extensionsDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "jules-e2e-ext-"),
+  );
 
   const app = await electron.launch({
     executablePath,
@@ -59,6 +66,10 @@ async function launchExtensionHost(): Promise<LaunchResult> {
     timeout: 30_000,
   });
 
+  // Give extension host time to activate so commands are registered before
+  // the test opens the command palette.
+  await page.waitForTimeout(5000);
+
   return {
     app,
     page,
@@ -66,7 +77,10 @@ async function launchExtensionHost(): Promise<LaunchResult> {
   };
 }
 
-async function openCommandPalette(page: Page, commandLabel: string): Promise<void> {
+async function openCommandPalette(
+  page: Page,
+  commandLabel: string,
+): Promise<void> {
   await page.keyboard.press(getCommandPaletteShortcut());
 
   const quickInput = page.locator(

--- a/src/test/createSession.e2e.ts
+++ b/src/test/createSession.e2e.ts
@@ -144,7 +144,11 @@ function cleanupTempDirs(tempDirs: string[]): void {
 
 suite("VS Code UI Smoke Tests", () => {
   test("Create Jules Session shows an error toast when no source is selected", async function () {
-    this.timeout(180_000);
+    // Budget: launch(60s) + workbench(30s) + statusbar/fallback(30s)
+    //       + palette ops(30s) + notification(60s) = 210s worst-case.
+    // Add 90 s headroom to avoid mocha killing the test before all
+    // sub-timeouts expire.
+    this.timeout(300_000);
 
     let app: ElectronApplication | undefined;
     let tempDirs: string[] = [];


### PR DESCRIPTION
## 問題

mainブランチのCIが落ちていた。

**失敗したジョブ**: `test / integration (macos-latest, 20)` → `Run E2E smoke test (macOS)`

**エラー内容**:
```
1) VS Code UI Smoke Tests
     Create Jules Session shows an error toast when no source is selected:
   locator.waitFor: Timeout 15000ms exceeded.
   - waiting for locator('.notifications-toasts').getByText('No source selected. ...', { exact: true }).first() to be visible
```

## 根本原因

`createSession.e2e.ts` の `launchExtensionHost()` で VS Code ウィンドウが表示された直後にコマンドパレットを開いていた。しかし拡張機能の activate はウィンドウ表示より遅れるため、`jules-extension.createSession` コマンドがまだ登録されていない状態でテストが実行され、エラートーストが表示されなかった。

## 修正

VS Code のワークベンチが ready になった後、5秒待機して拡張機能 host が activate を完了しコマンドを登録するのを待つようにした。

この修正は `origin/jules-6953044026138046400-cfa976c4` に既にあったが未マージだったもの。

## 検証

- `pnpm run check-types` ✅
- `pnpm run lint` ✅  
- `pnpm run test:unit` ✅ (378 passing)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

VS Code の workbench が ready になった直後に拡張機能のコマンドがまだ登録されていないというレースコンディションに起因する CI 失敗を修正する PR です。`launchExtensionHost()` に `waitForTimeout(5000)` を追加して拡張機能ホストのアクティベーション完了を待つようにしています。その他の変更は長い行の折り返しのみのフォーマット修正です。

固定スリープは低速な CI 環境で依然としてフラキネスが残るリスクがありますが、現実的な暫定対処として許容範囲です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージ可能。唯一の懸念点はハードコードされたスリープによるフラキネスリスクですが P2 レベルであり、ブロッキングな問題はありません。

変更は 1 ファイルのみで、CI 失敗の根本原因（レースコンディション）を実用的な方法で修正しています。残る P2 指摘（固定スリープのフラキネスリスク）は本質的な問題ではなく、マージをブロックする理由にはなりません。

src/test/createSession.e2e.ts の waitForTimeout(5000) — フラキネスが再発した場合はポーリングベースのアプローチへの置き換えを検討してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/createSession.e2e.ts | 拡張機能ホストのアクティベーション待機として固定 5 秒スリープを追加。他の変更は長い行の折り返しのみのフォーマット修正。ハードコードされたスリープは潜在的なフラキネスリスクあり（P2）。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as E2E テスト
    participant Electron as Electron (VS Code)
    participant ExtHost as 拡張機能ホスト

    Test->>Electron: electron.launch()
    Electron-->>Test: app
    Test->>Electron: app.firstWindow()
    Electron-->>Test: page
    Test->>Electron: waitFor('[aria-label="Open Quick Access"]', visible, 30s)
    Note over Electron: Workbench ready
    Electron-->>Test: OK
    Note over Test: ★ 追加: waitForTimeout(5000ms)
    ExtHost-->>Electron: activate() 完了・コマンド登録
    Test->>Electron: openCommandPalette("Create Jules Session")
    Electron-->>Test: コマンドが見つかり実行される
    Electron-->>Test: エラートースト表示
    Test->>Electron: notification.waitFor(visible, 15s)
    Electron-->>Test: ✅ テスト成功
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/test/createSession.e2e.ts
Line: 71

Comment:
**ハードコードされたスリープによる潜在的なフラキネス**

固定 5 秒待機は、低速な CI 環境（ネットワーク遅延・リソース競合）で拡張機能のアクティベーションがそれ以上かかる場合に依然としてテストが失敗するリスクがあります。より堅牢にするなら、コマンドパレットで `jules-extension.createSession` が選択肢として現れるまでポーリングする方法が考えられます。

```typescript
// 例: コマンドが登録されるまでリトライ
async function waitForCommandRegistered(page: Page, label: string, timeout = 30_000): Promise<void> {
  const deadline = Date.now() + timeout;
  while (Date.now() < deadline) {
    await page.keyboard.press(getCommandPaletteShortcut());
    const quickInput = page.locator('input[aria-label="Type the name of a command to run."]');
    await quickInput.waitFor({ state: "visible", timeout: 5_000 }).catch(() => null);
    await quickInput.fill(`>${label}`);
    const found = await page.locator(".quick-input-list .monaco-list-row")
      .filter({ hasText: label }).first().isVisible().catch(() => false);
    if (found) {
      await page.keyboard.press("Escape");
      return;
    }
    await page.keyboard.press("Escape");
    await page.waitForTimeout(500);
  }
  throw new Error(`Command "${label}" not registered within ${timeout}ms`);
}
```

ただし現状の 5 秒待機でも多くのケースで動作するため、まずはこの PR でマージして観察し、引き続きフラキネスが発生するようであれば上記のようなアプローチへ移行することも選択肢です。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: await extension host activation in ..."](https://github.com/hiroki-org/jules-extension/commit/4f15a1a16e7176e01307368b7d0bd26e61b8be4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28581752)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->