### PR TITLE
test: session context menu coverage を強化

### DIFF
--- a/src/test/sessionContextMenu.checkout.unit.test.ts
+++ b/src/test/sessionContextMenu.checkout.unit.test.ts
@@ -1,0 +1,385 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as sessionContextMenu from '../sessionContextMenu';
+import { GitHubAuth } from '../githubAuth';
+import * as githubUtils from '../githubUtils';
+import type { Session } from '../types';
+import type { PullRequestBranchInfo } from '../githubUtils';
+
+suite('sessionContextMenu checkout coverage suite', () => {
+    let sandbox: sinon.SinonSandbox;
+    let getExtensionStub: sinon.SinonStub;
+    let showQuickPickStub: sinon.SinonStub;
+    let showWarningMessageStub: sinon.SinonStub;
+    let showInformationMessageStub: sinon.SinonStub;
+    let showErrorMessageStub: sinon.SinonStub;
+    let openExternalStub: sinon.SinonStub;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        getExtensionStub = sandbox.stub(vscode.extensions, 'getExtension');
+        showQuickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
+        showWarningMessageStub = sandbox.stub(vscode.window, 'showWarningMessage');
+        showInformationMessageStub = sandbox.stub(vscode.window, 'showInformationMessage');
+        showErrorMessageStub = sandbox.stub(vscode.window, 'showErrorMessage');
+        openExternalStub = sandbox.stub(vscode.env, 'openExternal');
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    function createOutputChannel() {
+        return {
+            appendLine: sandbox.stub(),
+            append: sandbox.stub(),
+            clear: sandbox.stub(),
+            replace: sandbox.stub(),
+            dispose: sandbox.stub(),
+            show: sandbox.stub(),
+            hide: sandbox.stub(),
+            name: 'test'
+        } as unknown as vscode.OutputChannel;
+    }
+
+    function createRepository(overrides: Record<string, unknown> = {}) {
+        return {
+            rootUri: vscode.Uri.file('/repo'),
+            state: {
+                HEAD: { name: 'main' },
+                workingTreeChanges: [],
+                indexChanges: [],
+                remotes: []
+            },
+            checkout: sandbox.stub().resolves(),
+            fetch: sandbox.stub().resolves(),
+            addRemote: sandbox.stub().resolves(),
+            createBranch: sandbox.stub().resolves(),
+            stash: sandbox.stub().resolves(),
+            ...overrides
+        } as any;
+    }
+
+    function stubGitExtension(repositories: any[]) {
+        const getAPI = sandbox.stub().withArgs(1).returns({ repositories });
+        const activate = sandbox.stub().resolves();
+        getExtensionStub.withArgs('vscode.git').returns({ activate, exports: { getAPI } } as any);
+        return { activate, getAPI };
+    }
+
+    test('selectRepository returns the only repository without prompting', async () => {
+        const repo = createRepository();
+        const result = await sessionContextMenu.selectRepository([repo], () => undefined);
+
+        assert.strictEqual(result, repo);
+        assert.strictEqual(showQuickPickStub.called, false);
+    });
+
+    test('selectRepository returns null when multi-root selection is cancelled', async () => {
+        const repo1 = createRepository({ rootUri: vscode.Uri.file('/repo-a') });
+        const repo2 = createRepository({ rootUri: vscode.Uri.file('/repo-b') });
+        showQuickPickStub.resolves(undefined);
+
+        const result = await sessionContextMenu.selectRepository([repo1, repo2], () => undefined);
+
+        assert.strictEqual(result, null);
+        assert.strictEqual(showQuickPickStub.calledOnce, true);
+    });
+
+    test('selectRepository returns the chosen repository in multi-root workspaces', async () => {
+        const repo1 = createRepository({ rootUri: vscode.Uri.file('/repo-a') });
+        const repo2 = createRepository({ rootUri: vscode.Uri.file('/repo-b') });
+        showQuickPickStub.resolves({ repo: repo2 });
+
+        const result = await sessionContextMenu.selectRepository([repo1, repo2], () => undefined);
+
+        assert.strictEqual(result, repo2);
+    });
+
+    test('handleUncommittedChanges returns true when repository is clean', async () => {
+        const result = await sessionContextMenu.handleUncommittedChanges(createRepository(), 'feature/test', () => undefined);
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(showWarningMessageStub.called, false);
+    });
+
+    test('handleUncommittedChanges returns false when user cancels', async () => {
+        const repo = createRepository({
+            state: {
+                HEAD: { name: 'main' },
+                workingTreeChanges: [{ path: 'file.ts' }],
+                indexChanges: [],
+                remotes: []
+            }
+        });
+        showWarningMessageStub.resolves(undefined);
+
+        const result = await sessionContextMenu.handleUncommittedChanges(repo, 'feature/test', () => undefined);
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(showWarningMessageStub.calledOnce, true);
+    });
+
+    test('handleUncommittedChanges stashes and proceeds when user selects stash', async () => {
+        const repo = createRepository({
+            state: {
+                HEAD: { name: 'main' },
+                workingTreeChanges: [{ path: 'file.ts' }],
+                indexChanges: [],
+                remotes: []
+            }
+        });
+        showWarningMessageStub.resolves('Stash Changes & Checkout');
+
+        const result = await sessionContextMenu.handleUncommittedChanges(repo, 'feature/test', () => undefined);
+
+        assert.strictEqual(result, true);
+        assert.strictEqual((repo.stash as sinon.SinonStub).calledOnce, true);
+    });
+
+    test('handleUncommittedChanges returns false when stash fails', async () => {
+        const repo = createRepository({
+            stash: sandbox.stub().rejects(new Error('stash failed')),
+            state: {
+                HEAD: { name: 'main' },
+                workingTreeChanges: [{ path: 'file.ts' }],
+                indexChanges: [],
+                remotes: []
+            }
+        });
+        showWarningMessageStub.resolves('Stash Changes & Checkout');
+
+        const result = await sessionContextMenu.handleUncommittedChanges(repo, 'feature/test', () => undefined);
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(showErrorMessageStub.calledOnce, true);
+    });
+
+    test('checkoutToBranch returns false when the Git extension is unavailable', async () => {
+        getExtensionStub.withArgs('vscode.git').returns(undefined);
+
+        const result = await sessionContextMenu.checkoutToBranch('feature/test', createOutputChannel());
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(showErrorMessageStub.calledOnce, true);
+    });
+
+    test('checkoutToBranch returns false when checkout is cancelled by repository selection', async () => {
+        stubGitExtension([createRepository(), createRepository({ rootUri: vscode.Uri.file('/repo-b') })]);
+        showQuickPickStub.resolves(undefined);
+
+        const result = await sessionContextMenu.checkoutToBranch('feature/test', createOutputChannel());
+
+        assert.strictEqual(result, false);
+    });
+
+    test('checkoutToBranch performs a successful checkout when repository is clean', async () => {
+        const repo = createRepository();
+        stubGitExtension([repo]);
+
+        const result = await sessionContextMenu.checkoutToBranch('feature/test', createOutputChannel());
+
+        assert.strictEqual(result, true);
+        assert.strictEqual((repo.checkout as sinon.SinonStub).calledWithExactly('feature/test'), true);
+    });
+
+    test('checkoutToBranch falls back to fetch and checkout when the branch is missing locally', async () => {
+        const repo = createRepository({
+            checkout: sandbox.stub()
+                .onFirstCall().rejects(new Error('pathspec did not match any file(s) known to git'))
+                .onSecondCall().resolves()
+        });
+        stubGitExtension([repo]);
+        showInformationMessageStub.resolves('Fetch & Checkout');
+
+        const result = await sessionContextMenu.checkoutToBranch('feature/test', createOutputChannel());
+
+        assert.strictEqual(result, true);
+        assert.strictEqual((repo.fetch as sinon.SinonStub).calledOnce, true);
+        assert.strictEqual((repo.checkout as sinon.SinonStub).callCount, 2);
+    });
+
+    test('checkoutToBranch returns false when fetch fallback is cancelled', async () => {
+        const repo = createRepository({
+            checkout: sandbox.stub().rejects(new Error('branch not found'))
+        });
+        stubGitExtension([repo]);
+        showInformationMessageStub.resolves('Cancel');
+
+        const result = await sessionContextMenu.checkoutToBranch('feature/test', createOutputChannel());
+
+        assert.strictEqual(result, false);
+        assert.strictEqual((repo.fetch as sinon.SinonStub).called, false);
+    });
+
+    test('checkoutToBranch returns false for non-repository checkout failures', async () => {
+        const repo = createRepository({
+            checkout: sandbox.stub().rejects(new Error('permission denied'))
+        });
+        stubGitExtension([repo]);
+
+        const result = await sessionContextMenu.checkoutToBranch('feature/test', createOutputChannel());
+
+        assert.strictEqual(result, false);
+        assert.strictEqual((repo.fetch as sinon.SinonStub).called, false);
+    });
+
+    test('fetchBranchInfoFromPR returns null when no PR URL is available', async () => {
+        const session: Partial<Session> = { name: 'session-1', title: 'Session 1' };
+
+        const result = await sessionContextMenu.fetchBranchInfoFromPR(session as Session, createOutputChannel());
+
+        assert.strictEqual(result, null);
+    });
+
+    test('fetchBranchInfoFromPR returns null when token is unavailable', async () => {
+        const session: Partial<Session> = {
+            name: 'session-2',
+            title: 'Session 2',
+            outputs: [{ pullRequest: { url: 'https://github.com/owner/repo/pull/123' } } as any]
+        };
+        sandbox.stub(GitHubAuth, 'getToken').resolves(undefined);
+
+        const result = await sessionContextMenu.fetchBranchInfoFromPR(session as Session, createOutputChannel());
+
+        assert.strictEqual(result, null);
+    });
+
+    test('fetchBranchInfoFromPR returns branch info when API call succeeds', async () => {
+        const session: Partial<Session> = {
+            name: 'session-3',
+            title: 'Session 3',
+            outputs: [{ pullRequest: { url: 'https://github.com/owner/repo/pull/123' } } as any]
+        };
+        const branchInfo: PullRequestBranchInfo = {
+            headBranch: 'feature/pr-123',
+            baseBranch: 'main',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo.git',
+            state: 'open',
+            title: 'Test PR'
+        };
+        sandbox.stub(GitHubAuth, 'getToken').resolves('token');
+        sandbox.stub(githubUtils, 'getPullRequestBranchInfo').resolves(branchInfo);
+
+        const result = await sessionContextMenu.fetchBranchInfoFromPR(session as Session, createOutputChannel());
+
+        assert.deepStrictEqual(result, branchInfo);
+        assert.strictEqual((githubUtils.getPullRequestBranchInfo as sinon.SinonStub).calledOnceWithExactly('token', 'owner', 'repo', 123), true);
+    });
+
+    test('checkoutToBranchForSession falls back to the session branch when GitHub API is unavailable', async () => {
+        const repo = createRepository();
+        stubGitExtension([repo]);
+        sandbox.stub(GitHubAuth, 'getToken').resolves(undefined);
+        const session: Partial<Session> = {
+            name: 'session-4',
+            title: 'Session 4',
+            outputs: [{ pullRequest: { url: 'https://github.com/owner/repo/pull/123' } } as any],
+            sourceContext: {
+                githubRepoContext: { startingBranch: 'feature/fallback' }
+            } as any
+        };
+
+        const result = await sessionContextMenu.checkoutToBranchForSession(session as Session, createOutputChannel());
+
+        assert.strictEqual(result, true);
+        assert.strictEqual((repo.checkout as sinon.SinonStub).calledWithExactly('feature/fallback'), true);
+    });
+
+    test('checkoutToBranchForSession returns false when no branch information exists anywhere', async () => {
+        const repo = createRepository();
+        stubGitExtension([repo]);
+        sandbox.stub(GitHubAuth, 'getToken').resolves(undefined);
+        const session: Partial<Session> = {
+            name: 'session-5',
+            title: 'Session 5'
+        };
+
+        const result = await sessionContextMenu.checkoutToBranchForSession(session as Session, createOutputChannel());
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(showErrorMessageStub.called, true);
+    });
+
+    test('checkoutToBranchForSession uses PR branch info and remote tracking checkout', async () => {
+        const repo = createRepository({
+            state: {
+                HEAD: { name: 'main' },
+                workingTreeChanges: [],
+                indexChanges: [],
+                remotes: [{ remote: 'origin', fetchUrl: 'https://github.com/fork-owner/fork-repo.git' }]
+            },
+            checkout: sandbox.stub().onFirstCall().rejects(new Error('pathspec did not match any file(s) known to git')).onSecondCall().resolves(),
+            fetch: sandbox.stub().resolves()
+        });
+        stubGitExtension([repo]);
+        sandbox.stub(GitHubAuth, 'getToken').resolves('token');
+        sandbox.stub(githubUtils, 'getPullRequestBranchInfo').resolves({
+            headBranch: 'feature/pr-123',
+            baseBranch: 'main',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo.git',
+            state: 'open',
+            title: 'Test PR'
+        });
+        const session: Partial<Session> = {
+            name: 'session-6',
+            title: 'Session 6',
+            outputs: [{ pullRequest: { url: 'https://github.com/owner/repo/pull/123' } } as any]
+        };
+
+        const result = await sessionContextMenu.checkoutToBranchForSession(session as Session, createOutputChannel());
+
+        assert.strictEqual(result, true);
+        assert.strictEqual((repo.fetch as sinon.SinonStub).calledOnceWithExactly('origin'), true);
+        assert.strictEqual((repo.checkout as sinon.SinonStub).callCount, 1);
+        assert.strictEqual((repo.createBranch as sinon.SinonStub).calledOnce, true);
+    });
+
+    test('checkoutToBranchForSession returns false when fork remote addition is cancelled', async () => {
+        const repo = createRepository({
+            state: {
+                HEAD: { name: 'main' },
+                workingTreeChanges: [],
+                indexChanges: [],
+                remotes: []
+            }
+        });
+        stubGitExtension([repo]);
+        sandbox.stub(GitHubAuth, 'getToken').resolves('token');
+        sandbox.stub(githubUtils, 'getPullRequestBranchInfo').resolves({
+            headBranch: 'feature/pr-123',
+            baseBranch: 'main',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo.git',
+            state: 'open',
+            title: 'Test PR'
+        });
+        showInformationMessageStub.resolves('Cancel');
+        const session: Partial<Session> = {
+            name: 'session-7',
+            title: 'Session 7',
+            outputs: [{ pullRequest: { url: 'https://github.com/owner/repo/pull/123' } } as any]
+        };
+
+        const result = await sessionContextMenu.checkoutToBranchForSession(session as Session, createOutputChannel());
+
+        assert.strictEqual(result, false);
+    });
+
+    test('openPullRequestInBrowser handles success and failure paths', async () => {
+        openExternalStub.onFirstCall().resolves(true);
+        openExternalStub.onSecondCall().resolves(false);
+
+        await sessionContextMenu.openPullRequestInBrowser('https://github.com/owner/repo/pull/123');
+        await sessionContextMenu.openPullRequestInBrowser('https://github.com/owner/repo/pull/456');
+
+        assert.strictEqual(openExternalStub.callCount, 2);
+        assert.strictEqual(showErrorMessageStub.calledOnce, true);
+    });
+});

