### PR TITLE
chore: setup codecov test analytics for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,11 @@ jobs:
 
       - name: Upload test results to Codecov
         if: always()
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./test-results/junit.xml
+          report_type: test_results
       - name: Upload coverage to Codecov
         if: matrix.node-version == 20
         uses: codecov/codecov-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,11 @@ jobs:
         if: matrix.node-version == 20
         run: pnpm run test:coverage
 
+      - name: Upload test results to Codecov
+        if: always()
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage to Codecov
         if: matrix.node-version == 20
         uses: codecov/codecov-action@v6

--- a/package.json
+++ b/package.json
@@ -366,11 +366,11 @@
     "lint": "eslint src",
     "test": "vscode-test",
     "pretest:unit": "npm run compile-tests",
-    "test:unit": "mocha --ui tdd --require source-map-support/register --require out/test/vscodeMock.js \"out/test/*.unit.test.js\"",
+    "test:unit": "mocha --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --ui tdd --require source-map-support/register --require out/test/vscodeMock.js \"out/test/*.unit.test.js\"",
     "pretest:e2e": "npm run compile-tests && npm run compile",
     "test:e2e": "mocha --ui tdd --timeout 180000 --require source-map-support/register \"out/test/*.e2e.js\"",
     "pretest:coverage": "npm run pretest:unit",
-    "test:coverage": "c8 --all --src src --exclude \"src/test/**\" --exclude-after-remap --reporter=text-summary --reporter=json-summary --reporter=lcov mocha --ui tdd --require source-map-support/register --require out/test/vscodeMock.js \"out/test/*.unit.test.js\""
+    "test:coverage": "c8 --all --src src --exclude \"src/test/**\" --exclude-after-remap --reporter=text-summary --reporter=json-summary --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --ui tdd --require source-map-support/register --require out/test/vscodeMock.js \"out/test/*.unit.test.js\""
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",
@@ -386,6 +386,8 @@
     "esbuild": "^0.25.10",
     "eslint": "^9.36.0",
     "mocha": "^11.7.5",
+    "mocha-junit-reporter": "^2.2.1",
+    "mocha-multi-reporters": "^1.5.1",
     "npm-run-all": "^4.1.5",
     "playwright-core": "^1.58.2",
     "sinon": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,12 @@ importers:
       mocha:
         specifier: ^11.7.5
         version: 11.7.5
+      mocha-junit-reporter:
+        specifier: ^2.2.1
+        version: 2.2.1(mocha@11.7.5)
+      mocha-multi-reporters:
+        specifier: ^1.5.1
+        version: 1.5.1(mocha@11.7.5)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -696,6 +702,9 @@ packages:
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -748,6 +757,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1137,6 +1149,9 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -1319,6 +1334,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
@@ -1341,6 +1359,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
@@ -1389,6 +1410,22 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mocha-junit-reporter@2.2.1:
+    resolution: {integrity: sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==}
+    peerDependencies:
+      mocha: '>=2.2.5'
+
+  mocha-multi-reporters@1.5.1:
+    resolution: {integrity: sha512-Yb4QJOaGLIcmB0VY7Wif5AjvLMUFAdV57D2TWEva1Y0kU/3LjKpeRVmlMIfuO1SVbauve459kgtIizADqxMWPg==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      mocha: '>=3.1.2'
 
   mocha@11.7.5:
     resolution: {integrity: sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==}
@@ -1946,6 +1983,9 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2558,6 +2598,8 @@ snapshots:
 
   character-entities-legacy@3.0.0: {}
 
+  charenc@0.0.2: {}
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -2619,6 +2661,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypt@0.0.2: {}
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -3115,6 +3159,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-buffer@1.1.6: {}
+
   is-callable@1.2.7: {}
 
   is-core-module@2.16.1:
@@ -3290,6 +3336,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.18.1: {}
+
   log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
@@ -3316,6 +3364,12 @@ snapshots:
       uc.micro: 2.1.0
 
   math-intrinsics@1.1.0: {}
+
+  md5@2.3.0:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
 
   mdast-util-to-hast@13.2.1:
     dependencies:
@@ -3368,6 +3422,27 @@ snapshots:
       brace-expansion: 2.0.3
 
   minipass@7.1.2: {}
+
+  mkdirp@3.0.1: {}
+
+  mocha-junit-reporter@2.2.1(mocha@11.7.5):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      md5: 2.3.0
+      mkdirp: 3.0.1
+      mocha: 11.7.5
+      strip-ansi: 6.0.1
+      xml: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mocha-multi-reporters@1.5.1(mocha@11.7.5):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      lodash: 4.18.1
+      mocha: 11.7.5
+    transitivePeerDependencies:
+      - supports-color
 
   mocha@11.7.5:
     dependencies:
@@ -4050,6 +4125,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
+
+  xml@1.0.1: {}
 
   y18n@5.0.8: {}
 

--- a/reporter-config.json
+++ b/reporter-config.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "junit.xml"
+  }
+}

--- a/reporter-config.json
+++ b/reporter-config.json
@@ -1,6 +1,6 @@
 {
   "reporterEnabled": "spec, mocha-junit-reporter",
   "mochaJunitReporterReporterOptions": {
-    "mochaFile": "junit.xml"
+    "mochaFile": "test-results/junit.xml"
   }
 }


