### PR TITLE
TSK-537: feat: add Apply Patch Locally action for ChangeSet artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
       {
         "command": "jules-extension.applyPatchLocally",
         "title": "Jules: Apply Patch Locally",
+        "category": "Jules",
         "icon": "$(git-pull-request-go-to-changes)"
       },
       {

--- a/package.json
+++ b/package.json
@@ -197,6 +197,11 @@
         "category": "Jules"
       },
       {
+        "command": "jules-extension.applyPatchLocally",
+        "title": "Jules: Apply Patch Locally",
+        "icon": "$(git-pull-request-go-to-changes)"
+      },
+      {
         "command": "jules-extension.reviewPlan",
         "title": "Review Plan...",
         "category": "Jules",
@@ -324,6 +329,11 @@
         },
         {
           "command": "jules-extension.openChangeset",
+          "when": "view == julesSessionsView && viewItem =~ /jules-session-with-changeset/",
+          "group": "navigation"
+        },
+        {
+          "command": "jules-extension.applyPatchLocally",
           "when": "view == julesSessionsView && viewItem =~ /jules-session-with-changeset/",
           "group": "navigation"
         },

--- a/src/applyPatchLocally.ts
+++ b/src/applyPatchLocally.ts
@@ -1,0 +1,174 @@
+import * as vscode from 'vscode';
+import * as childProcess from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { Session } from './types';
+import { ChangeSetSummary } from './sessionArtifacts';
+import { getGitApi } from './gitUtils';
+import { selectRepository, handleUncommittedChanges } from './sessionContextMenu';
+
+export async function applyPatchLocallyForSession(options: {
+    session: Session;
+    changeSet: ChangeSetSummary;
+    outputChannel: vscode.OutputChannel;
+    context: vscode.ExtensionContext;
+}): Promise<void> {
+    const { session, changeSet, outputChannel } = options;
+
+    const log = (msg: string) => {
+        console.log(`[Jules] ${msg}`);
+        outputChannel.appendLine(`[Jules] ${msg}`);
+    };
+
+    // 1. Premise check
+    const gitPatch = changeSet.raw?.gitPatch as Record<string, unknown> | undefined;
+    if (!gitPatch) {
+        vscode.window.showErrorMessage("This session's ChangeSet does not contain a gitPatch.");
+        return;
+    }
+
+    const unidiffPatch = gitPatch.unidiffPatch as string | undefined;
+    const baseCommitId = gitPatch.baseCommitId as string | undefined;
+    const suggestedCommitMessage = gitPatch.suggestedCommitMessage as string | undefined;
+
+    if (!unidiffPatch) {
+        vscode.window.showErrorMessage("This session's ChangeSet does not contain a unidiffPatch.");
+        return;
+    }
+
+    try {
+        // 2. Workspace / Repository selection
+        const gitApi = await getGitApi(outputChannel);
+        const repositories = gitApi.repositories;
+        if (!repositories || repositories.length === 0) {
+            vscode.window.showErrorMessage("No Git repository found in the workspace.");
+            return;
+        }
+
+        const repository = await selectRepository(repositories, log);
+        if (!repository) {
+            return;
+        }
+
+        const sessionIdValue = session.name.split("/").pop() || "unknown";
+        const branchName = `jules-patch-${sessionIdValue}`;
+
+        // 3. dirty working tree inspection
+        const canProceed = await handleUncommittedChanges(repository, branchName, log);
+        if (!canProceed) {
+            return;
+        }
+
+        // 4. fetch
+        log("Fetching from remote...");
+        try {
+            await repository.fetch();
+        } catch (fetchError: any) {
+            vscode.window.showErrorMessage(`Failed to fetch from remote: ${fetchError.message}`);
+            return;
+        }
+
+        // 5. baseCommitId resolution
+        let commitToBranchFrom = baseCommitId;
+        if (baseCommitId) {
+            try {
+                await repository.getCommit(baseCommitId);
+            } catch (e) {
+                log(`Commit ${baseCommitId} not found in repository after fetch.`);
+                commitToBranchFrom = undefined;
+            }
+        }
+
+        if (!commitToBranchFrom) {
+            const startingBranch = session.sourceContext?.githubRepoContext?.startingBranch;
+            if (startingBranch) {
+                const action = await vscode.window.showWarningMessage(
+                    `Base commit ${baseCommitId ?? 'unknown'} not found. Fallback to starting branch "${startingBranch}"?`,
+                    { modal: true },
+                    "Fallback",
+                    "Cancel"
+                );
+                if (action !== "Fallback") {
+                    return;
+                }
+                commitToBranchFrom = startingBranch;
+            } else {
+                vscode.window.showErrorMessage("Base commit not found and no starting branch specified.");
+                return;
+            }
+        }
+
+        // 6. Create new branch
+        log(`Creating branch ${branchName} from ${commitToBranchFrom}...`);
+        
+        // Find a unique branch name
+        let finalBranchName = branchName;
+        let suffix = 2;
+        while (true) {
+            try {
+                await repository.getBranch(finalBranchName);
+                // Branch exists, increment suffix
+                finalBranchName = `${branchName}-${suffix}`;
+                suffix++;
+            } catch (e) {
+                // Branch does not exist, we can use it
+                break;
+            }
+        }
+
+        try {
+            await repository.createBranch(finalBranchName, true, commitToBranchFrom);
+            log(`Checked out to new branch: ${finalBranchName}`);
+        } catch (branchError: any) {
+            vscode.window.showErrorMessage(`Failed to create branch: ${branchError.message}`);
+            return;
+        }
+
+        // 7. Apply patch
+        const patchFileName = `jules-${sessionIdValue}-${Date.now()}.patch`;
+        const patchFilePath = path.join(os.tmpdir(), patchFileName);
+        
+        await fs.writeFile(patchFilePath, unidiffPatch, "utf8");
+
+        log(`Applying patch from ${patchFilePath}...`);
+        
+        try {
+            await new Promise<void>((resolve, reject) => {
+                childProcess.execFile(
+                    "git", 
+                    ["apply", "--3way", patchFilePath], 
+                    { cwd: repository.rootUri.fsPath }, 
+                    (error, stdout, stderr) => {
+                        if (error) {
+                            log(`Git apply failed: ${stderr || error.message}`);
+                            reject(new Error(`git apply failed. Check Jules output channel for details.`));
+                        } else {
+                            resolve();
+                        }
+                    }
+                );
+            });
+            
+            // Clean up patch file on success
+            await fs.unlink(patchFilePath).catch(() => {});
+        } catch (applyError: any) {
+            vscode.window.showErrorMessage(`Failed to apply patch: ${applyError.message}\nPatch file saved at: ${patchFilePath}`);
+            return;
+        }
+
+        // 8. Pre-fill commit message
+        if (suggestedCommitMessage) {
+            repository.inputBox.value = suggestedCommitMessage;
+        }
+
+        // 9. Completion notification
+        vscode.window.showInformationMessage(
+            `Patch applied to branch "${finalBranchName}". Please review the changes in the Source Control view and commit.`
+        );
+
+    } catch (err: any) {
+        log(`Error applying patch locally: ${err.message}`);
+        vscode.window.showErrorMessage(`An error occurred: ${err.message}`);
+    }
+}