--- a/src/test/sessionContextMenuArtifacts.unit.test.ts
+++ b/src/test/sessionContextMenuArtifacts.unit.test.ts
@@ -2,7 +2,8 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import * as sinon from "sinon";
 import * as path from "path";
-import { resolveWorkspaceFile, JulesDiffDocumentProvider } from "../sessionContextMenuArtifacts";
+import * as sessionArtifacts from "../sessionArtifacts";
+import { openChangesetForSession, openLatestDiffForSession, resolveWorkspaceFile, JulesDiffDocumentProvider } from "../sessionContextMenuArtifacts";
 
 suite("Session Context Menu Artifacts Security Suite", () => {
     let sandbox: sinon.SinonSandbox;
@@ -233,5 +234,180 @@ suite("JulesDiffDocumentProvider", () => {
         
         provider.setContent(uri, "updated");
         assert.strictEqual(provider.provideTextDocumentContent(uri), "updated");
+    });
+});
+
+suite("Session Context Menu Artifacts Openers", () => {
+    let sandbox: sinon.SinonSandbox;
+    let showErrorMessageStub: sinon.SinonStub;
+    let showQuickPickStub: sinon.SinonStub;
+    let withProgressStub: sinon.SinonStub;
+    let executeCommandStub: sinon.SinonStub;
+    let openTextDocumentStub: sinon.SinonStub;
+    let showTextDocumentStub: sinon.SinonStub;
+    let workspaceFoldersStub: sinon.SinonStub;
+    let fsStatStub: sinon.SinonStub;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
+        showQuickPickStub = sandbox.stub(vscode.window, "showQuickPick");
+        withProgressStub = sandbox.stub(vscode.window, "withProgress");
+        executeCommandStub = sandbox.stub(vscode.commands, "executeCommand");
+        openTextDocumentStub = sandbox.stub(vscode.workspace, "openTextDocument");
+        showTextDocumentStub = sandbox.stub(vscode.window, "showTextDocument");
+        workspaceFoldersStub = sandbox.stub(vscode.workspace, "workspaceFolders").value([]);
+        fsStatStub = sandbox.stub();
+        sandbox.stub(vscode.workspace, "fs").value({
+            stat: fsStatStub,
+            readDirectory: sandbox.stub(),
+            readFile: sandbox.stub(),
+            writeFile: sandbox.stub(),
+            delete: sandbox.stub(),
+            rename: sandbox.stub(),
+            copy: sandbox.stub(),
+            createDirectory: sandbox.stub(),
+            isWritableFileSystem: sandbox.stub()
+        });
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    function createLogChannel() {
+        return {
+            appendLine: sandbox.stub(),
+            append: sandbox.stub(),
+            clear: sandbox.stub(),
+            replace: sandbox.stub(),
+            dispose: sandbox.stub(),
+            show: sandbox.stub(),
+            hide: sandbox.stub(),
+            name: "test"
+        } as unknown as vscode.OutputChannel;
+    }
+
+    test("openLatestDiffForSession rejects invalid session IDs", async () => {
+        await openLatestDiffForSession({
+            sessionId: "bad id",
+            apiKey: "token",
+            apiBaseUrl: "https://api.example.com",
+            logChannel: createLogChannel(),
+            diffProvider: new JulesDiffDocumentProvider()
+        });
+
+        assert.strictEqual(showErrorMessageStub.calledOnceWithExactly("Invalid session ID."), true);
+        assert.strictEqual(withProgressStub.called, false);
+    });
+
+    test("openLatestDiffForSession opens a cached diff document", async () => {
+        const diffProvider = new JulesDiffDocumentProvider();
+        const leftUri = diffProvider.buildUri("sessions/test-123", "before");
+        const rightUri = diffProvider.buildUri("sessions/test-123", "after");
+        const artifacts = { latestDiff: "diff --git a/file.ts b/file.ts" };
+
+        withProgressStub.callsFake(async (_options: unknown, callback: () => Promise<typeof artifacts>) => callback());
+        sandbox.stub(sessionArtifacts, "getCachedSessionArtifacts").returns(artifacts as any);
+
+        await openLatestDiffForSession({
+            sessionId: "sessions/test-123",
+            sessionTitle: "Test Session",
+            apiKey: "token",
+            apiBaseUrl: "https://api.example.com",
+            logChannel: createLogChannel(),
+            diffProvider
+        });
+
+        assert.strictEqual(executeCommandStub.calledOnce, true);
+        assert.strictEqual(executeCommandStub.firstCall.args[0], "vscode.diff");
+        assert.strictEqual((executeCommandStub.firstCall.args[1] as vscode.Uri).toString(), leftUri.toString());
+        assert.strictEqual((executeCommandStub.firstCall.args[2] as vscode.Uri).toString(), rightUri.toString());
+        assert.strictEqual(executeCommandStub.firstCall.args[3], "Latest Diff: Test Session");
+    });
+
+    test("openLatestDiffForSession shows an error when no diff is available", async () => {
+        withProgressStub.callsFake(async (_options: unknown, callback: () => Promise<unknown>) => callback());
+        sandbox.stub(sessionArtifacts, "getCachedSessionArtifacts").returns({ latestDiff: undefined } as any);
+        sandbox.stub(sessionArtifacts, "fetchLatestSessionArtifacts").resolves({ latestDiff: undefined } as any);
+
+        await openLatestDiffForSession({
+            sessionId: "sessions/test-456",
+            apiKey: "token",
+            apiBaseUrl: "https://api.example.com",
+            logChannel: createLogChannel(),
+            diffProvider: new JulesDiffDocumentProvider()
+        });
+
+        assert.strictEqual(showErrorMessageStub.calledOnceWithExactly("No diff available for this session."), true);
+        assert.strictEqual(executeCommandStub.called, false);
+    });
+
+    test("openChangesetForSession shows an error when no files exist", async () => {
+        withProgressStub.callsFake(async (_options: unknown, callback: () => Promise<unknown>) => callback());
+        sandbox.stub(sessionArtifacts, "getCachedSessionArtifacts").returns({ latestChangeSet: { files: [] } } as any);
+
+        await openChangesetForSession({
+            sessionId: "sessions/test-789",
+            apiKey: "token",
+            apiBaseUrl: "https://api.example.com",
+            logChannel: createLogChannel()
+        });
+
+        assert.strictEqual(showErrorMessageStub.calledOnceWithExactly("No files found in changeset."), true);
+    });
+
+    test("openChangesetForSession opens a selected file from the workspace", async () => {
+        const rootPath = path.resolve("/Users/hirokimukai/Cloudprojects/jules-extension");
+        workspaceFoldersStub.value([
+            { uri: vscode.Uri.file(rootPath), name: "workspace", index: 0 }
+        ]);
+        fsStatStub.withArgs(sinon.match((uri: vscode.Uri) => uri.fsPath === path.resolve(rootPath, "src/sessionContextMenu.ts"))).resolves({ type: vscode.FileType.File });
+        withProgressStub.callsFake(async (_options: unknown, callback: () => Promise<unknown>) => callback());
+        sandbox.stub(sessionArtifacts, "getCachedSessionArtifacts").returns({
+            latestChangeSet: {
+                files: [
+                    { path: "src/sessionContextMenu.ts", status: "modified" }
+                ]
+            }
+        } as any);
+        showQuickPickStub.resolves({ label: "src/sessionContextMenu.ts", description: "modified", filePath: "src/sessionContextMenu.ts" } as any);
+        openTextDocumentStub.resolves({ uri: vscode.Uri.file(path.resolve(rootPath, "src/sessionContextMenu.ts")) } as any);
+        showTextDocumentStub.resolves(undefined);
+
+        await openChangesetForSession({
+            sessionId: "sessions/test-999",
+            apiKey: "token",
+            apiBaseUrl: "https://api.example.com",
+            logChannel: createLogChannel(),
+            sessionTitle: "Test Session"
+        });
+
+        assert.strictEqual(showQuickPickStub.calledOnce, true);
+        assert.strictEqual(openTextDocumentStub.calledOnce, true);
+        assert.strictEqual(showTextDocumentStub.calledOnce, true);
+        assert.strictEqual(showErrorMessageStub.called, false);
+    });
+
+    test("openChangesetForSession shows an error when the selected file is missing", async () => {
+        withProgressStub.callsFake(async (_options: unknown, callback: () => Promise<unknown>) => callback());
+        sandbox.stub(sessionArtifacts, "getCachedSessionArtifacts").returns({
+            latestChangeSet: {
+                files: [
+                    { path: "src/does-not-exist.ts", status: "modified" }
+                ]
+            }
+        } as any);
+        showQuickPickStub.resolves({ label: "src/does-not-exist.ts", description: "modified", filePath: "src/does-not-exist.ts" } as any);
+
+        await openChangesetForSession({
+            sessionId: "sessions/test-1000",
+            apiKey: "token",
+            apiBaseUrl: "https://api.example.com",
+            logChannel: createLogChannel()
+        });
+
+        assert.strictEqual(showErrorMessageStub.calledOnceWithExactly("File not found in workspace (or invalid path)."), true);
+        assert.strictEqual(openTextDocumentStub.called, false);
     });
 });