### PR DESCRIPTION
This PR sets up Codecov test analytics.

Changes made:
- Installed `mocha-junit-reporter` and `mocha-multi-reporters` dev dependencies.
- Added a `reporter-config.json` configuration file at the root to enable both standard `spec` output and `mocha-junit-reporter` output to `junit.xml`.
- Updated `package.json` to instruct the `test:unit` and `test:coverage` scripts to use the new multi-reporter configuration.
- Added a new step in `.github/workflows/test.yml` to upload the generated test results to Codecov using the `codecov/test-results-action@v1`.
- Verified that unit tests and coverage still run as expected and `junit.xml` gets created correctly.

---
*PR created automatically by Jules for task [1105940965986557942](https://jules.google.com/task/1105940965986557942) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Codecov Test Analytics のセットアップとして、`mocha-multi-reporters` と `mocha-junit-reporter` を追加し、`junit.xml` を生成してCIからアップロードする構成を導入しています。既存のカバレッジアップロードフローとの共存も適切に設計されています。

- `codecov/test-results-action@v1` に `files: ./junit.xml` が未指定のため、ファイルの自動検出に依存しています。明示的な指定を推奨します。
- `junit.xml` が `.gitignore` に追加されていないため、ローカル実行時に生成ファイルが誤ってコミットされる可能性があります。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

P2のみの指摘であり、マージ自体は概ね安全です。

変更内容はCodecov Test Analyticsのセットアップという限定的なスコープで、ロジック上の誤りはありません。指摘事項はすべてP2（スタイル・ベストプラクティス）レベルです。

.github/workflows/test.yml の files パラメータと if 条件の確認を推奨します。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/test.yml | Codecovテスト結果アップロードステップを追加。`files`パラメータ未指定・`if: always()`の使用に改善の余地あり。 |
| package.json | `test:unit`・`test:coverage`スクリプトに`mocha-multi-reporters`を追加し、JUnit XML出力を有効化。変更内容は正確。 |
| reporter-config.json | `spec`と`mocha-junit-reporter`の両方を有効化するマルチレポーター設定。問題なし。 |
| pnpm-lock.yaml | `mocha-junit-reporter`・`mocha-multi-reporters`と推移的依存関係（md5, mkdirp, lodash等）のロックファイルエントリを追加。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Mocha as Mocha (multi-reporters)
    participant Spec as spec reporter
    participant JUnit as mocha-junit-reporter
    participant C8 as c8 (coverage)
    participant Codecov as Codecov

    GHA->>Mocha: pnpm test:unit (node 22)
    Mocha->>Spec: コンソール出力
    Mocha->>JUnit: junit.xml 生成
    GHA->>C8: pnpm test:coverage (node 20)
    C8->>Mocha: Mochaサブプロセス起動
    Mocha->>JUnit: junit.xml 生成
    C8->>GHA: lcov.info, json-summary 生成
    GHA->>Codecov: test-results-action (junit.xml)
    GHA->>Codecov: codecov-action (lcov.info, node 20のみ)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.gitignore`, line 99 ([link](https://github.com/hiroki-org/jules-extension/blob/2daaaa085cb85fef695eac0fecc1b7347462c540/.gitignore#L99)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`junit.xml` が `.gitignore` に未追加**

   `mocha-junit-reporter` の設定により、`pnpm test:unit` や `pnpm test:coverage` をローカル実行すると `junit.xml` がプロジェクトルートに生成されます。この生成ファイルが `.gitignore` に含まれていないため、誤ってコミットされるリスクがあります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .gitignore
   Line: 99

   Comment:
   **`junit.xml` が `.gitignore` に未追加**

   `mocha-junit-reporter` の設定により、`pnpm test:unit` や `pnpm test:coverage` をローカル実行すると `junit.xml` がプロジェクトルートに生成されます。この生成ファイルが `.gitignore` に含まれていないため、誤ってコミットされるリスクがあります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/test.yml
Line: 40-44

Comment:
**`files` パラメータが未指定**

`codecov/test-results-action@v1` に `files` パラメータが指定されていません。`reporter-config.json` では `mochaFile: "junit.xml"` とプロジェクトルートへの出力を設定していますが、アクションがデフォルトで発見できない場合、テスト結果のアップロードが無音で失敗するリスクがあります。`codecov-action` と同様に明示的にファイルパスを指定することが推奨されます。

```suggestion
      - name: Upload test results to Codecov
        if: ${{ !cancelled() }}
        uses: codecov/test-results-action@v1
        with:
          token: ${{ secrets.CODECOV_TOKEN }}
          files: ./junit.xml
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .gitignore
Line: 99

Comment:
**`junit.xml` が `.gitignore` に未追加**

`mocha-junit-reporter` の設定により、`pnpm test:unit` や `pnpm test:coverage` をローカル実行すると `junit.xml` がプロジェクトルートに生成されます。この生成ファイルが `.gitignore` に含まれていないため、誤ってコミットされるリスクがあります。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: setup codecov test analytics for ..."](https://github.com/hiroki-org/jules-extension/commit/2daaaa085cb85fef695eac0fecc1b7347462c540) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29704176)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->