### PR TITLE
fix: address open review comments from PR #473 and #474

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ gha-creds-*.json
 # Copilot/AI agent state and temporary artifacts
 .copilot-state/
 patch_*.diff
+*_patch.sed
 pr[0-9]*_state.json
 pr[0-9]*_cycle_state.json
 pr[0-9]*_checks.json

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,15 @@ UNIT_TEST_SUMMARY.txt
 
 .gemini/
 gha-creds-*.json
+
+# Copilot/AI agent state and temporary artifacts
+.copilot-state/
+patch_*.diff
+pr[0-9]*_state.json
+pr[0-9]*_cycle_state.json
+pr[0-9]*_checks.json
+pr[0-9]*_comments.json
+pr[0-9]*_reviews.json
+pr[0-9]*_threads.json
+pr[0-9]*_view.json
+pr_status.json

--- a/githubAuth_patch.sed
+++ b/githubAuth_patch.sed
@@ -1,5 +1,0 @@
-s/(\.then((session) => {)/\1\
-            if (requestVersion !== GitHubAuth.sessionRequestVersion) {\
-                return undefined;\
-            }\
-/

--- a/githubAuth_patch.sed
+++ b/githubAuth_patch.sed
@@ -1,0 +1,5 @@
+s/(\.then((session) => {)/\1\
+            if (requestVersion !== GitHubAuth.sessionRequestVersion) {\
+                return undefined;\
+            }\
+/

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,12 +88,14 @@ const SESSION_STATE = {
 };
 
 // GitHub PR status cache to avoid excessive API calls
+interface PRStatusCacheEntry {
+  isClosed: boolean;
+  lastChecked: number;
+  isError?: boolean;
+}
+
 interface PRStatusCache {
-  [prUrl: string]: {
-    isClosed: boolean;
-    lastChecked: number;
-    isError?: boolean;
-  };
+  [prUrl: string]: PRStatusCacheEntry;
 }
 
 let prStatusCache: PRStatusCache = {};
@@ -589,27 +591,16 @@ export function extractPRs(
   return Array.from(prMap.values());
 }
 
-function getPRStatusFromCache(prUrl: string): boolean | undefined {
-  const cached = prStatusCache[prUrl];
-  const now = Date.now();
-  const ttl = cached?.isError ? PR_ERROR_CACHE_DURATION : PR_CACHE_DURATION;
-  if (cached && now - cached.lastChecked < ttl) {
-    return cached.isClosed;
-  }
-  return undefined;
-}
-
-async function checkPRStatus(
+export async function checkPRStatus(
   prUrl: string,
   token: string | undefined,
 ): Promise<boolean> {
   // Check cache first
-  const cachedStatus = getPRStatusFromCache(prUrl);
-  if (cachedStatus !== undefined) {
-    return cachedStatus;
-  }
-
+  const cached = prStatusCache[prUrl];
   const now = Date.now();
+  if (isPRCacheEntryFresh(cached, now)) {
+    return cached.isClosed;
+  }
 
   try {
     // Parse GitHub PR URL: https://github.com/owner/repo/pull/123
@@ -667,6 +658,18 @@ async function checkPRStatus(
     prStatusCache[prUrl] = { isClosed: false, lastChecked: now, isError: true };
     return false;
   }
+}
+
+function isPRCacheEntryFresh(
+  cached: PRStatusCacheEntry | undefined,
+  now: number,
+): cached is PRStatusCacheEntry {
+  if (!cached) {
+    return false;
+  }
+
+  const ttl = cached.isError ? PR_ERROR_CACHE_DURATION : PR_CACHE_DURATION;
+  return now - cached.lastChecked < ttl;
 }
 
 async function notifyPRCreated(
@@ -943,12 +946,13 @@ export async function updatePreviousStates(
   if (sessionsToCheck.length > 0) {
     const prStatusLookup = new Map<string, boolean>();
     const urlsToFetch: string[] = [];
+    const now = Date.now();
 
     // Identification of PRs that actually need to be fetched (missing or expired in cache)
     for (const url of uniquePRUrls) {
-      const cachedStatus = getPRStatusFromCache(url);
-      if (cachedStatus !== undefined) {
-        prStatusLookup.set(url, cachedStatus);
+      const cached = prStatusCache[url];
+      if (isPRCacheEntryFresh(cached, now)) {
+        prStatusLookup.set(url, cached.isClosed);
       } else {
         urlsToFetch.push(url);
       }
@@ -3828,4 +3832,5 @@ export function activate(context: vscode.ExtensionContext) {
 // This method is called when your extension is deactivated
 export function deactivate() {
   stopAutoRefresh();
+  GitHubAuth.dispose();
 }

--- a/src/githubAuth.ts
+++ b/src/githubAuth.ts
@@ -6,8 +6,46 @@ export class GitHubAuth {
     private static cachedSession: vscode.AuthenticationSession | undefined = undefined;
     private static sessionExpiry: number = 0;
     private static readonly CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+    private static pendingSessionPromise: Promise<vscode.AuthenticationSession | undefined> | undefined = undefined;
+    private static authChangeListenerDisposable: vscode.Disposable | undefined = undefined;
+    private static sessionRequestVersion = 0;
+
+    private static ensureAuthSessionListener(): void {
+        if (GitHubAuth.authChangeListenerDisposable) {
+            return;
+        }
+
+        const disposable = (vscode.authentication as any).onDidChangeSessions?.call(
+            vscode.authentication,
+            (event: unknown) => {
+                const providerId = (event as { provider?: { id?: string } }).provider?.id;
+                if (providerId && providerId !== 'github') {
+                    return;
+                }
+                GitHubAuth.clearCache();
+            }
+        );
+        if (disposable) {
+            GitHubAuth.authChangeListenerDisposable = disposable;
+        }
+    }
+
+    private static cacheSession(
+        session: vscode.AuthenticationSession,
+        requestVersion: number
+    ): void {
+        if (requestVersion !== GitHubAuth.sessionRequestVersion) {
+            return;
+        }
+        GitHubAuth.cachedSession = session;
+        GitHubAuth.sessionExpiry = Date.now() + GitHubAuth.CACHE_TTL;
+    }
 
     static async signIn(): Promise<string | undefined> {
+        GitHubAuth.ensureAuthSessionListener();
+        GitHubAuth.clearCache();
+        const requestVersion = GitHubAuth.sessionRequestVersion;
+
         try {
             const session = await vscode.authentication.getSession(
                 'github',
@@ -16,38 +54,60 @@ export class GitHubAuth {
             );
 
             if (session) {
-                GitHubAuth.cachedSession = session;
-                GitHubAuth.sessionExpiry = Date.now() + GitHubAuth.CACHE_TTL;
+                GitHubAuth.cacheSession(session, requestVersion);
+            } else {
+                GitHubAuth.clearCache();
             }
 
             return session?.accessToken;
         } catch (error) {
+            GitHubAuth.clearCache();
             vscode.window.showErrorMessage('Failed to sign in to GitHub');
             return undefined;
         }
     }
 
     static async getSession(): Promise<vscode.AuthenticationSession | undefined> {
+        GitHubAuth.ensureAuthSessionListener();
+
         const now = Date.now();
         if (GitHubAuth.cachedSession && now < GitHubAuth.sessionExpiry) {
             return GitHubAuth.cachedSession;
         }
 
-        try {
-            const session = await vscode.authentication.getSession(
-                'github',
-                GitHubAuth.SCOPES,
-                { createIfNone: false }
-            );
+        if (GitHubAuth.pendingSessionPromise) {
+            return GitHubAuth.pendingSessionPromise;
+        }
 
+        const requestVersion = GitHubAuth.sessionRequestVersion;
+        const promise = (GitHubAuth.pendingSessionPromise = Promise.resolve(vscode.authentication.getSession(
+            'github',
+            GitHubAuth.SCOPES,
+            { createIfNone: false }
+        )).then((session) => {
+            if (requestVersion !== GitHubAuth.sessionRequestVersion) {
+                return undefined;
+            }
             if (session) {
-                GitHubAuth.cachedSession = session;
-                GitHubAuth.sessionExpiry = now + GitHubAuth.CACHE_TTL;
+                GitHubAuth.cacheSession(session, requestVersion);
             } else {
                 GitHubAuth.clearCache();
             }
 
             return session;
+        }).catch((error) => { 
+            if (requestVersion === GitHubAuth.sessionRequestVersion) {
+                GitHubAuth.clearCache();
+            }
+            return undefined;
+        }).finally(() => {
+            if (GitHubAuth.pendingSessionPromise === promise) {
+                GitHubAuth.pendingSessionPromise = undefined;
+            }
+        }));
+
+        try {
+            return await promise;
         } catch (error) {
             GitHubAuth.clearCache();
             return undefined;
@@ -77,7 +137,17 @@ export class GitHubAuth {
     }
 
     static clearCache(): void {
+        GitHubAuth.sessionRequestVersion += 1;
         GitHubAuth.cachedSession = undefined;
         GitHubAuth.sessionExpiry = 0;
+        GitHubAuth.pendingSessionPromise = undefined;
+    }
+
+    static dispose(): void {
+        if (GitHubAuth.authChangeListenerDisposable) {
+            GitHubAuth.authChangeListenerDisposable.dispose();
+            GitHubAuth.authChangeListenerDisposable = undefined;
+        }
+        GitHubAuth.clearCache();
     }
 }

--- a/src/githubAuth.ts
+++ b/src/githubAuth.ts
@@ -10,6 +10,14 @@ export class GitHubAuth {
     private static authChangeListenerDisposable: vscode.Disposable | undefined = undefined;
     private static sessionRequestVersion = 0;
 
+    public static handleAuthChange(event: unknown): void {
+        const providerId = (event as { provider?: { id?: string } }).provider?.id;
+        if (providerId && providerId !== 'github') {
+            return;
+        }
+        GitHubAuth.clearCache();
+    }
+
     private static ensureAuthSessionListener(): void {
         if (GitHubAuth.authChangeListenerDisposable) {
             return;
@@ -17,13 +25,7 @@ export class GitHubAuth {
 
         const disposable = (vscode.authentication as any).onDidChangeSessions?.call(
             vscode.authentication,
-            (event: unknown) => {
-                const providerId = (event as { provider?: { id?: string } }).provider?.id;
-                if (providerId && providerId !== 'github') {
-                    return;
-                }
-                GitHubAuth.clearCache();
-            }
+            GitHubAuth.handleAuthChange
         );
         if (disposable) {
             GitHubAuth.authChangeListenerDisposable = disposable;

--- a/src/githubAuth.ts
+++ b/src/githubAuth.ts
@@ -12,7 +12,7 @@ export class GitHubAuth {
 
     public static handleAuthChange(event: unknown): void {
         const providerId = (event as { provider?: { id?: string } }).provider?.id;
-        if (providerId && providerId !== 'github') {
+        if (providerId !== 'github') {
             return;
         }
         GitHubAuth.clearCache();
@@ -108,12 +108,7 @@ export class GitHubAuth {
             }
         }));
 
-        try {
-            return await promise;
-        } catch (error) {
-            GitHubAuth.clearCache();
-            return undefined;
-        }
+        return await promise;
     }
 
     static async getToken(): Promise<string | undefined> {

--- a/src/test/extensionHelpers.unit.test.ts
+++ b/src/test/extensionHelpers.unit.test.ts
@@ -440,7 +440,7 @@ suite("Extension helper unit tests", () => {
     });
 
     test("re-fetches error cached entries after PR_ERROR_CACHE_DURATION", async () => {
-      let clock = sandbox.useFakeTimers(Date.now());
+      const clock = sandbox.useFakeTimers(Date.now());
       
       const tokenStub = sandbox.stub(GitHubAuth, "getToken").resolves("token");
       const fetchStub = sandbox.stub(fetchUtils, "fetchWithTimeout");
@@ -493,8 +493,6 @@ suite("Extension helper unit tests", () => {
         .at(-1);
       const savedStates = stateUpdate?.args[1] as Record<string, { isTerminated?: boolean }>;
       assert.strictEqual(savedStates["sessions/error-cache"].isTerminated, true);
-      
-      clock.restore();
     });
 
     test("does not terminate COMPLETED session with no PRs", async () => {

--- a/src/test/extensionHelpers.unit.test.ts
+++ b/src/test/extensionHelpers.unit.test.ts
@@ -19,6 +19,7 @@ import {
   mergeActivitiesByIdentity,
   resetUpdatePreviousStatesCachesForTests,
   updatePreviousStates,
+  checkPRStatus,
 } from "../extension";
 import { updateSessionArtifactsCache } from "../sessionArtifacts";
 import * as fetchUtils from "../fetchUtils";
@@ -205,6 +206,82 @@ suite("Extension helper unit tests", () => {
     });
   });
 
+  suite("checkPRStatus", () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+      sandbox = sinon.createSandbox();
+      resetUpdatePreviousStatesCachesForTests();
+    });
+
+    teardown(() => {
+      sandbox.restore();
+      resetUpdatePreviousStatesCachesForTests();
+    });
+
+    test("should use token if provided and check github status without token if undefined", async () => {
+      const fetchStub = sandbox.stub(fetchUtils, "fetchWithTimeout").resolves({
+        ok: true,
+        json: async () => ({ state: "closed" }),
+      } as any);
+
+      // With token
+      const isClosedToken = await checkPRStatus("https://github.com/org/repo/pull/123", "dummy-token");
+      assert.strictEqual(isClosedToken, true);
+      assert.strictEqual(fetchStub.callCount, 1);
+      const headersToken = fetchStub.firstCall.args[1]?.headers as Record<string, string>;
+      assert.strictEqual(headersToken?.Authorization, "Bearer dummy-token");
+
+      resetUpdatePreviousStatesCachesForTests();
+
+      // Without token
+      const isClosedNoToken = await checkPRStatus("https://github.com/org/repo/pull/124", undefined);
+      assert.strictEqual(isClosedNoToken, true);
+      assert.strictEqual(fetchStub.callCount, 2);
+      const headersNoToken = fetchStub.secondCall.args[1]?.headers as Record<string, string>;
+      assert.strictEqual(headersNoToken?.Authorization, undefined);
+    });
+
+    test("should handle 4xx/5xx API errors properly and cache as error", async () => {
+      const fetchStub = sandbox.stub(fetchUtils, "fetchWithTimeout").resolves({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      } as any);
+
+      const isClosed = await checkPRStatus("https://github.com/org/repo/pull/999", undefined);
+      assert.strictEqual(isClosed, false);
+      
+      // The second call should use cache and not fetch again immediately
+      const isClosedCached = await checkPRStatus("https://github.com/org/repo/pull/999", undefined);
+      assert.strictEqual(isClosedCached, false);
+      assert.strictEqual(fetchStub.callCount, 1); // Not incremented, served from error cache
+    });
+
+    test("should return false for invalid GitHub PR URLs without fetching", async () => {
+      const fetchStub = sandbox.stub(fetchUtils, "fetchWithTimeout");
+
+      const isClosed = await checkPRStatus("not-a-github-pr-url", undefined);
+
+      assert.strictEqual(isClosed, false);
+      assert.strictEqual(fetchStub.called, false);
+
+      const cachedResult = await checkPRStatus("not-a-github-pr-url", undefined);
+      assert.strictEqual(cachedResult, false);
+      assert.strictEqual(fetchStub.called, false);
+    });
+
+    test("should handle fetch exceptions and cache as error", async () => {
+      const fetchStub = sandbox.stub(fetchUtils, "fetchWithTimeout").rejects(new Error("Network failure"));
+      const isClosed = await checkPRStatus("https://github.com/org/repo/pull/888", undefined);
+      assert.strictEqual(isClosed, false);
+      assert.strictEqual(fetchStub.callCount, 1);
+      const isClosedCached = await checkPRStatus("https://github.com/org/repo/pull/888", undefined);
+      assert.strictEqual(isClosedCached, false);
+      assert.strictEqual(fetchStub.callCount, 1);
+    });
+  });
+
   suite("updatePreviousStates", () => {
     let sandbox: sinon.SinonSandbox;
 
@@ -257,7 +334,8 @@ suite("Extension helper unit tests", () => {
       assert.strictEqual(fetchStub.callCount, 1);
       const stateUpdate = updateStub
         .getCalls()
-        .find((call) => call.args[0] === "jules.previousSessionStates");
+        .filter((call) => call.args[0] === "jules.previousSessionStates")
+        .at(-1);
       assert.ok(stateUpdate);
       const savedStates = stateUpdate?.args[1] as Record<
         string,
@@ -312,7 +390,8 @@ suite("Extension helper unit tests", () => {
       assert.strictEqual(fetchStub.callCount, 2);
       const stateUpdate = updateStub
         .getCalls()
-        .find((call) => call.args[0] === "jules.previousSessionStates");
+        .filter((call) => call.args[0] === "jules.previousSessionStates")
+        .at(-1);
       assert.ok(stateUpdate);
       const savedStates = stateUpdate?.args[1] as Record<
         string,
@@ -320,6 +399,132 @@ suite("Extension helper unit tests", () => {
       >;
       assert.strictEqual(savedStates["sessions/pr-status-closed-1"].isTerminated, true);
       assert.strictEqual(savedStates["sessions/pr-status-closed-2"].isTerminated, true);
+    });
+
+    test("skips token fetch when all PRs are freshly cached", async () => {
+      const tokenStub = sandbox.stub(GitHubAuth, "getToken").resolves("token");
+      const fetchStub = sandbox.stub(fetchUtils, "fetchWithTimeout").resolves({
+        ok: true,
+        json: async () => ({ state: "open" }),
+      } as any);
+      const updateStub = sandbox.stub().resolves();
+
+      const mockContext = {
+        globalState: {
+          get: sandbox.stub().returns(undefined),
+          update: updateStub,
+        },
+      } as unknown as vscode.ExtensionContext;
+
+      const sessions: Session[] = [
+        {
+          name: "sessions/fresh-cache",
+          state: "COMPLETED",
+          rawState: "COMPLETED",
+          outputs: [{ pullRequest: { url: "https://github.com/org/repo/pull/111" } } as any],
+        } as Session,
+      ];
+
+      // First call to populate cache
+      await updatePreviousStates(sessions, mockContext);
+      assert.strictEqual(tokenStub.callCount, 1);
+      assert.strictEqual(fetchStub.callCount, 1);
+
+      // Second call should hit cache and NOT fetch token or PR
+      tokenStub.resetHistory();
+      fetchStub.resetHistory();
+      await updatePreviousStates(sessions, mockContext);
+      
+      assert.strictEqual(tokenStub.callCount, 0, "getToken should not be called when cache is fresh");
+      assert.strictEqual(fetchStub.callCount, 0, "fetchWithTimeout should not be called when cache is fresh");
+    });
+
+    test("re-fetches error cached entries after PR_ERROR_CACHE_DURATION", async () => {
+      let clock = sandbox.useFakeTimers(Date.now());
+      
+      const tokenStub = sandbox.stub(GitHubAuth, "getToken").resolves("token");
+      const fetchStub = sandbox.stub(fetchUtils, "fetchWithTimeout");
+      
+      // First fetch returns an error
+      fetchStub.onFirstCall().resolves({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      } as any);
+      
+      const updateStub = sandbox.stub().resolves();
+      const mockContext = {
+        globalState: {
+          get: sandbox.stub().returns(undefined),
+          update: updateStub,
+        },
+      } as unknown as vscode.ExtensionContext;
+
+      const sessions: Session[] = [
+        {
+          name: "sessions/error-cache",
+          state: "COMPLETED",
+          rawState: "COMPLETED",
+          outputs: [{ pullRequest: { url: "https://github.com/org/repo/pull/222" } } as any],
+        } as Session,
+      ];
+
+      await updatePreviousStates(sessions, mockContext);
+      assert.strictEqual(fetchStub.callCount, 1);
+      
+      // Fast forward 31 seconds (past PR_ERROR_CACHE_DURATION of 30s)
+      clock.tick(31000);
+      
+      // Second fetch should succeed
+      fetchStub.onSecondCall().resolves({
+        ok: true,
+        json: async () => ({ state: "closed" }),
+      } as any);
+      
+      tokenStub.resetHistory();
+      await updatePreviousStates(sessions, mockContext);
+      
+      assert.strictEqual(tokenStub.callCount, 1, "getToken should be called after error cache expires");
+      assert.strictEqual(fetchStub.callCount, 2, "fetchWithTimeout should be called after error cache expires");
+      
+      const stateUpdate = updateStub
+        .getCalls()
+        .filter((call) => call.args[0] === "jules.previousSessionStates")
+        .at(-1);
+      const savedStates = stateUpdate?.args[1] as Record<string, { isTerminated?: boolean }>;
+      assert.strictEqual(savedStates["sessions/error-cache"].isTerminated, true);
+      
+      clock.restore();
+    });
+
+    test("does not terminate COMPLETED session with no PRs", async () => {
+      const updateStub = sandbox.stub().resolves();
+      const mockContext = {
+        globalState: {
+          get: sandbox.stub().returns(undefined),
+          update: updateStub,
+        },
+      } as unknown as vscode.ExtensionContext;
+
+      const sessions: Session[] = [
+        {
+          name: "sessions/no-pr",
+          title: "no-pr",
+          state: "COMPLETED",
+          rawState: "COMPLETED",
+          outputs: [], // No PRs
+        } as Session,
+      ];
+
+      await updatePreviousStates(sessions, mockContext);
+
+      const stateUpdate = updateStub
+        .getCalls()
+        .filter((call) => call.args[0] === "jules.previousSessionStates")
+        .at(-1);
+      assert.ok(stateUpdate);
+      const savedStates = stateUpdate?.args[1] as Record<string, { isTerminated?: boolean }>;
+      assert.strictEqual(savedStates["sessions/no-pr"].isTerminated, false);
     });
   });
 

--- a/src/test/githubAuth.test.ts
+++ b/src/test/githubAuth.test.ts
@@ -130,12 +130,8 @@ suite('GitHubAuth Test Suite', () => {
             const first = await GitHubAuth.getSession();
             assert.strictEqual(first?.accessToken, 'fake-token');
             assert.strictEqual(getSessionStub.calledOnce, true);
-            assert.strictEqual(onDidChangeSessionsStub.calledOnce, true);
 
-            const authChangeListener = onDidChangeSessionsStub.firstCall?.args[0] as
-                | ((event: unknown) => void)
-                | undefined;
-            authChangeListener?.({ provider: { id: 'github' } });
+            GitHubAuth.handleAuthChange({ provider: { id: 'github' } });
 
             const second = await GitHubAuth.getSession();
             assert.strictEqual(second?.accessToken, 'new-token');

--- a/src/test/githubAuth.test.ts
+++ b/src/test/githubAuth.test.ts
@@ -7,6 +7,25 @@ suite('GitHubAuth Test Suite', () => {
     let sandbox: sinon.SinonSandbox;
     let getSessionStub: sinon.SinonStub;
     let showErrorMessageStub: sinon.SinonStub;
+    let onDidChangeSessionsStub: sinon.SinonStub;
+    let onDidChangeSessionsListener: ((event: unknown) => void) | undefined;
+
+    const resetGitHubAuthState = () => {
+        const authState = GitHubAuth as unknown as {
+            authChangeListenerDisposable?: { dispose?: () => void };
+            cachedSession?: vscode.AuthenticationSession;
+            sessionExpiry?: number;
+            pendingSessionPromise?: Promise<vscode.AuthenticationSession | undefined>;
+            sessionRequestVersion?: number;
+        };
+
+        authState.authChangeListenerDisposable?.dispose?.();
+        authState.authChangeListenerDisposable = undefined;
+        authState.cachedSession = undefined;
+        authState.sessionExpiry = 0;
+        authState.pendingSessionPromise = undefined;
+        authState.sessionRequestVersion = 0;
+    };
 
     const FAKE_SESSION = {
         accessToken: 'fake-token',
@@ -16,13 +35,25 @@ suite('GitHubAuth Test Suite', () => {
     };
 
     setup(() => {
+        resetGitHubAuthState();
         sandbox = sinon.createSandbox();
+        onDidChangeSessionsListener = undefined;
         getSessionStub = sandbox.stub(vscode.authentication, 'getSession');
+        onDidChangeSessionsStub = sandbox.stub(
+            (vscode.authentication as unknown as { onDidChangeSessions: (listener: (event: unknown) => void) => vscode.Disposable }),
+            'onDidChangeSessions'
+        );
+        onDidChangeSessionsStub.callsFake((listener: (event: unknown) => void) => {
+            onDidChangeSessionsListener = listener;
+            return { dispose: () => undefined };
+        });
         GitHubAuth.clearCache();
         showErrorMessageStub = sandbox.stub(vscode.window, 'showErrorMessage');
     });
 
     teardown(() => {
+        resetGitHubAuthState();
+        onDidChangeSessionsListener = undefined;
         sandbox.restore();
     });
 
@@ -68,6 +99,48 @@ suite('GitHubAuth Test Suite', () => {
             const session = await GitHubAuth.getSession();
 
             assert.strictEqual(session, undefined);
+        });
+
+        test('should dedupe concurrent session fetches', async () => {
+            let resolveSession: ((value: typeof FAKE_SESSION | undefined) => void) | undefined;
+            const pendingSession = new Promise<typeof FAKE_SESSION | undefined>((resolve) => {
+                resolveSession = resolve;
+            });
+            getSessionStub.onFirstCall().returns(pendingSession);
+
+            const p1 = GitHubAuth.getToken();
+            const p2 = GitHubAuth.getToken();
+
+            assert.strictEqual(getSessionStub.calledOnce, true);
+            resolveSession?.(FAKE_SESSION);
+
+            const [token1, token2] = await Promise.all([p1, p2]);
+            assert.strictEqual(token1, 'fake-token');
+            assert.strictEqual(token2, 'fake-token');
+        });
+
+        test('should clear cache when GitHub sessions change', async () => {
+            const refreshedSession = {
+                ...FAKE_SESSION,
+                accessToken: 'new-token',
+                id: 's2'
+            };
+            getSessionStub.onFirstCall().resolves(FAKE_SESSION);
+            getSessionStub.onSecondCall().resolves(refreshedSession);
+
+            const first = await GitHubAuth.getSession();
+            assert.strictEqual(first?.accessToken, 'fake-token');
+            assert.strictEqual(getSessionStub.calledOnce, true);
+            assert.strictEqual(onDidChangeSessionsStub.calledOnce, true);
+
+            const authChangeListener = onDidChangeSessionsStub.firstCall?.args[0] as
+                | ((event: unknown) => void)
+                | undefined;
+            authChangeListener?.({ provider: { id: 'github' } });
+
+            const second = await GitHubAuth.getSession();
+            assert.strictEqual(second?.accessToken, 'new-token');
+            assert.strictEqual(getSessionStub.calledTwice, true);
         });
     });
 

--- a/src/test/githubAuth.test.ts
+++ b/src/test/githubAuth.test.ts
@@ -35,7 +35,7 @@ suite('GitHubAuth Test Suite', () => {
     };
 
     setup(() => {
-        resetGitHubAuthState();
+        GitHubAuth.dispose();
         sandbox = sinon.createSandbox();
         onDidChangeSessionsListener = undefined;
         getSessionStub = sandbox.stub(vscode.authentication, 'getSession');
@@ -47,12 +47,11 @@ suite('GitHubAuth Test Suite', () => {
             onDidChangeSessionsListener = listener;
             return { dispose: () => undefined };
         });
-        GitHubAuth.clearCache();
         showErrorMessageStub = sandbox.stub(vscode.window, 'showErrorMessage');
     });
 
     teardown(() => {
-        resetGitHubAuthState();
+        GitHubAuth.dispose();
         onDidChangeSessionsListener = undefined;
         sandbox.restore();
     });

--- a/src/test/githubAuth.unit.test.ts
+++ b/src/test/githubAuth.unit.test.ts
@@ -196,7 +196,7 @@ suite("GitHubAuth Unit Test Suite", () => {
     assert.strictEqual(getSessionStub.calledTwice, true);
   });
 
-  test("getSession should ignore auth change events for other providers", async () => {
+  test("getSession should ignore auth change events for other providers or missing providers", async () => {
     getSessionStub.resolves(fakeSession);
 
     const session = await GitHubAuth.getSession();
@@ -204,7 +204,13 @@ suite("GitHubAuth Unit Test Suite", () => {
 
     GitHubAuth.handleAuthChange({ provider: { id: "azure" } });
 
-    const cachedSession = await GitHubAuth.getSession();
+    let cachedSession = await GitHubAuth.getSession();
+    assert.strictEqual(cachedSession, fakeSession);
+    assert.strictEqual(getSessionStub.calledOnce, true);
+
+    GitHubAuth.handleAuthChange({});
+
+    cachedSession = await GitHubAuth.getSession();
     assert.strictEqual(cachedSession, fakeSession);
     assert.strictEqual(getSessionStub.calledOnce, true);
     assert.strictEqual(listenerDisposeSpy?.calledOnce ?? false, false);

--- a/src/test/githubAuth.unit.test.ts
+++ b/src/test/githubAuth.unit.test.ts
@@ -35,7 +35,7 @@ suite("GitHubAuth Unit Test Suite", () => {
   };
 
   setup(() => {
-    resetGitHubAuthState();
+    GitHubAuth.dispose();
     sandbox = sinon.createSandbox();
     onDidChangeSessionsListener = undefined;
     getSessionStub = sandbox.stub((vscode as any).authentication, "getSession");
@@ -48,12 +48,11 @@ suite("GitHubAuth Unit Test Suite", () => {
       listenerDisposeSpy = sandbox.spy();
       return { dispose: listenerDisposeSpy };
     });
-    GitHubAuth.clearCache();
     sandbox.stub(vscode.window, "showErrorMessage");
   });
 
   teardown(() => {
-    resetGitHubAuthState();
+    GitHubAuth.dispose();
     onDidChangeSessionsListener = undefined;
     sandbox.restore();
   });

--- a/src/test/githubAuth.unit.test.ts
+++ b/src/test/githubAuth.unit.test.ts
@@ -188,12 +188,8 @@ suite("GitHubAuth Unit Test Suite", () => {
     const first = await GitHubAuth.getSession();
     assert.strictEqual(first?.accessToken, "fake-token");
     assert.strictEqual(getSessionStub.calledOnce, true);
-    assert.strictEqual(onDidChangeSessionsStub.calledOnce, true);
 
-    const authChangeListener = onDidChangeSessionsStub.firstCall?.args[0] as
-      | ((event: unknown) => void)
-      | undefined;
-    authChangeListener?.({ provider: { id: "github" } });
+    GitHubAuth.handleAuthChange({ provider: { id: "github" } });
 
     const second = await GitHubAuth.getSession();
     assert.strictEqual(second?.accessToken, "new-token");
@@ -205,12 +201,8 @@ suite("GitHubAuth Unit Test Suite", () => {
 
     const session = await GitHubAuth.getSession();
     assert.strictEqual(session, fakeSession);
-    assert.strictEqual(onDidChangeSessionsStub.calledOnce, true);
 
-    const authChangeListener = onDidChangeSessionsStub.firstCall?.args[0] as
-      | ((event: unknown) => void)
-      | undefined;
-    authChangeListener?.({ provider: { id: "azure" } });
+    GitHubAuth.handleAuthChange({ provider: { id: "azure" } });
 
     const cachedSession = await GitHubAuth.getSession();
     assert.strictEqual(cachedSession, fakeSession);

--- a/src/test/githubAuth.unit.test.ts
+++ b/src/test/githubAuth.unit.test.ts
@@ -6,6 +6,26 @@ import { GitHubAuth } from "../githubAuth";
 suite("GitHubAuth Unit Test Suite", () => {
   let sandbox: sinon.SinonSandbox;
   let getSessionStub: sinon.SinonStub;
+  let onDidChangeSessionsStub: sinon.SinonStub;
+  let onDidChangeSessionsListener: ((event: unknown) => void) | undefined;
+  let listenerDisposeSpy: sinon.SinonSpy;
+
+  const resetGitHubAuthState = () => {
+    const authState = GitHubAuth as unknown as {
+      authChangeListenerDisposable?: { dispose?: () => void };
+      cachedSession?: vscode.AuthenticationSession;
+      sessionExpiry?: number;
+      pendingSessionPromise?: Promise<vscode.AuthenticationSession | undefined>;
+      sessionRequestVersion?: number;
+    };
+
+    authState.authChangeListenerDisposable?.dispose?.();
+    authState.authChangeListenerDisposable = undefined;
+    authState.cachedSession = undefined;
+    authState.sessionExpiry = 0;
+    authState.pendingSessionPromise = undefined;
+    authState.sessionRequestVersion = 0;
+  };
 
   const fakeSession = {
     accessToken: "fake-token",
@@ -15,13 +35,26 @@ suite("GitHubAuth Unit Test Suite", () => {
   };
 
   setup(() => {
+    resetGitHubAuthState();
     sandbox = sinon.createSandbox();
+    onDidChangeSessionsListener = undefined;
     getSessionStub = sandbox.stub((vscode as any).authentication, "getSession");
+    onDidChangeSessionsStub = sandbox.stub(
+      (vscode as any).authentication,
+      "onDidChangeSessions",
+    );
+    onDidChangeSessionsStub.callsFake((listener: (event: unknown) => void) => {
+      onDidChangeSessionsListener = listener;
+      listenerDisposeSpy = sandbox.spy();
+      return { dispose: listenerDisposeSpy };
+    });
     GitHubAuth.clearCache();
     sandbox.stub(vscode.window, "showErrorMessage");
   });
 
   teardown(() => {
+    resetGitHubAuthState();
+    onDidChangeSessionsListener = undefined;
     sandbox.restore();
   });
 
@@ -51,6 +84,40 @@ suite("GitHubAuth Unit Test Suite", () => {
     );
   });
 
+  test("signIn should ignore stale session for cache after cache clear", async () => {
+    const refreshedSession = {
+      ...fakeSession,
+      accessToken: "fresh-token",
+      id: "session-2",
+    };
+    let resolveSignInSession:
+      | ((value: typeof fakeSession | undefined) => void)
+      | undefined;
+    const pendingSignInSession = new Promise<typeof fakeSession | undefined>(
+      (resolve) => {
+        resolveSignInSession = resolve;
+      },
+    );
+
+    getSessionStub.onFirstCall().returns(pendingSignInSession);
+    getSessionStub.onSecondCall().resolves(refreshedSession);
+
+    const signInPromise = GitHubAuth.signIn();
+    GitHubAuth.clearCache();
+    resolveSignInSession?.(fakeSession);
+
+    await signInPromise;
+
+    const session = await GitHubAuth.getSession();
+    assert.strictEqual(session?.accessToken, "fresh-token");
+    assert.strictEqual(getSessionStub.calledTwice, true);
+    assert.deepStrictEqual(getSessionStub.secondCall.args, [
+      "github",
+      ["repo"],
+      { createIfNone: false },
+    ]);
+  });
+
   test("getSession should request a non-creating session", async () => {
     getSessionStub.resolves(fakeSession);
 
@@ -62,6 +129,94 @@ suite("GitHubAuth Unit Test Suite", () => {
       ["repo"],
       { createIfNone: false },
     ]);
+  });
+
+  test("getSession should return undefined when the request fails", async () => {
+    getSessionStub.rejects(new Error("Auth failed"));
+
+    const session = await GitHubAuth.getSession();
+
+    assert.strictEqual(session, undefined);
+  });
+
+  test("getSession should dedupe concurrent session fetches", async () => {
+    let resolveSession: ((value: typeof fakeSession | undefined) => void) | undefined;
+    const pendingSession = new Promise<typeof fakeSession | undefined>((resolve) => {
+      resolveSession = resolve;
+    });
+    getSessionStub.onFirstCall().returns(pendingSession);
+
+    const p1 = GitHubAuth.getToken();
+    const p2 = GitHubAuth.getToken();
+
+    assert.strictEqual(getSessionStub.calledOnce, true);
+    resolveSession?.(fakeSession);
+
+    const [token1, token2] = await Promise.all([p1, p2]);
+    assert.strictEqual(token1, "fake-token");
+    assert.strictEqual(token2, "fake-token");
+  });
+
+  test("getSession should ignore stale results after cache clear", async () => {
+    let resolveSession: ((value: typeof fakeSession | undefined) => void) | undefined;
+    const pendingSession = new Promise<typeof fakeSession | undefined>((resolve) => {
+      resolveSession = resolve;
+    });
+    getSessionStub.onFirstCall().returns(pendingSession);
+    getSessionStub.onSecondCall().resolves(fakeSession);
+
+    const pendingRequest = GitHubAuth.getSession();
+    GitHubAuth.clearCache();
+    resolveSession?.(fakeSession);
+
+    const staleSession = await pendingRequest;
+    assert.strictEqual(staleSession, undefined);
+
+    const freshSession = await GitHubAuth.getSession();
+    assert.strictEqual(freshSession, fakeSession);
+    assert.strictEqual(getSessionStub.calledTwice, true);
+  });
+
+  test("getSession should clear cache when GitHub sessions change", async () => {
+    const refreshedSession = {
+      ...fakeSession,
+      accessToken: "new-token",
+      id: "session-2",
+    };
+    getSessionStub.onFirstCall().resolves(fakeSession);
+    getSessionStub.onSecondCall().resolves(refreshedSession);
+
+    const first = await GitHubAuth.getSession();
+    assert.strictEqual(first?.accessToken, "fake-token");
+    assert.strictEqual(getSessionStub.calledOnce, true);
+    assert.strictEqual(onDidChangeSessionsStub.calledOnce, true);
+
+    const authChangeListener = onDidChangeSessionsStub.firstCall?.args[0] as
+      | ((event: unknown) => void)
+      | undefined;
+    authChangeListener?.({ provider: { id: "github" } });
+
+    const second = await GitHubAuth.getSession();
+    assert.strictEqual(second?.accessToken, "new-token");
+    assert.strictEqual(getSessionStub.calledTwice, true);
+  });
+
+  test("getSession should ignore auth change events for other providers", async () => {
+    getSessionStub.resolves(fakeSession);
+
+    const session = await GitHubAuth.getSession();
+    assert.strictEqual(session, fakeSession);
+    assert.strictEqual(onDidChangeSessionsStub.calledOnce, true);
+
+    const authChangeListener = onDidChangeSessionsStub.firstCall?.args[0] as
+      | ((event: unknown) => void)
+      | undefined;
+    authChangeListener?.({ provider: { id: "azure" } });
+
+    const cachedSession = await GitHubAuth.getSession();
+    assert.strictEqual(cachedSession, fakeSession);
+    assert.strictEqual(getSessionStub.calledOnce, true);
+    assert.strictEqual(listenerDisposeSpy?.calledOnce ?? false, false);
   });
 
   test("getToken should return undefined when no session exists", async () => {

--- a/src/test/vscodeMock.ts
+++ b/src/test/vscodeMock.ts
@@ -64,6 +64,7 @@ const mockVscode = {
     },
     authentication: {
         getSession: async () => undefined,
+        onDidChangeSessions: () => ({ dispose: () => { } }),
     },
     extensions: {
         getExtension: () => undefined,


### PR DESCRIPTION
- Addressed CodeRabbit's feedback on PR #473 regarding `checkPRStatus` duplicate cache logic, unused `context` parameter, and missing test coverage for `checkPRStatus` and `updatePreviousStates`.\n- Improved `GitHubAuth.getSession()` to deduplicate concurrent requests.\n- Added `.gitignore` rules for temporary AI agent artifacts and PR snapshots as suggested in PR #474.\n\nReplaces #475

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

PR #473・#474 のレビューコメントへの対応として、`checkPRStatus` のキャッシュロジック重複解消、`GitHubAuth.getSession()` の同時リクエストデデュープ実装、テストカバレッジ追加、`.gitignore` への AI エージェント成果物パターン追加を行っています。

- **P1**: `githubAuth_patch.sed` が誤ってリポジトリにコミットされており、`.gitignore` の `patch_*.diff` パターンでは除外されないため、削除が必要です。
- `src/githubAuth.ts` の `ensureAuthSessionListener()` で `providerId` が `undefined` の場合にも `clearCache()` が呼ばれる軽微なロジックバグがあります（P2）。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

`githubAuth_patch.sed` の削除が必要ですが、それ以外の変更はリポジトリの品質向上に貢献しており概ね安全です。

意図しない開発成果物 (`githubAuth_patch.sed`) がコミットされているため P1 扱いとし、スコアを 4 とします。機能的なロジックは堅牢で、テストカバレッジも充実しています。

`githubAuth_patch.sed`（削除推奨）および `src/githubAuth.ts`（`providerId` の判定ロジックと到達不能 `catch` ブロック）
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| githubAuth_patch.sed | AIエージェントが生成した一時的な sed スクリプト。リポジトリに含めるべきでなく、.gitignore の `patch_*.diff` パターンでも除外されない。 |
| src/githubAuth.ts | 同時セッション取得のデデュープロジック・セッション変更リスナー・`dispose()` を追加。`providerId` の判定ロジックに軽微なバグあり、`catch` ブロックが到達不能。 |
| src/extension.ts | `PRStatusCacheEntry` インターフェース抽出、`isPRCacheEntryFresh` ヘルパー追加、`checkPRStatus` のエクスポート化、`deactivate()` での `GitHubAuth.dispose()` 呼び出し追加。変更はクリーン。 |
| src/test/extensionHelpers.unit.test.ts | `checkPRStatus` と `updatePreviousStates` に対する新規ユニットテストを追加。キャッシュ挙動・エラーキャッシュ・トークン省略の検証を網羅。 |
| src/test/githubAuth.unit.test.ts | バージョン検証・キャッシュ無効化・他プロバイダーイベント無視など、`GitHubAuth` の新機能を詳細にカバー。 |
| .gitignore | AIエージェント関連の一時ファイルパターンを追加。ただし `.sed` ファイルは対象外のため、誤ってコミットされた `githubAuth_patch.sed` は除外されない。 |
| src/test/vscodeMock.ts | `onDidChangeSessions` のモック実装を追加。新しいテストで必要な変更。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C1 as 呼び出し元1
    participant C2 as 呼び出し元2
    participant GA as GitHubAuth
    participant VS as vscode.authentication

    C1->>GA: getSession()
    Note over GA: キャッシュなし・pending なし
    GA->>VS: getSession() → pendingPromise 作成
    C2->>GA: getSession()
    Note over GA: pendingPromise あり → 同じ Promise を返す
    VS-->>GA: session 解決
    GA->>GA: バージョン検証 OK → cacheSession()
    GA-->>C1: session
    GA-->>C2: session (同じ Promise)

    Note over GA: clearCache() 呼び出し時
    GA->>GA: sessionRequestVersion++
    GA->>GA: pendingPromise = undefined
    Note over GA: 飛行中 Promise はバージョン不一致で undefined を返す
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/githubAuth.ts`, line 109-114 ([link](https://github.com/hiroki-org/jules-extension/blob/367494279e2a8114bb3815b12951c812e5155de8/src/githubAuth.ts#L109-L114)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **到達不能な `catch` ブロック**

   `promise` は `.catch()` ハンドラー（98〜102行目）が全エラーをキャッチして `undefined` を返すため、`await promise` が例外をスローすることはありません。`try/catch` ブロックは完全にデッドコードです。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/githubAuth.ts
   Line: 109-114

   Comment:
   **到達不能な `catch` ブロック**

   `promise` は `.catch()` ハンドラー（98〜102行目）が全エラーをキャッチして `undefined` を返すため、`await promise` が例外をスローすることはありません。`try/catch` ブロックは完全にデッドコードです。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: githubAuth_patch.sed
Line: 1-5

Comment:
**AIエージェントの作業ファイルがリポジトリに混入**

`githubAuth_patch.sed` は `githubAuth.ts` へのパッチ適用に使用された一時的な開発用 sed スクリプトです。このファイルはリポジトリに含めるべきではありません。

また `.gitignore` に追加された `patch_*.diff` パターンはこのファイルを除外しません（拡張子が `.sed` のため）。このファイルは削除し、必要であれば `.gitignore` に `*.sed` または `githubAuth_patch.sed` を追加することを検討してください。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/githubAuth.ts
Line: 109-114

Comment:
**到達不能な `catch` ブロック**

`promise` は `.catch()` ハンドラー（98〜102行目）が全エラーをキャッチして `undefined` を返すため、`await promise` が例外をスローすることはありません。`try/catch` ブロックは完全にデッドコードです。

```suggestion
        return await promise;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/githubAuth.ts
Line: 21-26

Comment:
**`providerId` が `undefined` の場合にキャッシュが不必要にクリアされる**

現在の条件式 `if (providerId && providerId !== 'github')` は、`providerId` が `undefined` のとき（プロバイダー情報のないイベント）に `false` と評価されるため、`clearCache()` が呼ばれてしまいます。意図は「GitHub 以外のプロバイダーは無視する」のはずですが、実際にはプロバイダー不明のイベントもキャッシュクリアの対象になっています。

```suggestion
                if (!providerId || providerId !== 'github') {
                    return;
                }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address open review comments from P..."](https://github.com/hiroki-org/jules-extension/commit/367494279e2a8114bb3815b12951c812e5155de8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29544879)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->