--- a/src/applyPatchLocally.ts
+++ b/src/applyPatchLocally.ts
@@ -96,7 +96,10 @@ export async function applyPatchLocallyForSession(options: {
                 if (action !== "Fallback") {
                     return;
                 }
-                commitToBranchFrom = startingBranch;
+                commitToBranchFrom = await resolveStartingBranchRef(repository, startingBranch);
+                if (commitToBranchFrom !== startingBranch) {
+                    log(`Resolved starting branch "${startingBranch}" to "${commitToBranchFrom}".`);
+                }
             } else {
                 vscode.window.showErrorMessage("Base commit not found and no starting branch specified.");
                 return;
@@ -167,6 +170,50 @@ export async function applyPatchLocallyForSession(options: {
 function isBranchNotFoundError(error: unknown): boolean {
     const message = error instanceof Error ? error.message : String(error);
     return /branch.*not found|not found.*branch|no such branch|does not exist|unknown revision|could not find ref/i.test(message);
+}
+
+async function branchExists(repository: any, branchRef: string): Promise<boolean> {
+    try {
+        return !!(await repository.getBranch(branchRef));
+    } catch (error) {
+        if (isBranchNotFoundError(error)) {
+            return false;
+        }
+        throw error;
+    }
+}
+
+async function resolveStartingBranchRef(repository: any, startingBranch: string): Promise<string> {
+    const branchRef = startingBranch.trim();
+    if (branchRef.length === 0) {
+        return startingBranch;
+    }
+    if (await branchExists(repository, branchRef)) {
+        return branchRef;
+    }
+
+    const remotes = Array.isArray(repository.state?.remotes) ? repository.state.remotes : [];
+    const remoteNames = remotes
+        .map((remote: { name?: unknown }) => typeof remote.name === "string" ? remote.name.trim() : "")
+        .filter((name: string) => name.length > 0)
+        .sort((a: string, b: string) => {
+            if (a === "origin") {
+                return -1;
+            }
+            if (b === "origin") {
+                return 1;
+            }
+            return a.localeCompare(b);
+        });
+
+    for (const remoteName of remoteNames) {
+        const remoteRef = `${remoteName}/${branchRef}`;
+        if (await branchExists(repository, remoteRef)) {
+            return remoteRef;
+        }
+    }
+
+    return branchRef;
 }
 
 async function findAvailableBranchName(repository: any, branchName: string): Promise<string> {

--- a/src/applyPatchLocally.ts
+++ b/src/applyPatchLocally.ts
@@ -4,15 +4,16 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import { Session } from './types';
-import { ChangeSetSummary } from './sessionArtifacts';
+import { ChangeSetSummary, getChangeSetGitPatch, getChangeSetUnidiffPatch } from './sessionArtifacts';
 import { getGitApi } from './gitUtils';
 import { selectRepository, handleUncommittedChanges } from './sessionContextMenu';
+
+const MAX_BRANCH_NAME_ATTEMPTS = 20;
 
 export async function applyPatchLocallyForSession(options: {
     session: Session;
     changeSet: ChangeSetSummary;
     outputChannel: vscode.OutputChannel;
-    context: vscode.ExtensionContext;
 }): Promise<void> {
     const { session, changeSet, outputChannel } = options;
 
@@ -22,15 +23,15 @@ export async function applyPatchLocallyForSession(options: {
     };
 
     // 1. Premise check
-    const gitPatch = changeSet.raw?.gitPatch as Record<string, unknown> | undefined;
+    const gitPatch = getChangeSetGitPatch(changeSet);
     if (!gitPatch) {
         vscode.window.showErrorMessage("This session's ChangeSet does not contain a gitPatch.");
         return;
     }
 
-    const unidiffPatch = gitPatch.unidiffPatch as string | undefined;
-    const baseCommitId = gitPatch.baseCommitId as string | undefined;
-    const suggestedCommitMessage = gitPatch.suggestedCommitMessage as string | undefined;
+    const unidiffPatch = getChangeSetUnidiffPatch(changeSet);
+    const baseCommitId = changeSet.baseCommitId;
+    const suggestedCommitMessage = changeSet.suggestedCommitMessage;
 
     if (!unidiffPatch) {
         vscode.window.showErrorMessage("This session's ChangeSet does not contain a unidiffPatch.");
@@ -45,6 +46,9 @@ export async function applyPatchLocallyForSession(options: {
             vscode.window.showErrorMessage("No Git repository found in the workspace.");
             return;
         }
+        const gitExecutable = typeof gitApi.git?.path === "string" && gitApi.git.path.trim().length > 0
+            ? gitApi.git.path
+            : "git";
 
         const repository = await selectRepository(repositories, log);
         if (!repository) {
@@ -102,20 +106,7 @@ export async function applyPatchLocallyForSession(options: {
         // 6. Create new branch
         log(`Creating branch ${branchName} from ${commitToBranchFrom}...`);
         
-        // Find a unique branch name
-        let finalBranchName = branchName;
-        let suffix = 2;
-        while (true) {
-            try {
-                await repository.getBranch(finalBranchName);
-                // Branch exists, increment suffix
-                finalBranchName = `${branchName}-${suffix}`;
-                suffix++;
-            } catch (e) {
-                // Branch does not exist, we can use it
-                break;
-            }
-        }
+        const finalBranchName = await findAvailableBranchName(repository, branchName);
 
         try {
             await repository.createBranch(finalBranchName, true, commitToBranchFrom);
@@ -136,7 +127,7 @@ export async function applyPatchLocallyForSession(options: {
         try {
             await new Promise<void>((resolve, reject) => {
                 childProcess.execFile(
-                    "git", 
+                    gitExecutable,
                     ["apply", "--3way", patchFilePath], 
                     { cwd: repository.rootUri.fsPath }, 
                     (error, stdout, stderr) => {
@@ -171,4 +162,27 @@ export async function applyPatchLocallyForSession(options: {
         log(`Error applying patch locally: ${err.message}`);
         vscode.window.showErrorMessage(`An error occurred: ${err.message}`);
     }
+}
+
+function isBranchNotFoundError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return /branch.*not found|not found.*branch|no such branch|does not exist|unknown revision|could not find ref/i.test(message);
+}
+
+async function findAvailableBranchName(repository: any, branchName: string): Promise<string> {
+    for (let attempt = 1; attempt <= MAX_BRANCH_NAME_ATTEMPTS; attempt += 1) {
+        const candidate = attempt === 1 ? branchName : `${branchName}-${attempt}`;
+        try {
+            const branch = await repository.getBranch(candidate);
+            if (!branch) {
+                return candidate;
+            }
+        } catch (error) {
+            if (isBranchNotFoundError(error)) {
+                return candidate;
+            }
+            throw error;
+        }
+    }
+    throw new Error(`Could not find an available branch name after ${MAX_BRANCH_NAME_ATTEMPTS} attempts.`);
 }

--- a/src/applyPatchLocally.ts
+++ b/src/applyPatchLocally.ts
@@ -90,9 +90,12 @@ export async function applyPatchLocallyForSession(options: {
 
         if (!commitToBranchFrom) {
             const startingBranch = session.sourceContext?.githubRepoContext?.startingBranch?.trim();
+            const baseCommitStatusMessage = baseCommitId
+                ? `Base commit ${baseCommitId} not found`
+                : "Base commit not specified";
             if (startingBranch) {
                 const action = await vscode.window.showWarningMessage(
-                    `Base commit ${baseCommitId ?? 'unknown'} not found. Fallback to starting branch "${startingBranch}"?`,
+                    `${baseCommitStatusMessage}. Fallback to starting branch "${startingBranch}"?`,
                     { modal: true },
                     "Fallback",
                     "Cancel"
@@ -105,7 +108,7 @@ export async function applyPatchLocallyForSession(options: {
                     log(`Resolved starting branch "${startingBranch}" to "${commitToBranchFrom}".`);
                 }
             } else {
-                vscode.window.showErrorMessage("Base commit not found and no starting branch specified.");
+                vscode.window.showErrorMessage(`${baseCommitStatusMessage} and no starting branch specified.`);
                 return;
             }
         }
@@ -186,7 +189,7 @@ function isBranchNotFoundError(error: unknown): boolean {
     const structuredValues = ["code", "gitErrorCode", "name"]
         .map((key) => readErrorStringProperty(error, key))
         .filter((value): value is string => typeof value === "string");
-    if (structuredValues.some((value) => /branch.*not.*found|not.*found.*branch|no.*such.*branch|does.*not.*exist|unknown.*revision|could.*not.*find.*ref|enoent/i.test(value))) {
+    if (structuredValues.some((value) => /branch.*not.*found|not.*found.*branch|no.*such.*branch|does.*not.*exist|unknown.*revision|could.*not.*find.*ref/i.test(value))) {
         return true;
     }
 

--- a/src/applyPatchLocally.ts
+++ b/src/applyPatchLocally.ts
@@ -46,9 +46,13 @@ export async function applyPatchLocallyForSession(options: {
             vscode.window.showErrorMessage("No Git repository found in the workspace.");
             return;
         }
-        const gitExecutable = typeof gitApi.git?.path === "string" && gitApi.git.path.trim().length > 0
+        const resolvedGitPath = typeof gitApi.git?.path === "string" && gitApi.git.path.trim().length > 0
             ? gitApi.git.path
-            : "git";
+            : undefined;
+        if (!resolvedGitPath) {
+            log("VS Code Git API did not expose git.path; falling back to 'git' on PATH.");
+        }
+        const gitExecutable = resolvedGitPath ?? "git";
 
         const repository = await selectRepository(repositories, log);
         if (!repository) {
@@ -85,7 +89,7 @@ export async function applyPatchLocallyForSession(options: {
         }
 
         if (!commitToBranchFrom) {
-            const startingBranch = session.sourceContext?.githubRepoContext?.startingBranch;
+            const startingBranch = session.sourceContext?.githubRepoContext?.startingBranch?.trim();
             if (startingBranch) {
                 const action = await vscode.window.showWarningMessage(
                     `Base commit ${baseCommitId ?? 'unknown'} not found. Fallback to starting branch "${startingBranch}"?`,
@@ -110,6 +114,9 @@ export async function applyPatchLocallyForSession(options: {
         log(`Creating branch ${branchName} from ${commitToBranchFrom}...`);
         
         const finalBranchName = await findAvailableBranchName(repository, branchName);
+        const originalBranch = typeof repository.state?.HEAD?.name === "string" && repository.state.HEAD.name.trim().length > 0
+            ? repository.state.HEAD.name
+            : undefined;
 
         try {
             await repository.createBranch(finalBranchName, true, commitToBranchFrom);
@@ -123,7 +130,7 @@ export async function applyPatchLocallyForSession(options: {
         const patchFileName = `jules-${sessionIdValue}-${Date.now()}.patch`;
         const patchFilePath = path.join(os.tmpdir(), patchFileName);
         
-        await fs.writeFile(patchFilePath, unidiffPatch, "utf8");
+        await fs.writeFile(patchFilePath, unidiffPatch, { encoding: "utf8", mode: 0o600 });
 
         log(`Applying patch from ${patchFilePath}...`);
         
@@ -135,7 +142,8 @@ export async function applyPatchLocallyForSession(options: {
                     { cwd: repository.rootUri.fsPath }, 
                     (error, stdout, stderr) => {
                         if (error) {
-                            log(`Git apply failed: ${stderr || error.message}`);
+                            const failureDetails = stderr || error.message;
+                            log(`Git apply failed for ${patchFilePath}: ${failureDetails}`);
                             reject(new Error(`git apply failed. Check Jules output channel for details.`));
                         } else {
                             resolve();
@@ -147,7 +155,14 @@ export async function applyPatchLocallyForSession(options: {
             // Clean up patch file on success
             await fs.unlink(patchFilePath).catch(() => {});
         } catch (applyError: any) {
-            vscode.window.showErrorMessage(`Failed to apply patch: ${applyError.message}\nPatch file saved at: ${patchFilePath}`);
+            const branchStateMessage = await restoreOriginalBranchAfterApplyFailure(
+                repository,
+                originalBranch,
+                finalBranchName,
+                log,
+            );
+            log(`Patch file saved at: ${patchFilePath}`);
+            vscode.window.showErrorMessage(`Failed to apply patch: ${applyError.message}\n${branchStateMessage}\nPatch file saved at: ${patchFilePath}`);
             return;
         }
 
@@ -168,8 +183,47 @@ export async function applyPatchLocallyForSession(options: {
 }
 
 function isBranchNotFoundError(error: unknown): boolean {
+    const structuredValues = ["code", "gitErrorCode", "name"]
+        .map((key) => readErrorStringProperty(error, key))
+        .filter((value): value is string => typeof value === "string");
+    if (structuredValues.some((value) => /branch.*not.*found|not.*found.*branch|no.*such.*branch|does.*not.*exist|unknown.*revision|could.*not.*find.*ref|enoent/i.test(value))) {
+        return true;
+    }
+
     const message = error instanceof Error ? error.message : String(error);
-    return /branch.*not found|not found.*branch|no such branch|does not exist|unknown revision|could not find ref/i.test(message);
+    return /branch.*not found|not found.*branch|no such branch|does not exist|unknown revision|could not find ref|ブランチ.*(見つかりません|見つからない|存在しません|存在しない)|存在しない.*ブランチ|参照.*(見つかりません|見つからない)|リビジョン.*不明/i.test(message);
+}
+
+function readErrorStringProperty(error: unknown, propertyName: string): string | undefined {
+    if (!error || typeof error !== "object") {
+        return undefined;
+    }
+    const value = (error as Record<string, unknown>)[propertyName];
+    return typeof value === "string" ? value : undefined;
+}
+
+async function restoreOriginalBranchAfterApplyFailure(
+    repository: any,
+    originalBranch: string | undefined,
+    failedBranchName: string,
+    log: (msg: string) => void,
+): Promise<string> {
+    if (!originalBranch || typeof repository.checkout !== "function") {
+        const message = `Current branch may remain "${failedBranchName}".`;
+        log(`Patch apply failed on ${failedBranchName}; original branch is unavailable for automatic restore.`);
+        return message;
+    }
+
+    try {
+        await repository.checkout(originalBranch);
+        const message = `Restored original branch "${originalBranch}" after patch failure. Failed branch "${failedBranchName}" remains for inspection.`;
+        log(message);
+        return message;
+    } catch (checkoutError: any) {
+        const message = `Could not restore original branch "${originalBranch}". Current branch may remain "${failedBranchName}".`;
+        log(`${message} Checkout error: ${checkoutError?.message ?? checkoutError}`);
+        return message;
+    }
 }
 
 async function branchExists(repository: any, branchRef: string): Promise<boolean> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,13 @@ import {
   checkoutToBranchForSession,
 } from "./sessionContextMenu";
 import {
+  getGitApi,
+  getRepositoryForWorkspaceFolder,
+  getRemoteUrl,
+  getCurrentBranchSha,
+} from "./gitUtils";
+import { applyPatchLocallyForSession } from "./applyPatchLocally";
+import {
   getCachedSessionArtifacts,
   updateSessionArtifactsCache,
   fetchLatestSessionArtifacts,
@@ -234,101 +241,6 @@ async function getGitHubUrl(): Promise<string | undefined> {
 }
 
 /**
- * Get and activate the VS Code Git Extension API
- */
-async function getGitApi(outputChannel?: vscode.OutputChannel): Promise<any> {
-  const logger =
-    outputChannel ??
-    ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
-  const gitExtension = vscode.extensions.getExtension("vscode.git");
-  if (!gitExtension) {
-    throw new Error("Git extension not found");
-  }
-  // Ensure the Git extension is activated
-  await gitExtension.activate();
-  const git = gitExtension.exports.getAPI(1);
-  if (!git) {
-    throw new Error("Git API not available");
-  }
-  return git;
-}
-
-/**
- * Find the Git repository that corresponds to the given workspace folder
- */
-function getRepositoryForWorkspaceFolder(
-  git: any,
-  workspaceFolder: vscode.WorkspaceFolder,
-  outputChannel?: vscode.OutputChannel,
-): any {
-  const logger =
-    outputChannel ??
-    ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
-  const repository = git.repositories.find(
-    (repo: any) => repo.rootUri?.fsPath === workspaceFolder.uri.fsPath,
-  );
-  if (!repository) {
-    const safeWsPath = sanitizeForLogging(workspaceFolder.uri.fsPath);
-    logger.appendLine(
-      `[Jules] No Git repository found for workspace folder ${safeWsPath}`,
-    );
-    return null;
-  }
-  return repository;
-}
-
-/**
- * Get the remote URL from a repository, with fallback strategy:
- * 1. Try 'origin' remote
- * 2. Fall back to first remote with fetchUrl or pushUrl
- * 3. Return null if none found
- */
-function getRemoteUrl(
-  repository: any,
-  preferredRemoteName: string = "origin",
-  outputChannel?: vscode.OutputChannel,
-): string | null {
-  const logger =
-    outputChannel ??
-    ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
-
-  if (!repository.state.remotes || repository.state.remotes.length === 0) {
-    logger.appendLine("[Jules] No remotes found in repository");
-    return null;
-  }
-
-  // Try to find the preferred remote (default: 'origin')
-  let remote = repository.state.remotes.find(
-    (r: any) => r.name === preferredRemoteName,
-  );
-
-  // Fallback: find first remote with a URL
-  if (!remote) {
-    remote = repository.state.remotes.find((r: any) => r.fetchUrl || r.pushUrl);
-    if (remote) {
-      logger.appendLine(
-        `[Jules] Preferred remote '${preferredRemoteName}' not found, using '${remote.name}'`,
-      );
-    }
-  }
-
-  if (!remote) {
-    logger.appendLine(`[Jules] No remote URL found in repository`);
-    return null;
-  }
-
-  const remoteUrl = remote.fetchUrl || remote.pushUrl;
-  if (!remoteUrl) {
-    logger.appendLine(
-      `[Jules] Remote '${remote.name}' has no fetchUrl or pushUrl`,
-    );
-    return null;
-  }
-
-  return remoteUrl;
-}
-
-/**
  * リモートブランチ作成に必要なリポジトリ情報を取得
  */
 async function getRepoInfoForBranchCreation(
@@ -466,37 +378,6 @@ export async function createRemoteBranch(
   }
 }
 
-export async function getCurrentBranchSha(
-  outputChannel?: vscode.OutputChannel,
-): Promise<string | null> {
-  const logger =
-    outputChannel ??
-    ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
-  try {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    if (!workspaceFolder) {
-      logger.appendLine(
-        "[Jules] No workspace folder found to get current branch SHA.",
-      );
-      return null;
-    }
-
-    const git = await getGitApi(outputChannel);
-    const repository = getRepositoryForWorkspaceFolder(
-      git,
-      workspaceFolder,
-      outputChannel,
-    );
-    if (!repository) {
-      return null;
-    }
-
-    return repository.state.HEAD?.commit || null;
-  } catch (error) {
-    logger.appendLine(`[Jules] Error getting current branch sha: ${error}`);
-    return null;
-  }
-}
 
 /**
  * Get privacy icon for a source
@@ -3755,6 +3636,26 @@ export function activate(context: vscode.ExtensionContext) {
     },
   );
 
+  const applyPatchLocallyDisposable = vscode.commands.registerCommand(
+    "jules-extension.applyPatchLocally",
+    async (item?: SessionTreeItem) => {
+      if (!item) {
+        return;
+      }
+      const cached = getCachedSessionArtifacts(item.session.name);
+      if (!cached?.latestChangeSet) {
+        vscode.window.showErrorMessage("This session has no ChangeSet artifact.");
+        return;
+      }
+      await applyPatchLocallyForSession({
+        session: item.session,
+        changeSet: cached.latestChangeSet,
+        outputChannel: logChannel,
+        context,
+      });
+    },
+  );
+
   // Plan review provider for displaying plan content in virtual documents
   const planProvider = new JulesPlanDocumentProvider();
   const planProviderDisposable =
@@ -3823,6 +3724,7 @@ export function activate(context: vscode.ExtensionContext) {
     diffProviderDisposable,
     openLatestDiffDisposable,
     openChangesetDisposable,
+    applyPatchLocallyDisposable,
     planProviderDisposable,
     reviewPlanDisposable,
     chatViewProviderDisposable,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ import {
   updateSessionArtifactsCache,
   fetchLatestSessionArtifacts,
   initializeSessionArtifactsCacheFromGlobalState,
+  getChangeSetUnidiffPatch,
 } from "./sessionArtifacts";
 import {
   JulesDiffDocumentProvider,
@@ -3642,16 +3643,36 @@ export function activate(context: vscode.ExtensionContext) {
       if (!item) {
         return;
       }
-      const cached = getCachedSessionArtifacts(item.session.name);
-      if (!cached?.latestChangeSet) {
+      let changeSet = getCachedSessionArtifacts(item.session.name)?.latestChangeSet;
+      if (!getChangeSetUnidiffPatch(changeSet)) {
+        const apiKey = await getStoredApiKey(context);
+        if (!apiKey) {
+          return;
+        }
+        try {
+          const fresh = await fetchLatestSessionArtifacts(
+            apiKey,
+            item.session.name,
+            JULES_API_BASE_URL,
+          );
+          changeSet = fresh.latestChangeSet;
+        } catch (error) {
+          vscode.window.showErrorMessage(`Failed to fetch latest ChangeSet artifact: ${sanitizeError(error)}`);
+          return;
+        }
+      }
+      if (!changeSet) {
         vscode.window.showErrorMessage("This session has no ChangeSet artifact.");
+        return;
+      }
+      if (!getChangeSetUnidiffPatch(changeSet)) {
+        vscode.window.showErrorMessage("This session has no applicable patch artifact.");
         return;
       }
       await applyPatchLocallyForSession({
         session: item.session,
-        changeSet: cached.latestChangeSet,
+        changeSet,
         outputChannel: logChannel,
-        context,
       });
     },
   );

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -1,13 +1,17 @@
 import * as vscode from "vscode";
 import { sanitizeForLogging } from "./securityUtils";
 
+type Logger = Pick<vscode.OutputChannel, "appendLine">;
+
+function resolveLogger(outputChannel?: vscode.OutputChannel): Logger {
+    return outputChannel ?? { appendLine: (s: string) => console.log(s) };
+}
+
 /**
  * Get and activate the VS Code Git Extension API
  */
 export async function getGitApi(outputChannel?: vscode.OutputChannel): Promise<any> {
-    const logger =
-        outputChannel ??
-        ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
+    const logger = resolveLogger(outputChannel);
     const gitExtension = vscode.extensions.getExtension("vscode.git");
     if (!gitExtension) {
         logger.appendLine("[Jules] vscode.git extension not found");
@@ -31,9 +35,7 @@ export function getRepositoryForWorkspaceFolder(
     workspaceFolder: vscode.WorkspaceFolder,
     outputChannel?: vscode.OutputChannel,
 ): any {
-    const logger =
-        outputChannel ??
-        ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
+    const logger = resolveLogger(outputChannel);
     const repository = git.repositories.find(
         (repo: any) => repo.rootUri?.fsPath === workspaceFolder.uri.fsPath,
     );
@@ -58,9 +60,7 @@ export function getRemoteUrl(
     preferredRemoteName: string = "origin",
     outputChannel?: vscode.OutputChannel,
 ): string | null {
-    const logger =
-        outputChannel ??
-        ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
+    const logger = resolveLogger(outputChannel);
 
     if (!repository.state.remotes || repository.state.remotes.length === 0) {
         logger.appendLine("[Jules] No remotes found in repository");
@@ -108,9 +108,7 @@ export function getRemoteUrl(
  * @param outputChannel Optional destination for diagnostics; console is used as a fallback.
  */
 export async function getCurrentBranchSha(outputChannel?: vscode.OutputChannel): Promise<string | null> {
-    const logger =
-        outputChannel ??
-        ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
+    const logger = resolveLogger(outputChannel);
     try {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
         if (!workspaceFolder) {

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -5,14 +5,19 @@ import { sanitizeForLogging } from "./securityUtils";
  * Get and activate the VS Code Git Extension API
  */
 export async function getGitApi(outputChannel?: vscode.OutputChannel): Promise<any> {
+    const logger =
+        outputChannel ??
+        ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
     const gitExtension = vscode.extensions.getExtension("vscode.git");
     if (!gitExtension) {
+        logger.appendLine("[Jules] vscode.git extension not found");
         throw new Error("Git extension not found");
     }
     // Ensure the Git extension is activated
     await gitExtension.activate();
     const git = gitExtension.exports.getAPI(1);
     if (!git) {
+        logger.appendLine("[Jules] vscode.git extension did not return a Git API");
         throw new Error("Git API not available");
     }
     return git;
@@ -93,9 +98,16 @@ export function getRemoteUrl(
     return remoteUrl;
 }
 
-export async function getCurrentBranchSha(
-    outputChannel?: vscode.OutputChannel,
-): Promise<string | null> {
+/**
+ * Get the HEAD commit SHA for the primary workspace folder.
+ *
+ * This helper intentionally reads only `vscode.workspace.workspaceFolders?.[0]`.
+ * Current callers use the same first-folder convention for branch creation, so
+ * this does not provide multi-root workspace support.
+ *
+ * @param outputChannel Optional destination for diagnostics; console is used as a fallback.
+ */
+export async function getCurrentBranchSha(outputChannel?: vscode.OutputChannel): Promise<string | null> {
     const logger =
         outputChannel ??
         ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -5,9 +5,6 @@ import { sanitizeForLogging } from "./securityUtils";
  * Get and activate the VS Code Git Extension API
  */
 export async function getGitApi(outputChannel?: vscode.OutputChannel): Promise<any> {
-    const logger =
-        outputChannel ??
-        ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
     const gitExtension = vscode.extensions.getExtension("vscode.git");
     if (!gitExtension) {
         throw new Error("Git extension not found");

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -1,0 +1,129 @@
+import * as vscode from "vscode";
+import { sanitizeForLogging } from "./securityUtils";
+
+/**
+ * Get and activate the VS Code Git Extension API
+ */
+export async function getGitApi(outputChannel?: vscode.OutputChannel): Promise<any> {
+    const logger =
+        outputChannel ??
+        ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
+    const gitExtension = vscode.extensions.getExtension("vscode.git");
+    if (!gitExtension) {
+        throw new Error("Git extension not found");
+    }
+    // Ensure the Git extension is activated
+    await gitExtension.activate();
+    const git = gitExtension.exports.getAPI(1);
+    if (!git) {
+        throw new Error("Git API not available");
+    }
+    return git;
+}
+
+/**
+ * Find the Git repository that corresponds to the given workspace folder
+ */
+export function getRepositoryForWorkspaceFolder(
+    git: any,
+    workspaceFolder: vscode.WorkspaceFolder,
+    outputChannel?: vscode.OutputChannel,
+): any {
+    const logger =
+        outputChannel ??
+        ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
+    const repository = git.repositories.find(
+        (repo: any) => repo.rootUri?.fsPath === workspaceFolder.uri.fsPath,
+    );
+    if (!repository) {
+        const safeWsPath = sanitizeForLogging(workspaceFolder.uri.fsPath);
+        logger.appendLine(
+            `[Jules] No Git repository found for workspace folder ${safeWsPath}`,
+        );
+        return null;
+    }
+    return repository;
+}
+
+/**
+ * Get the remote URL from a repository, with fallback strategy:
+ * 1. Try 'origin' remote
+ * 2. Fall back to first remote with fetchUrl or pushUrl
+ * 3. Return null if none found
+ */
+export function getRemoteUrl(
+    repository: any,
+    preferredRemoteName: string = "origin",
+    outputChannel?: vscode.OutputChannel,
+): string | null {
+    const logger =
+        outputChannel ??
+        ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
+
+    if (!repository.state.remotes || repository.state.remotes.length === 0) {
+        logger.appendLine("[Jules] No remotes found in repository");
+        return null;
+    }
+
+    // Try to find the preferred remote (default: 'origin')
+    let remote = repository.state.remotes.find(
+        (r: any) => r.name === preferredRemoteName,
+    );
+
+    // Fallback: find first remote with a URL
+    if (!remote) {
+        remote = repository.state.remotes.find((r: any) => r.fetchUrl || r.pushUrl);
+        if (remote) {
+            logger.appendLine(
+                `[Jules] Preferred remote '${preferredRemoteName}' not found, using '${remote.name}'`,
+            );
+        }
+    }
+
+    if (!remote) {
+        logger.appendLine(`[Jules] No remote URL found in repository`);
+        return null;
+    }
+
+    const remoteUrl = remote.fetchUrl || remote.pushUrl;
+    if (!remoteUrl) {
+        logger.appendLine(
+            `[Jules] Remote '${remote.name}' has no fetchUrl or pushUrl`,
+        );
+        return null;
+    }
+
+    return remoteUrl;
+}
+
+export async function getCurrentBranchSha(
+    outputChannel?: vscode.OutputChannel,
+): Promise<string | null> {
+    const logger =
+        outputChannel ??
+        ({ appendLine: (s: string) => console.log(s) } as vscode.OutputChannel);
+    try {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            logger.appendLine(
+                "[Jules] No workspace folder found to get current branch SHA.",
+            );
+            return null;
+        }
+
+        const git = await getGitApi(outputChannel);
+        const repository = getRepositoryForWorkspaceFolder(
+            git,
+            workspaceFolder,
+            outputChannel,
+        );
+        if (!repository) {
+            return null;
+        }
+
+        return repository.state.HEAD?.commit || null;
+    } catch (error) {
+        logger.appendLine(`[Jules] Error getting current branch sha: ${error}`);
+        return null;
+    }
+}

--- a/src/sessionArtifacts.ts
+++ b/src/sessionArtifacts.ts
@@ -22,7 +22,14 @@ interface Activity {
 }
 
 interface Artifact {
-    changeSet?: Record<string, unknown>;
+    changeSet?: {
+        gitPatch?: {
+            unidiffPatch?: string;
+            baseCommitId?: string;
+            suggestedCommitMessage?: string;
+        };
+        [key: string]: unknown;
+    };
 }
 
 export interface ChangeSetFile {
@@ -33,6 +40,8 @@ export interface ChangeSetFile {
 export interface ChangeSetSummary {
     files: ChangeSetFile[];
     raw: Record<string, unknown>;
+    baseCommitId?: string;
+    suggestedCommitMessage?: string;
 }
 
 export interface SessionArtifacts {
@@ -430,7 +439,7 @@ export function extractLatestArtifactsFromActivities(activities: Activity[]): Se
 
                     // Check for Diff from artifact (Priority 2)
                     if (!latestDiff) {
-                        const uniDiff = (artifact.changeSet?.gitPatch as any)?.unidiffPatch;
+                        const uniDiff = artifact.changeSet?.gitPatch?.unidiffPatch;
                         if (typeof uniDiff === "string" && uniDiff.trim().length > 0) {
                             latestDiff = uniDiff;
                         }
@@ -451,9 +460,12 @@ export function extractLatestArtifactsFromActivities(activities: Activity[]): Se
 
     let latestChangeSet: ChangeSetSummary | undefined;
     if (latestChangeSetRaw) {
+        const gitPatch = latestChangeSetRaw.gitPatch as any;
         latestChangeSet = {
             files: extractChangeSetFiles(latestChangeSetRaw, latestDiff),
             raw: latestChangeSetRaw,
+            baseCommitId: gitPatch?.baseCommitId,
+            suggestedCommitMessage: gitPatch?.suggestedCommitMessage,
         };
     }
 

--- a/src/sessionArtifacts.ts
+++ b/src/sessionArtifacts.ts
@@ -505,6 +505,15 @@ function areChangeSetFilesEqual(a?: ChangeSetSummary, b?: ChangeSetSummary): boo
     return true;
 }
 
+function areChangeSetsEqual(a?: ChangeSetSummary, b?: ChangeSetSummary): boolean {
+    if (!areChangeSetFilesEqual(a, b)) {
+        return false;
+    }
+    return getChangeSetUnidiffPatch(a) === getChangeSetUnidiffPatch(b)
+        && a?.baseCommitId === b?.baseCommitId
+        && a?.suggestedCommitMessage === b?.suggestedCommitMessage;
+}
+
 export function updateSessionArtifactsCache(sessionId: string, activities: Activity[], updateTime?: string): boolean {
     const latest = extractLatestArtifactsFromActivities(activities);
     const previousEntry = artifactsCache.get(sessionId);
@@ -513,7 +522,7 @@ export function updateSessionArtifactsCache(sessionId: string, activities: Activ
     const nextSavedAt = Date.now();
 
     const diffChanged = previousArtifacts?.latestDiff !== latest.latestDiff;
-    const changeSetChanged = !areChangeSetFilesEqual(previousArtifacts?.latestChangeSet, latest.latestChangeSet);
+    const changeSetChanged = !areChangeSetsEqual(previousArtifacts?.latestChangeSet, latest.latestChangeSet);
     const timeChanged = updateTime !== previousEntry?.updateTime;
 
     if (diffChanged || changeSetChanged || (!!updateTime && timeChanged)) {

--- a/src/sessionArtifacts.ts
+++ b/src/sessionArtifacts.ts
@@ -1,5 +1,5 @@
 import { fetchWithTimeout } from "./fetchUtils";
-import { ActivitiesResponse } from "./types";
+import type { ActivitiesResponse, Artifact, GitPatch } from "./types";
 import { JULES_API_BASE_URL } from "./julesApiConstants";
 
 export const ARTIFACTS_CACHE_STATE_KEY = "jules.artifacts.cache";
@@ -21,17 +21,6 @@ interface Activity {
     artifacts?: Artifact[];
 }
 
-interface Artifact {
-    changeSet?: {
-        gitPatch?: {
-            unidiffPatch?: string;
-            baseCommitId?: string;
-            suggestedCommitMessage?: string;
-        };
-        [key: string]: unknown;
-    };
-}
-
 export interface ChangeSetFile {
     path: string;
     status?: string;
@@ -47,6 +36,22 @@ export interface ChangeSetSummary {
 export interface SessionArtifacts {
     latestDiff?: string;
     latestChangeSet?: ChangeSetSummary;
+}
+
+export function getChangeSetGitPatch(changeSet?: ChangeSetSummary): GitPatch | undefined {
+    const gitPatch = changeSet?.raw?.gitPatch;
+    if (!gitPatch || typeof gitPatch !== "object") {
+        return undefined;
+    }
+    return gitPatch as GitPatch;
+}
+
+export function getChangeSetUnidiffPatch(changeSet?: ChangeSetSummary): string | undefined {
+    const unidiffPatch = getChangeSetGitPatch(changeSet)?.unidiffPatch;
+    if (typeof unidiffPatch !== "string" || unidiffPatch.trim().length === 0) {
+        return undefined;
+    }
+    return unidiffPatch;
 }
 
 interface CachedSessionArtifacts {

--- a/src/sessionArtifacts.ts
+++ b/src/sessionArtifacts.ts
@@ -465,12 +465,21 @@ export function extractLatestArtifactsFromActivities(activities: Activity[]): Se
 
     let latestChangeSet: ChangeSetSummary | undefined;
     if (latestChangeSetRaw) {
-        const gitPatch = latestChangeSetRaw.gitPatch as any;
+        const rawGitPatch = latestChangeSetRaw.gitPatch;
+        const gitPatch = rawGitPatch && typeof rawGitPatch === "object"
+            ? (rawGitPatch as Record<string, unknown>)
+            : undefined;
+        const baseCommitId = typeof gitPatch?.baseCommitId === "string"
+            ? gitPatch.baseCommitId
+            : undefined;
+        const suggestedCommitMessage = typeof gitPatch?.suggestedCommitMessage === "string"
+            ? gitPatch.suggestedCommitMessage
+            : undefined;
         latestChangeSet = {
             files: extractChangeSetFiles(latestChangeSetRaw, latestDiff),
             raw: latestChangeSetRaw,
-            baseCommitId: gitPatch?.baseCommitId,
-            suggestedCommitMessage: gitPatch?.suggestedCommitMessage,
+            baseCommitId,
+            suggestedCommitMessage,
         };
     }
 

--- a/src/sessionContextMenu.ts
+++ b/src/sessionContextMenu.ts
@@ -210,7 +210,7 @@ export async function checkoutToBranchForSession(
 /**
  * リポジトリを選択するヘルパー関数
  */
-async function selectRepository(
+export async function selectRepository(
     repositories: any[],
     log: (msg: string) => void
 ): Promise<any | null> {
@@ -239,7 +239,7 @@ async function selectRepository(
 /**
  * 未コミット変更のハンドリング
  */
-async function handleUncommittedChanges(
+export async function handleUncommittedChanges(
     repository: any,
     branchName: string,
     log: (msg: string) => void

--- a/src/test/applyPatchLocally.unit.test.ts
+++ b/src/test/applyPatchLocally.unit.test.ts
@@ -169,4 +169,146 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
         );
         await fs.rm(expectedPath, { force: true });
     });
+
+    test('Git repository がない場合はエラーを表示して止めること', async () => {
+        getGitApiStub.resolves({ repositories: [], git: { path: '/custom/git' } });
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /No Git repository/);
+        assert.strictEqual(repository.fetch.called, false);
+    });
+
+    test('repository 選択がキャンセルされた場合は処理を止めること', async () => {
+        (sessionContextMenu.selectRepository as sinon.SinonStub).resolves(undefined);
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.strictEqual(repository.fetch.called, false);
+    });
+
+    test('未コミット変更チェックで進行不可の場合は処理を止めること', async () => {
+        (sessionContextMenu.handleUncommittedChanges as sinon.SinonStub).resolves(false);
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.strictEqual(repository.fetch.called, false);
+    });
+
+    test('fetch が失敗した場合はエラーを表示して止めること', async () => {
+        repository.fetch.rejects(new Error('fetch failed'));
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /Failed to fetch from remote: fetch failed/);
+        assert.strictEqual(repository.createBranch.called, false);
+    });
+
+    test('fallback 確認でキャンセルされた場合は処理を止めること', async () => {
+        repository.getCommit.rejects(new Error('commit not found'));
+        showWarningMessageStub.resolves('Cancel');
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.strictEqual(repository.createBranch.called, false);
+    });
+
+    test('baseCommitId も startingBranch もない場合はエラーを表示すること', async () => {
+        repository.getCommit.rejects(new Error('commit not found'));
+        const session = createSession();
+        session.sourceContext = undefined;
+
+        await applyPatchLocallyForSession({
+            session,
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /Base commit not found/);
+        assert.strictEqual(repository.createBranch.called, false);
+    });
+
+    test('createBranch が失敗した場合はエラーを表示すること', async () => {
+        repository.createBranch.rejects(new Error('branch create failed'));
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /Failed to create branch: branch create failed/);
+        assert.strictEqual(execFileStub.called, false);
+    });
+
+    test('Git API に git.path がない場合は git コマンド名へフォールバックすること', async () => {
+        getGitApiStub.resolves({ repositories: [repository], git: {} });
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.strictEqual(execFileStub.firstCall.args[0], 'git');
+    });
+
+    test('getBranch が undefined を返す場合はそのブランチ名を使うこと', async () => {
+        repository.getBranch.resolves(undefined);
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.strictEqual(repository.createBranch.firstCall.args[0], 'jules-patch-abc');
+    });
+
+    test('getBranch が branch not found 以外のエラーを返す場合は全体エラーにすること', async () => {
+        repository.getBranch.rejects(new Error('repository is locked'));
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /An error occurred: repository is locked/);
+        assert.strictEqual(repository.createBranch.called, false);
+    });
+
+    test('利用可能なブランチ名が探索上限まで見つからない場合は全体エラーにすること', async () => {
+        repository.getBranch.resolves({ name: 'existing' });
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /Could not find an available branch name/);
+        assert.strictEqual(repository.createBranch.called, false);
+        assert.strictEqual(repository.getBranch.callCount, 20);
+    });
 });

--- a/src/test/applyPatchLocally.unit.test.ts
+++ b/src/test/applyPatchLocally.unit.test.ts
@@ -199,7 +199,9 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
             'エラーメッセージに patch ファイルの保存先を含めるべき',
         );
         const patchStats = await fs.stat(expectedPath);
-        assert.strictEqual(patchStats.mode & 0o777, 0o600);
+        if (process.platform !== 'win32') {
+            assert.strictEqual(patchStats.mode & 0o777, 0o600);
+        }
         await fs.rm(expectedPath, { force: true });
     });
 

--- a/src/test/applyPatchLocally.unit.test.ts
+++ b/src/test/applyPatchLocally.unit.test.ts
@@ -27,8 +27,10 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
             getCommit: sandbox.stub().resolves({ hash: 'base-sha' }),
             getBranch: sandbox.stub().rejects(new Error('branch not found')),
             createBranch: sandbox.stub().resolves(),
+            checkout: sandbox.stub().resolves(),
             inputBox: { value: '' },
             rootUri: { fsPath: '/repo' },
+            state: { HEAD: { name: 'main' }, remotes: [] },
         };
         outputChannel = {
             appendLine: sandbox.spy(),
@@ -174,8 +176,10 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
         assert.strictEqual(getGitApiStub.called, false);
     });
 
-    test('git apply 失敗時は保存済み patch パスをエラーに含めること', async () => {
+    test('git apply 失敗時は元ブランチへ戻し、保存済み patch パスをエラーに含めること', async () => {
         sandbox.stub(Date, 'now').returns(1234);
+        const expectedPath = path.join(os.tmpdir(), 'jules-abc-1234.patch');
+        await fs.rm(expectedPath, { force: true });
         execFileStub.callsFake(((_file: string, _args: string[], _options: any, callback: any) => {
             callback(new Error('apply failed'), '', 'fatal: patch failed');
             return {} as childProcess.ChildProcess;
@@ -187,12 +191,15 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
             outputChannel,
         });
 
-        const expectedPath = path.join(os.tmpdir(), 'jules-abc-1234.patch');
         assert.match(showErrorMessageStub.firstCall.args[0], /Failed to apply patch/);
+        assert.strictEqual(repository.checkout.calledOnceWithExactly('main'), true);
+        assert.match(showErrorMessageStub.firstCall.args[0], /Restored original branch "main"/);
         assert.ok(
             showErrorMessageStub.firstCall.args[0].includes(expectedPath),
             'エラーメッセージに patch ファイルの保存先を含めるべき',
         );
+        const patchStats = await fs.stat(expectedPath);
+        assert.strictEqual(patchStats.mode & 0o777, 0o600);
         await fs.rm(expectedPath, { force: true });
     });
 
@@ -274,6 +281,21 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
         assert.strictEqual(repository.createBranch.called, false);
     });
 
+    test('startingBranch が空白だけの場合はエラーを表示すること', async () => {
+        repository.getCommit.rejects(new Error('commit not found'));
+        const session = createSession();
+        session.sourceContext!.githubRepoContext!.startingBranch = '   ';
+
+        await applyPatchLocallyForSession({
+            session,
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /Base commit not found/);
+        assert.strictEqual(repository.createBranch.called, false);
+    });
+
     test('createBranch が失敗した場合はエラーを表示すること', async () => {
         repository.createBranch.rejects(new Error('branch create failed'));
 
@@ -297,10 +319,38 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
         });
 
         assert.strictEqual(execFileStub.firstCall.args[0], 'git');
+        assert.strictEqual(
+            (outputChannel.appendLine as sinon.SinonSpy).calledWithMatch(/falling back to 'git'/),
+            true,
+        );
     });
 
     test('getBranch が undefined を返す場合はそのブランチ名を使うこと', async () => {
         repository.getBranch.resolves(undefined);
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.strictEqual(repository.createBranch.firstCall.args[0], 'jules-patch-abc');
+    });
+
+    test('getBranch の構造化された not found コードをブランチ不在として扱うこと', async () => {
+        repository.getBranch.rejects(Object.assign(new Error('missing ref'), { code: 'BranchNotFound' }));
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.strictEqual(repository.createBranch.firstCall.args[0], 'jules-patch-abc');
+    });
+
+    test('getBranch の日本語 not found メッセージをブランチ不在として扱うこと', async () => {
+        repository.getBranch.rejects(new Error('ブランチが見つかりません'));
 
         await applyPatchLocallyForSession({
             session: createSession(),

--- a/src/test/applyPatchLocally.unit.test.ts
+++ b/src/test/applyPatchLocally.unit.test.ts
@@ -119,6 +119,28 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
         });
 
         assert.strictEqual(showWarningMessageStub.calledOnce, true);
+        assert.match(showWarningMessageStub.firstCall.args[0], /Base commit base-sha not found/);
+        assert.deepStrictEqual(repository.createBranch.firstCall.args, [
+            'jules-patch-abc',
+            true,
+            'main',
+        ]);
+    });
+
+    test('baseCommitId が未指定の場合は未指定メッセージで startingBranch フォールバック確認を出すこと', async () => {
+        const changeSet = createChangeSet();
+        delete changeSet.baseCommitId;
+        showWarningMessageStub.resolves('Fallback');
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet,
+            outputChannel,
+        });
+
+        assert.strictEqual(repository.getCommit.called, false);
+        assert.strictEqual(showWarningMessageStub.calledOnce, true);
+        assert.match(showWarningMessageStub.firstCall.args[0], /Base commit not specified/);
         assert.deepStrictEqual(repository.createBranch.firstCall.args, [
             'jules-patch-abc',
             true,
@@ -185,24 +207,27 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
             return {} as childProcess.ChildProcess;
         }) as any);
 
-        await applyPatchLocallyForSession({
-            session: createSession(),
-            changeSet: createChangeSet(),
-            outputChannel,
-        });
+        try {
+            await applyPatchLocallyForSession({
+                session: createSession(),
+                changeSet: createChangeSet(),
+                outputChannel,
+            });
 
-        assert.match(showErrorMessageStub.firstCall.args[0], /Failed to apply patch/);
-        assert.strictEqual(repository.checkout.calledOnceWithExactly('main'), true);
-        assert.match(showErrorMessageStub.firstCall.args[0], /Restored original branch "main"/);
-        assert.ok(
-            showErrorMessageStub.firstCall.args[0].includes(expectedPath),
-            'エラーメッセージに patch ファイルの保存先を含めるべき',
-        );
-        const patchStats = await fs.stat(expectedPath);
-        if (process.platform !== 'win32') {
-            assert.strictEqual(patchStats.mode & 0o777, 0o600);
+            assert.match(showErrorMessageStub.firstCall.args[0], /Failed to apply patch/);
+            assert.strictEqual(repository.checkout.calledOnceWithExactly('main'), true);
+            assert.match(showErrorMessageStub.firstCall.args[0], /Restored original branch "main"/);
+            assert.ok(
+                showErrorMessageStub.firstCall.args[0].includes(expectedPath),
+                'エラーメッセージに patch ファイルの保存先を含めるべき',
+            );
+            const patchStats = await fs.stat(expectedPath);
+            if (process.platform !== 'win32') {
+                assert.strictEqual(patchStats.mode & 0o777, 0o600);
+            }
+        } finally {
+            await fs.rm(expectedPath, { force: true });
         }
-        await fs.rm(expectedPath, { force: true });
     });
 
     test('Git repository がない場合はエラーを表示して止めること', async () => {
@@ -279,7 +304,24 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
             outputChannel,
         });
 
-        assert.match(showErrorMessageStub.firstCall.args[0], /Base commit not found/);
+        assert.match(showErrorMessageStub.firstCall.args[0], /Base commit base-sha not found/);
+        assert.strictEqual(repository.createBranch.called, false);
+    });
+
+    test('baseCommitId 未指定かつ startingBranch もない場合は未指定エラーを表示すること', async () => {
+        const session = createSession();
+        session.sourceContext = undefined;
+        const changeSet = createChangeSet();
+        delete changeSet.baseCommitId;
+
+        await applyPatchLocallyForSession({
+            session,
+            changeSet,
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /Base commit not specified and no starting branch specified/);
+        assert.strictEqual(repository.getCommit.called, false);
         assert.strictEqual(repository.createBranch.called, false);
     });
 
@@ -294,7 +336,7 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
             outputChannel,
         });
 
-        assert.match(showErrorMessageStub.firstCall.args[0], /Base commit not found/);
+        assert.match(showErrorMessageStub.firstCall.args[0], /Base commit base-sha not found/);
         assert.strictEqual(repository.createBranch.called, false);
     });
 
@@ -349,6 +391,19 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
         });
 
         assert.strictEqual(repository.createBranch.firstCall.args[0], 'jules-patch-abc');
+    });
+
+    test('getBranch の構造化 ENOENT はブランチ不在として扱わないこと', async () => {
+        repository.getBranch.rejects(Object.assign(new Error('missing binary'), { code: 'ENOENT' }));
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /An error occurred: missing binary/);
+        assert.strictEqual(repository.createBranch.called, false);
     });
 
     test('getBranch の日本語 not found メッセージをブランチ不在として扱うこと', async () => {

--- a/src/test/applyPatchLocally.unit.test.ts
+++ b/src/test/applyPatchLocally.unit.test.ts
@@ -124,6 +124,32 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
         ]);
     });
 
+    test('startingBranch のローカル branch がない場合は origin の追跡 ref にフォールバックすること', async () => {
+        repository.state = { remotes: [{ name: 'upstream' }, { name: 'origin' }] };
+        repository.getCommit.rejects(new Error('commit not found'));
+        repository.getBranch.callsFake(async (branchRef: string) => {
+            if (branchRef === 'origin/main') {
+                return { name: 'origin/main' };
+            }
+            throw new Error('branch not found');
+        });
+        showWarningMessageStub.resolves('Fallback');
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.strictEqual(repository.getBranch.calledWith('main'), true);
+        assert.strictEqual(repository.getBranch.calledWith('origin/main'), true);
+        assert.deepStrictEqual(repository.createBranch.firstCall.args, [
+            'jules-patch-abc',
+            true,
+            'origin/main',
+        ]);
+    });
+
     test('gitPatch または unidiffPatch が欠落している場合はエラーを表示して処理を止めること', async () => {
         await applyPatchLocallyForSession({
             session: createSession(),

--- a/src/test/applyPatchLocally.unit.test.ts
+++ b/src/test/applyPatchLocally.unit.test.ts
@@ -1,0 +1,172 @@
+import * as assert from 'assert';
+import childProcess = require('child_process');
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { applyPatchLocallyForSession } from '../applyPatchLocally';
+import * as gitUtils from '../gitUtils';
+import * as sessionContextMenu from '../sessionContextMenu';
+import { ChangeSetSummary } from '../sessionArtifacts';
+import { Session } from '../types';
+
+suite('applyPatchLocallyForSession ユニットテスト', () => {
+    let sandbox: sinon.SinonSandbox;
+    let repository: any;
+    let outputChannel: vscode.OutputChannel;
+    let getGitApiStub: sinon.SinonStub;
+    let execFileStub: sinon.SinonStub;
+    let showErrorMessageStub: sinon.SinonStub;
+    let showWarningMessageStub: sinon.SinonStub;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        repository = {
+            fetch: sandbox.stub().resolves(),
+            getCommit: sandbox.stub().resolves({ hash: 'base-sha' }),
+            getBranch: sandbox.stub().rejects(new Error('branch not found')),
+            createBranch: sandbox.stub().resolves(),
+            inputBox: { value: '' },
+            rootUri: { fsPath: '/repo' },
+        };
+        outputChannel = {
+            appendLine: sandbox.spy(),
+        } as any;
+
+        getGitApiStub = sandbox.stub(gitUtils, 'getGitApi').resolves({
+            repositories: [repository],
+            git: { path: '/custom/git' },
+        });
+        sandbox.stub(sessionContextMenu, 'selectRepository').resolves(repository);
+        sandbox.stub(sessionContextMenu, 'handleUncommittedChanges').resolves(true);
+        showErrorMessageStub = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined);
+        showWarningMessageStub = sandbox.stub(vscode.window, 'showWarningMessage').resolves(undefined);
+        sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined);
+        execFileStub = sandbox.stub(childProcess, 'execFile');
+        execFileStub.callsFake(((_file: string, _args: string[], _options: any, callback: any) => {
+            callback(null, '', '');
+            return {} as childProcess.ChildProcess;
+        }) as any);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    function createSession(): Session {
+        return {
+            name: 'sessions/abc',
+            title: 'Apply patch session',
+            state: 'COMPLETED',
+            rawState: 'COMPLETED',
+            sourceContext: {
+                source: 'sources/github/Hiroki-org/jules-extension',
+                githubRepoContext: {
+                    startingBranch: 'main',
+                },
+            },
+        };
+    }
+
+    function createChangeSet(rawGitPatch: Record<string, unknown> = {}): ChangeSetSummary {
+        return {
+            files: [],
+            raw: {
+                gitPatch: {
+                    unidiffPatch: 'diff --git a/src/file.ts b/src/file.ts\n--- a/src/file.ts\n+++ b/src/file.ts',
+                    baseCommitId: 'base-sha',
+                    suggestedCommitMessage: 'feat: apply patch locally',
+                    ...rawGitPatch,
+                },
+            },
+            baseCommitId: 'base-sha',
+            suggestedCommitMessage: 'feat: apply patch locally',
+        };
+    }
+
+    test('ブランチ名衝突時にユニークなブランチ名で作成し、VS Code Git API の git path を使うこと', async () => {
+        repository.getBranch.resetBehavior();
+        repository.getBranch.onFirstCall().resolves({ name: 'jules-patch-abc' });
+        repository.getBranch.onSecondCall().resolves({ name: 'jules-patch-abc-2' });
+        repository.getBranch.onThirdCall().rejects(new Error('branch not found'));
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.deepStrictEqual(repository.createBranch.firstCall.args, [
+            'jules-patch-abc-3',
+            true,
+            'base-sha',
+        ]);
+        assert.strictEqual(execFileStub.firstCall.args[0], '/custom/git');
+        assert.strictEqual(repository.inputBox.value, 'feat: apply patch locally');
+    });
+
+    test('baseCommitId が解決できない場合は startingBranch へのフォールバック確認を使うこと', async () => {
+        repository.getCommit.rejects(new Error('commit not found'));
+        showWarningMessageStub.resolves('Fallback');
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        assert.strictEqual(showWarningMessageStub.calledOnce, true);
+        assert.deepStrictEqual(repository.createBranch.firstCall.args, [
+            'jules-patch-abc',
+            true,
+            'main',
+        ]);
+    });
+
+    test('gitPatch または unidiffPatch が欠落している場合はエラーを表示して処理を止めること', async () => {
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: { files: [], raw: {} },
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /gitPatch/);
+        assert.strictEqual(getGitApiStub.called, false);
+
+        showErrorMessageStub.resetHistory();
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: {
+                files: [],
+                raw: { gitPatch: {} },
+            },
+            outputChannel,
+        });
+
+        assert.match(showErrorMessageStub.firstCall.args[0], /unidiffPatch/);
+        assert.strictEqual(getGitApiStub.called, false);
+    });
+
+    test('git apply 失敗時は保存済み patch パスをエラーに含めること', async () => {
+        sandbox.stub(Date, 'now').returns(1234);
+        execFileStub.callsFake(((_file: string, _args: string[], _options: any, callback: any) => {
+            callback(new Error('apply failed'), '', 'fatal: patch failed');
+            return {} as childProcess.ChildProcess;
+        }) as any);
+
+        await applyPatchLocallyForSession({
+            session: createSession(),
+            changeSet: createChangeSet(),
+            outputChannel,
+        });
+
+        const expectedPath = path.join(os.tmpdir(), 'jules-abc-1234.patch');
+        assert.match(showErrorMessageStub.firstCall.args[0], /Failed to apply patch/);
+        assert.ok(
+            showErrorMessageStub.firstCall.args[0].includes(expectedPath),
+            'エラーメッセージに patch ファイルの保存先を含めるべき',
+        );
+        await fs.rm(expectedPath, { force: true });
+    });
+});

--- a/src/test/extensionApplyPatchCommand.unit.test.ts
+++ b/src/test/extensionApplyPatchCommand.unit.test.ts
@@ -1,0 +1,112 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { activate, deactivate, Session, SessionTreeItem } from '../extension';
+import * as applyPatch from '../applyPatchLocally';
+import * as fetchUtils from '../fetchUtils';
+import * as sessionArtifacts from '../sessionArtifacts';
+import {
+    ChangeSetSummary,
+    clearSessionArtifactsInMemoryCache,
+} from '../sessionArtifacts';
+
+suite('applyPatchLocally command ユニットテスト', () => {
+    let sandbox: sinon.SinonSandbox;
+    let commands: Map<string, (...args: any[]) => unknown>;
+    let context: vscode.ExtensionContext;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        commands = new Map();
+        clearSessionArtifactsInMemoryCache();
+
+        sandbox.stub(vscode.commands, 'registerCommand').callsFake((command: string, callback: (...args: any[]) => unknown) => {
+            commands.set(command, callback);
+            return { dispose: () => undefined } as any;
+        });
+        sandbox.stub(vscode.window, 'createTreeView').returns({
+            dispose: () => undefined,
+            onDidChangeSelection: () => ({ dispose: () => undefined }),
+        } as any);
+        sandbox.stub(vscode.window, 'registerWebviewViewProvider').returns({
+            dispose: () => undefined,
+        } as any);
+        sandbox.stub(fetchUtils, 'fetchWithTimeout').resolves({
+            ok: true,
+            json: async () => ({ sessions: [] }),
+        } as any);
+
+        context = {
+            globalState: {
+                get: sandbox.stub().callsFake((_key: string, defaultValue?: unknown) => defaultValue),
+                update: sandbox.stub().resolves(),
+                keys: sandbox.stub().returns([]),
+            },
+            secrets: {
+                get: sandbox.stub().resolves('api-key'),
+                store: sandbox.stub().resolves(),
+            },
+            subscriptions: [],
+        } as any;
+    });
+
+    teardown(() => {
+        for (const subscription of context.subscriptions) {
+            subscription.dispose();
+        }
+        deactivate();
+        clearSessionArtifactsInMemoryCache();
+        sandbox.restore();
+    });
+
+    function createSession(): Session {
+        return {
+            name: 'sessions/apply-command',
+            title: 'Apply command',
+            state: 'COMPLETED',
+            rawState: 'COMPLETED',
+        };
+    }
+
+    function createChangeSet(): ChangeSetSummary {
+        return {
+            files: [],
+            raw: {
+                gitPatch: {
+                    unidiffPatch: 'diff --git a/file.ts b/file.ts',
+                },
+            },
+        };
+    }
+
+    test('item がない場合は何もしないこと', async () => {
+        const applyStub = sandbox.stub(applyPatch, 'applyPatchLocallyForSession').resolves();
+
+        activate(context);
+        const handler = commands.get('jules-extension.applyPatchLocally');
+        assert.ok(handler, 'applyPatchLocally command should be registered');
+
+        await handler();
+
+        assert.strictEqual(applyStub.called, false);
+    });
+
+    test('cached ChangeSet に patch がない場合は最新 artifacts を再取得してから適用すること', async () => {
+        const changeSet = createChangeSet();
+        sandbox.stub(sessionArtifacts, 'fetchLatestSessionArtifacts').resolves({
+            latestChangeSet: changeSet,
+        });
+        const applyStub = sandbox.stub(applyPatch, 'applyPatchLocallyForSession').resolves();
+
+        activate(context);
+        const handler = commands.get('jules-extension.applyPatchLocally');
+        assert.ok(handler, 'applyPatchLocally command should be registered');
+
+        const item = new SessionTreeItem(createSession());
+        await handler(item);
+
+        assert.strictEqual(applyStub.calledOnce, true);
+        assert.strictEqual(applyStub.firstCall.args[0].changeSet, changeSet);
+        assert.strictEqual(applyStub.firstCall.args[0].session, item.session);
+    });
+});

--- a/src/test/extensionApplyPatchCommand.unit.test.ts
+++ b/src/test/extensionApplyPatchCommand.unit.test.ts
@@ -93,7 +93,7 @@ suite('applyPatchLocally command ユニットテスト', () => {
 
     test('cached ChangeSet に patch がない場合は最新 artifacts を再取得してから適用すること', async () => {
         const changeSet = createChangeSet();
-        sandbox.stub(sessionArtifacts, 'fetchLatestSessionArtifacts').resolves({
+        const fetchArtifactsStub = sandbox.stub(sessionArtifacts, 'fetchLatestSessionArtifacts').resolves({
             latestChangeSet: changeSet,
         });
         const applyStub = sandbox.stub(applyPatch, 'applyPatchLocallyForSession').resolves();
@@ -106,6 +106,7 @@ suite('applyPatchLocally command ユニットテスト', () => {
         await handler(item);
 
         assert.strictEqual(applyStub.calledOnce, true);
+        assert.strictEqual(fetchArtifactsStub.firstCall.args.length, 3);
         assert.strictEqual(applyStub.firstCall.args[0].changeSet, changeSet);
         assert.strictEqual(applyStub.firstCall.args[0].session, item.session);
     });

--- a/src/test/gitUtils.unit.test.ts
+++ b/src/test/gitUtils.unit.test.ts
@@ -52,6 +52,7 @@ suite('gitUtils ユニットテスト', () => {
             async () => await getGitApi(outputChannel as any),
             /Git extension not found/,
         );
+        assert.match(outputChannel.appendLine.firstCall.args[0], /vscode\.git extension not found/);
     });
 
     test('getGitApi は Git API が取得できない場合にエラーを投げること', async () => {
@@ -64,6 +65,7 @@ suite('gitUtils ユニットテスト', () => {
             async () => await getGitApi(outputChannel as any),
             /Git API not available/,
         );
+        assert.match(outputChannel.appendLine.firstCall.args[0], /did not return a Git API/);
     });
 
     test('getRepositoryForWorkspaceFolder は一致する repository を返すこと', () => {
@@ -206,6 +208,9 @@ suite('gitUtils ユニットテスト', () => {
         const result = await getCurrentBranchSha(outputChannel as any);
 
         assert.strictEqual(result, null);
-        assert.match(outputChannel.appendLine.firstCall.args[0], /Error getting current branch sha/);
+        assert.strictEqual(
+            outputChannel.appendLine.calledWithMatch(/Error getting current branch sha/),
+            true,
+        );
     });
 });

--- a/src/test/gitUtils.unit.test.ts
+++ b/src/test/gitUtils.unit.test.ts
@@ -1,0 +1,211 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {
+    getCurrentBranchSha,
+    getGitApi,
+    getRemoteUrl,
+    getRepositoryForWorkspaceFolder,
+} from '../gitUtils';
+
+suite('gitUtils ユニットテスト', () => {
+    let sandbox: sinon.SinonSandbox;
+    let outputChannel: { appendLine: sinon.SinonSpy };
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        outputChannel = { appendLine: sandbox.spy() };
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    function workspaceFolder(fsPath: string): vscode.WorkspaceFolder {
+        return {
+            uri: vscode.Uri.file(fsPath),
+            name: 'workspace',
+            index: 0,
+        };
+    }
+
+    test('getGitApi は Git extension を activate して API を返すこと', async () => {
+        const gitApi = { repositories: [] };
+        const activate = sandbox.stub().resolves();
+        const getAPI = sandbox.stub().withArgs(1).returns(gitApi);
+        sandbox.stub(vscode.extensions, 'getExtension').withArgs('vscode.git').returns({
+            activate,
+            exports: { getAPI },
+        } as any);
+
+        const result = await getGitApi(outputChannel as any);
+
+        assert.strictEqual(result, gitApi);
+        assert.strictEqual(activate.calledOnce, true);
+        assert.strictEqual(getAPI.calledOnceWithExactly(1), true);
+    });
+
+    test('getGitApi は Git extension がない場合にエラーを投げること', async () => {
+        sandbox.stub(vscode.extensions, 'getExtension').withArgs('vscode.git').returns(undefined);
+
+        await assert.rejects(
+            async () => await getGitApi(outputChannel as any),
+            /Git extension not found/,
+        );
+    });
+
+    test('getGitApi は Git API が取得できない場合にエラーを投げること', async () => {
+        sandbox.stub(vscode.extensions, 'getExtension').withArgs('vscode.git').returns({
+            activate: sandbox.stub().resolves(),
+            exports: { getAPI: sandbox.stub().returns(undefined) },
+        } as any);
+
+        await assert.rejects(
+            async () => await getGitApi(outputChannel as any),
+            /Git API not available/,
+        );
+    });
+
+    test('getRepositoryForWorkspaceFolder は一致する repository を返すこと', () => {
+        const folder = workspaceFolder('/workspace/project');
+        const repository = { rootUri: vscode.Uri.file('/workspace/project') };
+        const git = {
+            repositories: [
+                { rootUri: vscode.Uri.file('/workspace/other') },
+                repository,
+            ],
+        };
+
+        const result = getRepositoryForWorkspaceFolder(git, folder, outputChannel as any);
+
+        assert.strictEqual(result, repository);
+    });
+
+    test('getRepositoryForWorkspaceFolder は repository がない場合に null を返してログすること', () => {
+        const folder = workspaceFolder('/workspace/project\nsecret');
+        const git = { repositories: [] };
+
+        const result = getRepositoryForWorkspaceFolder(git, folder, outputChannel as any);
+
+        assert.strictEqual(result, null);
+        assert.match(outputChannel.appendLine.firstCall.args[0], /No Git repository found/);
+        assert.ok(!outputChannel.appendLine.firstCall.args[0].includes('\nsecret'));
+    });
+
+    test('getRemoteUrl は origin の URL を優先して返すこと', () => {
+        const repository = {
+            state: {
+                remotes: [
+                    { name: 'upstream', fetchUrl: 'https://github.com/example/upstream.git' },
+                    { name: 'origin', fetchUrl: 'https://github.com/example/repo.git' },
+                ],
+            },
+        };
+
+        assert.strictEqual(
+            getRemoteUrl(repository, 'origin', outputChannel as any),
+            'https://github.com/example/repo.git',
+        );
+    });
+
+    test('getRemoteUrl は preferred remote がない場合に URL 付き remote へフォールバックすること', () => {
+        const repository = {
+            state: {
+                remotes: [
+                    { name: 'backup', pushUrl: 'https://github.com/example/backup.git' },
+                ],
+            },
+        };
+
+        assert.strictEqual(
+            getRemoteUrl(repository, 'origin', outputChannel as any),
+            'https://github.com/example/backup.git',
+        );
+        assert.match(outputChannel.appendLine.firstCall.args[0], /Preferred remote/);
+    });
+
+    test('getRemoteUrl は remotes が空の場合に null を返すこと', () => {
+        const repository = { state: { remotes: [] } };
+
+        assert.strictEqual(getRemoteUrl(repository, 'origin', outputChannel as any), null);
+        assert.match(outputChannel.appendLine.firstCall.args[0], /No remotes found/);
+    });
+
+    test('getRemoteUrl は URL 付き remote がない場合に null を返すこと', () => {
+        const repository = {
+            state: {
+                remotes: [{ name: 'origin' }],
+            },
+        };
+
+        assert.strictEqual(getRemoteUrl(repository, 'origin', outputChannel as any), null);
+        assert.match(outputChannel.appendLine.firstCall.args[0], /has no fetchUrl or pushUrl/);
+    });
+
+    test('getRemoteUrl は preferred remote 不在かつ URL 付き remote もない場合に null を返すこと', () => {
+        const repository = {
+            state: {
+                remotes: [{ name: 'backup' }],
+            },
+        };
+
+        assert.strictEqual(getRemoteUrl(repository, 'origin', outputChannel as any), null);
+        assert.match(outputChannel.appendLine.firstCall.args[0], /No remote URL found/);
+    });
+
+    test('getCurrentBranchSha は workspace がない場合に null を返すこと', async () => {
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value(undefined);
+
+        const result = await getCurrentBranchSha(outputChannel as any);
+
+        assert.strictEqual(result, null);
+        assert.match(outputChannel.appendLine.firstCall.args[0], /No workspace folder/);
+    });
+
+    test('getCurrentBranchSha は現在の HEAD commit を返すこと', async () => {
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder('/workspace/project')]);
+        sandbox.stub(vscode.extensions, 'getExtension').withArgs('vscode.git').returns({
+            activate: sandbox.stub().resolves(),
+            exports: {
+                getAPI: sandbox.stub().returns({
+                    repositories: [
+                        {
+                            rootUri: vscode.Uri.file('/workspace/project'),
+                            state: { HEAD: { commit: 'abc123' } },
+                        },
+                    ],
+                }),
+            },
+        } as any);
+
+        const result = await getCurrentBranchSha(outputChannel as any);
+
+        assert.strictEqual(result, 'abc123');
+    });
+
+    test('getCurrentBranchSha は repository が見つからない場合に null を返すこと', async () => {
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder('/workspace/project')]);
+        sandbox.stub(vscode.extensions, 'getExtension').withArgs('vscode.git').returns({
+            activate: sandbox.stub().resolves(),
+            exports: {
+                getAPI: sandbox.stub().returns({
+                    repositories: [],
+                }),
+            },
+        } as any);
+
+        const result = await getCurrentBranchSha(outputChannel as any);
+
+        assert.strictEqual(result, null);
+    });
+
+    test('getCurrentBranchSha は Git API 取得エラー時に null を返すこと', async () => {
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder('/workspace/project')]);
+        sandbox.stub(vscode.extensions, 'getExtension').withArgs('vscode.git').returns(undefined);
+
+        const result = await getCurrentBranchSha(outputChannel as any);
+
+        assert.strictEqual(result, null);
+        assert.match(outputChannel.appendLine.firstCall.args[0], /Error getting current branch sha/);
+    });
+});

--- a/src/test/sessionArtifacts.unit.test.ts
+++ b/src/test/sessionArtifacts.unit.test.ts
@@ -1480,8 +1480,6 @@ index 123..abc 100644`;
             assert.ok(fetchStub.calledTwice, 'エラー時はフォールバックすべき');
         });
     });
-});
-
     suite('Phase 5-2: ChangeSetSummary extraction of baseCommitId and suggestedCommitMessage', () => {
         test('extractLatestArtifactsFromActivities extracts baseCommitId and suggestedCommitMessage', () => {
             const activities = [
@@ -1548,3 +1546,4 @@ index 123..abc 100644`;
             assert.strictEqual(result.latestChangeSet?.suggestedCommitMessage, undefined);
         });
     });
+});

--- a/src/test/sessionArtifacts.unit.test.ts
+++ b/src/test/sessionArtifacts.unit.test.ts
@@ -1566,6 +1566,29 @@ index 123..abc 100644`;
             assert.strictEqual(result.latestChangeSet?.baseCommitId, undefined);
             assert.strictEqual(result.latestChangeSet?.suggestedCommitMessage, undefined);
         });
+
+        test('baseCommitId と suggestedCommitMessage が文字列でない場合は無視すること', () => {
+            const activities = [
+                {
+                    createTime: '2024-01-01T00:00:00Z',
+                    artifacts: [
+                        {
+                            changeSet: {
+                                files: [{ path: 'src/file.ts', status: 'modified' }],
+                                gitPatch: {
+                                    unidiffPatch: 'diff --git a/src/file.ts b/src/file.ts',
+                                    baseCommitId: 123456,
+                                    suggestedCommitMessage: { message: 'Fix bug in file.ts' },
+                                }
+                            }
+                        }
+                    ]
+                }
+            ];
+            const result = extractLatestArtifactsFromActivities(activities as any);
+            assert.strictEqual(result.latestChangeSet?.baseCommitId, undefined);
+            assert.strictEqual(result.latestChangeSet?.suggestedCommitMessage, undefined);
+        });
         
         test('old cache format (re-extracted from raw)', () => {
             // Note: Since extractLatestArtifactsFromActivities handles raw data directly from the activity,

--- a/src/test/sessionArtifacts.unit.test.ts
+++ b/src/test/sessionArtifacts.unit.test.ts
@@ -1481,3 +1481,70 @@ index 123..abc 100644`;
         });
     });
 });
+
+    suite('Phase 5-2: ChangeSetSummary extraction of baseCommitId and suggestedCommitMessage', () => {
+        test('extractLatestArtifactsFromActivities extracts baseCommitId and suggestedCommitMessage', () => {
+            const activities = [
+                {
+                    createTime: '2024-01-01T00:00:00Z',
+                    artifacts: [
+                        {
+                            changeSet: {
+                                files: [{ path: 'src/file.ts', status: 'modified' }],
+                                gitPatch: {
+                                    unidiffPatch: 'diff --git a/src/file.ts b/src/file.ts',
+                                    baseCommitId: 'abcdef123456',
+                                    suggestedCommitMessage: 'Fix bug in file.ts',
+                                }
+                            }
+                        }
+                    ]
+                }
+            ];
+            const result = extractLatestArtifactsFromActivities(activities as any);
+            assert.strictEqual(result.latestChangeSet?.baseCommitId, 'abcdef123456');
+            assert.strictEqual(result.latestChangeSet?.suggestedCommitMessage, 'Fix bug in file.ts');
+        });
+
+        test('gitPatch itself is missing', () => {
+            const activities = [
+                {
+                    createTime: '2024-01-01T00:00:00Z',
+                    artifacts: [
+                        {
+                            changeSet: {
+                                files: [{ path: 'src/file.ts', status: 'modified' }],
+                            }
+                        }
+                    ]
+                }
+            ];
+            const result = extractLatestArtifactsFromActivities(activities as any);
+            assert.strictEqual(result.latestChangeSet?.baseCommitId, undefined);
+            assert.strictEqual(result.latestChangeSet?.suggestedCommitMessage, undefined);
+        });
+        
+        test('old cache format (re-extracted from raw)', () => {
+            // Note: Since extractLatestArtifactsFromActivities handles raw data directly from the activity,
+            // we simulate what happens when it processes an old payload that still has gitPatch inside changeSet.
+            const activities = [
+                {
+                    createTime: '2024-01-01T00:00:00Z',
+                    artifacts: [
+                        {
+                            changeSet: {
+                                files: [{ path: 'src/file.ts', status: 'modified' }],
+                                gitPatch: {
+                                    unidiffPatch: 'diff --git a/src/file.ts b/src/file.ts',
+                                    baseCommitId: '123456abcdef',
+                                }
+                            }
+                        }
+                    ]
+                }
+            ];
+            const result = extractLatestArtifactsFromActivities(activities as any);
+            assert.strictEqual(result.latestChangeSet?.baseCommitId, '123456abcdef');
+            assert.strictEqual(result.latestChangeSet?.suggestedCommitMessage, undefined);
+        });
+    });

--- a/src/test/sessionArtifacts.unit.test.ts
+++ b/src/test/sessionArtifacts.unit.test.ts
@@ -758,6 +758,51 @@ index 123..abc 100644`;
 
             assert.strictEqual(updated, true);
         });
+
+        test('changeSet のファイルが同じでも gitPatch が復元された場合は true を返すこと', () => {
+            const sessionId = 'session-007-gitpatch';
+            const diff = 'diff --git a/file1.ts b/file1.ts';
+            const activitiesWithoutRawPatch = [
+                {
+                    createTime: '2024-01-01T00:00:00Z',
+                    gitPatch: { diff },
+                    artifacts: [
+                        {
+                            changeSet: {
+                                files: [{ path: 'file1.ts', status: 'modified' }],
+                            },
+                        },
+                    ],
+                },
+            ];
+            const activitiesWithRawPatch = [
+                {
+                    createTime: '2024-01-02T00:00:00Z',
+                    gitPatch: { diff },
+                    artifacts: [
+                        {
+                            changeSet: {
+                                files: [{ path: 'file1.ts', status: 'modified' }],
+                                gitPatch: {
+                                    unidiffPatch: diff,
+                                    baseCommitId: 'base-sha',
+                                    suggestedCommitMessage: 'feat: patch',
+                                },
+                            },
+                        },
+                    ],
+                },
+            ];
+
+            updateSessionArtifactsCache(sessionId, activitiesWithoutRawPatch);
+            const updated = updateSessionArtifactsCache(sessionId, activitiesWithRawPatch);
+
+            assert.strictEqual(updated, true);
+            assert.strictEqual(
+                getCachedSessionArtifacts(sessionId)?.latestChangeSet?.baseCommitId,
+                'base-sha',
+            );
+        });
     });
 
     // =========================================================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,8 +73,20 @@ export interface Session {
 // Convenience type alias
 export type SourceType = Source;
 
+export interface GitPatch {
+    unidiffPatch?: string;
+    baseCommitId?: string;
+    suggestedCommitMessage?: string;
+}
+
+export interface ChangeSet {
+    gitPatch?: GitPatch;
+    // 既存 raw データは互換性のため許容
+    [key: string]: unknown;
+}
+
 export interface Artifact {
-    changeSet?: Record<string, unknown>;
+    changeSet?: ChangeSet;
     bashOutput?: Record<string, unknown>;
     media?: Record<string, unknown>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface Session {
 // Convenience type alias
 export type SourceType = Source;
 
+/* c8 ignore start */
 export interface GitPatch {
     unidiffPatch?: string;
     baseCommitId?: string;
@@ -90,6 +91,7 @@ export interface Artifact {
     bashOutput?: Record<string, unknown>;
     media?: Record<string, unknown>;
 }
+/* c8 ignore stop */
 
 export interface Activity {
     name: string;


### PR DESCRIPTION
ref TSK-537

### Description
This PR introduces the **"Apply Patch Locally"** action for Jules sessions created with `automationMode: "MANUAL"`. Instead of just viewing the generated patch, users can now automatically fetch the base branch, check out a new local branch, and apply the `ChangeSet` patch directly in their VS Code workspace.

### Implementation Phases
* **Phase 1: Type Definitions:** Expanded `Artifact`, `ChangeSet`, and `GitPatch` types. Updated `extractLatestArtifactsFromActivities` to extract `baseCommitId` and `suggestedCommitMessage` directly from the activity, carrying them backward-compatibly in the artifact cache.
* **Phase 2: Git Helpers:** Extracted generic Git operations (`getGitApi`, `getRepositoryForWorkspaceFolder`, `getRemoteUrl`, `getCurrentBranchSha`) into a standalone `src/gitUtils.ts` file to avoid circular dependencies and bloat in `extension.ts`.
* **Phase 3: Apply Patch Logic:** Added `applyPatchLocallyForSession` in `src/applyPatchLocally.ts`. The workflow selects a repository, checks for uncommitted changes, fetches from the remote, resolves the base commit, creates a new local branch, and applies the `unidiffPatch` using `git apply --3way`.
* **Phase 4: Registration:** Registered the command `jules-extension.applyPatchLocally` and added it to the context menu under the `jules-session-with-changeset` condition.
* **Phase 5: Testing:** Added unit tests verifying the extraction of `baseCommitId` and `suggestedCommitMessage` including fallback behaviors for older cached structures. All existing 30+ artifacts tests pass successfully.

### Related Issue
Closes https://github.com/Hiroki-org/jules-extension/issues/486

### Verification
1. Create a Jules session with `automationMode: "MANUAL"`.
2. Wait for the session to complete and receive the `ChangeSet` artifact.
3. Right-click the session in the Tree View and select **"Jules: Apply Patch Locally"**.
4. Confirm a new branch is created, the `unidiffPatch` is applied to the working tree, and the VS Code Source Control view shows the changes ready for review.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ChangeSet アーティファクトをローカルに適用する「Apply Patch Locally」機能を追加するPRです。Git ヘルパーを `gitUtils.ts` へ分離し、パッチ適用ロジックを `applyPatchLocally.ts` に実装、コマンドの登録とコンテキストメニューへの追加まで一連の実装が含まれています。前回レビューで指摘された `Phase 5-2` テストスイートのネスト問題、未使用 `context` パラメータ、型付きフィールド未使用、`category` 欠落、`getBranch` の例外処理についてはすべて対応済みです。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

P2 のみの指摘でマージブロッカーなし。コアロジック・テストカバレッジともに十分。

P1/P0 の問題は確認されず、P2 が 2 件（`baseCommitId` 未設定時のメッセージのミスリーディング、`getGitApi` の未使用 `outputChannel` パラメータ）のみ。前回のレビュー指摘はすべて対応済みで、テストカバレッジも充実している。

特になし。`src/applyPatchLocally.ts` のフォールバックメッセージと `src/gitUtils.ts` の未使用パラメータは軽微な P2 のみ。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/applyPatchLocally.ts | Apply Patch Locally の主要ロジック。フロー全体（リポジトリ選択→fetch→ブランチ作成→パッチ適用）は概ね正しく実装されているが、`baseCommitId` が未設定の場合のフォールバックメッセージがミスリーディング（P2）。 |
| src/gitUtils.ts | `extension.ts` から Git ヘルパー関数を切り出した新ファイル。移植は正しく行われているが、`getGitApi` の `outputChannel` パラメータが未使用のまま引き継がれている（P2）。 |
| src/sessionArtifacts.ts | `ChangeSetSummary` に `baseCommitId`・`suggestedCommitMessage` を追加し、`areChangeSetsEqual` でキャッシュ比較を強化。`getChangeSetGitPatch`・`getChangeSetUnidiffPatch` ヘルパーの導入も適切。 |
| src/types.ts | `GitPatch`・`ChangeSet`・`Artifact` 型を追加し、型安全性を向上。`c8 ignore` は型定義にのみ適用されており妥当。 |
| src/extension.ts | `applyPatchLocally` コマンドの登録、キャッシュミス時の再フェッチ、`changeSet` / `unidiffPatch` の二重バリデーションが適切に実装されている。 |
| src/sessionContextMenu.ts | `selectRepository` と `handleUncommittedChanges` を `export` に変更のみ。変更は最小限で破壊的変更なし。 |
| src/test/applyPatchLocally.unit.test.ts | 正常系・異常系のシナリオを網羅した14テストを追加。ブランチ名衝突、fetch 失敗、上限超過など主要なエッジケースをカバー。 |
| src/test/sessionArtifacts.unit.test.ts | 前回指摘の `Phase 5-2` スイートの配置問題が修正済み（外側の suite 内に正しくネスト）。`baseCommitId`・`suggestedCommitMessage` 抽出のフォールバックテストも追加されている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[コマンド呼び出し jules-extension.applyPatchLocally] --> B{item あり?}
    B -- いいえ --> Z[終了]
    B -- はい --> C{キャッシュに unidiffPatch あり?}
    C -- いいえ --> D[fetchLatestSessionArtifacts]
    D --> E{取得成功 & unidiffPatch あり?}
    E -- いいえ --> Z
    E -- はい --> F[applyPatchLocallyForSession]
    C -- はい --> F
    F --> G{gitPatch / unidiffPatch 存在チェック}
    G -- 欠落 --> Z
    G -- OK --> H[getGitApi / リポジトリ選択]
    H --> I{リポジトリあり?}
    I -- いいえ --> Z
    I -- はい --> J[handleUncommittedChanges]
    J -- キャンセル --> Z
    J -- OK --> K[repository.fetch]
    K -- 失敗 --> Z
    K -- 成功 --> L{baseCommitId解決}
    L -- 見つかった --> O
    L -- 未設定 or 未発見 --> M{startingBranch フォールバック確認}
    M -- キャンセル --> Z
    M -- Fallback --> N[resolveStartingBranchRef]
    N --> O[findAvailableBranchName]
    O --> P[repository.createBranch]
    P -- 失敗 --> Z
    P -- 成功 --> Q[fs.writeFile patch to tmpdir]
    Q --> R[execFile: git apply --3way]
    R -- 失敗 --> S[エラー表示 patch ファイルパス付き]
    R -- 成功 --> T[fs.unlink patch file]
    T --> U[inputBox.value = suggestedCommitMessage]
    U --> V[完了通知]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/applyPatchLocally.ts
Line: 87-91

Comment:
**`baseCommitId` が未設定の場合にミスリーディングなメッセージが表示される**

`baseCommitId` が最初から `undefined`（Jules バックエンドが提供しなかったケース）の場合、`if (baseCommitId)` ブロックをスキップしたまま `if (!commitToBranchFrom)` に進み、ユーザーには `"Base commit unknown not found. Fallback to starting branch..."` と表示されます。これは「コミットが見つからなかった」のではなく「コミットIDが提供されていない」という別の状況であるため、ユーザーが混乱する可能性があります。

```typescript
// 提案: baseCommitId が存在しない場合と、存在するが見つからない場合でメッセージを分ける
if (!commitToBranchFrom) {
    const startingBranch = session.sourceContext?.githubRepoContext?.startingBranch;
    if (startingBranch) {
        const baseCommitDesc = baseCommitId
            ? `Base commit ${baseCommitId} not found locally.`
            : "No base commit ID available.";
        const action = await vscode.window.showWarningMessage(
            `${baseCommitDesc} Fallback to starting branch "${startingBranch}"?`,
            { modal: true },
            "Fallback",
            "Cancel"
        );
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/gitUtils.ts
Line: 502-514

Comment:
**`outputChannel` パラメータが `getGitApi` 内で未使用**

`getGitApi` は `outputChannel` を受け取りますが、関数本体では一切使用されていません。元の `extension.ts` 内の実装も同様でしたが、今回 `gitUtils.ts` へ切り出す際に整理する機会でした。呼び出し元（`applyPatchLocally.ts` の 43 行目など）から渡された `outputChannel` へのログが一切記録されないため、デバッグ時に有用な情報が失われます。パラメータを削除するか、エラーやデバッグ情報のロギングに活用してください。

```typescript
export async function getGitApi(): Promise<any> {
    const gitExtension = vscode.extensions.getExtension("vscode.git");
    if (!gitExtension) {
        throw new Error("Git extension not found");
    }
    await gitExtension.activate();
    const git = gitExtension.exports.getAPI(1);
    if (!git) {
        throw new Error("Git API not available");
    }
    return git;
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(apply-patch): handle refreshed artif..."](https://github.com/hiroki-org/jules-extension/commit/3599c417640de01189455dff1439910deed1a7a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29706282)</sub>

<!-- /greptile_comment -->