--- a/src/test/sessionContextMenuArtifacts.unit.test.ts
+++ b/src/test/sessionContextMenuArtifacts.unit.test.ts
@@ -358,7 +358,7 @@ suite("Session Context Menu Artifacts Openers", () => {
     });
 
     test("openChangesetForSession opens a selected file from the workspace", async () => {
-        const rootPath = path.resolve("/Users/hirokimukai/Cloudprojects/jules-extension");
+        const rootPath = path.resolve("/tmp/test-workspace");
         workspaceFoldersStub.value([
             { uri: vscode.Uri.file(rootPath), name: "workspace", index: 0 }
         ]);
@@ -390,6 +390,11 @@ suite("Session Context Menu Artifacts Openers", () => {
     });
 
     test("openChangesetForSession shows an error when the selected file is missing", async () => {
+        const rootPath = path.resolve("/tmp/test-workspace");
+        workspaceFoldersStub.value([
+            { uri: vscode.Uri.file(rootPath), name: "workspace", index: 0 }
+        ]);
+        fsStatStub.rejects(vscode.FileSystemError.FileNotFound());
         withProgressStub.callsFake(async (_options: unknown, callback: () => Promise<unknown>) => callback());
         sandbox.stub(sessionArtifacts, "getCachedSessionArtifacts").returns({
             latestChangeSet: {


### PR DESCRIPTION
sessionContextMenu の checkout / PR フローと sessionContextMenuArtifacts の opener を追加でテストし、カバレッジを底上げしました。

- checkoutToBranch / checkoutToBranchForSession / fetchBranchInfoFromPR の分岐を追加検証
- openLatestDiffForSession / openChangesetForSession の成功・失敗分岐を追加検証
- `pnpm run check-types`
- `pnpm run lint`
- `pnpm run test:coverage`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `sessionContextMenu` の checkout / PR フローと `sessionContextMenuArtifacts` のオープン系関数に対するユニットテストを大幅に追加し、カバレッジを強化するものです。テスト全体の設計は適切で、モック戦略や分岐検証は実装と正しく整合しています。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テスト専用の変更であり、プロダクションコードへの影響はありません。P2 指摘が 2 件ありますが、マージに支障はありません。

P2 のみが存在し、P0/P1 はなし。発見された問題はハードコードされた開発者固有パスとテストシナリオの意図ずれで、実際の動作には影響しません。

src/test/sessionContextMenuArtifacts.unit.test.ts（ハードコードパスとシナリオ誤りの 2 点）
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/sessionContextMenu.checkout.unit.test.ts | 新規テストファイル。checkoutToBranch / checkoutToBranchForSession / fetchBranchInfoFromPR / selectRepository / handleUncommittedChanges の主要分岐を網羅しており、実装との整合性も確認できた。 |
| src/test/sessionContextMenuArtifacts.unit.test.ts | openLatestDiffForSession / openChangesetForSession のテストを追加。開発者固有の絶対パスのハードコードと「ファイルなし」テストのシナリオ誤りの 2 点が P2 として存在する。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[checkoutToBranchForSession] --> B{Git拡張利用可能?}
    B -- No --> Z1[エラー表示 / false]
    B -- Yes --> C{リポジトリ選択}
    C -- キャンセル --> Z2[false]
    C -- 選択済み --> D[fetchBranchInfoFromPR]
    D --> E{PR URL 有り?}
    E -- No --> F[フォールバック: セッションブランチ]
    E -- Yes --> G{GitHubトークン取得}
    G -- 失敗 --> F
    G -- 成功 --> H[getPullRequestBranchInfo API]
    H --> I{branchInfo 取得?}
    I -- No --> F
    I -- Yes --> J[fetchAndCheckoutFromPRInfo]
    J --> K{一致リモートあり?}
    K -- Yes --> L[fetch + checkout/createBranch]
    K -- No --> M{フォーク追加確認}
    M -- キャンセル --> Z3[false]
    M -- 追加 --> N[addRemote + fetch + checkout]
    N --> Z4[true]
    L --> Z4
    F --> O{ブランチ名あり?}
    O -- No --> Z5[エラー表示 / false]
    O -- Yes --> P[performCheckout]
    P --> Q{ローカルに存在?}
    Q -- Yes --> Z4
    Q -- No --> R{fetch & checkout確認}
    R -- キャンセル --> Z3
    R -- 実行 --> S[fetch + checkout]
    S --> Z4
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/test/sessionContextMenuArtifacts.unit.test.ts
Line: 338-340

Comment:
**特定の開発者マシンパスがハードコードされています**

`rootPath` に `/Users/hirokimukai/Cloudprojects/jules-extension` という絶対パスが直書きされています。このテストはモックを使っているため他の環境でも動作しますが、コードレビュー時に意図が伝わりにくく、今後のメンテナンス時に混乱を招く可能性があります。`os.tmpdir()` などを使った汎用的なパス、または単純な `/tmp/test-workspace` のような架空パスに置き換えることを推奨します。

```suggestion
        const rootPath = "/tmp/test-workspace";
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/test/sessionContextMenuArtifacts.unit.test.ts
Line: 386-409

Comment:
**「ファイルが見つからない」テストが実際には「ワークスペースフォルダなし」のシナリオを検証しています**

`setup()` で `workspaceFoldersStub.value([])` が設定されており、このテストでは上書きされていません。そのため `resolveWorkspaceFileAsync` は `folders.length === 0` で早期 `return null` を返し、「ワークスペースフォルダが空」のパスを通ります。本来テストしたい「ワークスペースには該当フォルダがあるがファイルが存在しない」シナリオ（`fs.stat` がエラーを throw するパス）とは異なります。意図どおりであればテスト名を修正してください。

```suggestion
    test("openChangesetForSession shows an error when workspace has no folders", async () => {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: expand session context menu covera..."](https://github.com/hiroki-org/jules-extension/commit/2644067abedd54b54862b51b11f24df68e4dfdd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29716197)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->