### PR TITLE
feat: support single activity fetch for issue #485

### DIFF
--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -213,6 +213,8 @@ export function buildChatMessagesFromActivities(
       getActivityLabelPrefix(activity) +
       getActivitySummaryText(activity);
     let detailsHtml = "";
+    // TODO(issue-485): detailsはUI上で折りたたまれているが、HTML自体はここで先に生成している。
+    // 大きなplan/diff/bashOutputは展開時に個別取得する遅延読み込みへ移行可能。
     if (activity.sessionFailed?.reason) {
       detailsHtml +=
         '<details class="activity-details"><summary>View Error Details</summary><div class="details-content code-block"><pre><code>' +

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3096,6 +3096,8 @@ export function activate(context: vscode.ExtensionContext) {
             showPaginationProgress: true,
           },
         );
+        // TODO(issue-485): ページング取得で欠損/破損した activity がある場合、
+        // fetchSingleActivity(apiKey, sessionId, activityId) で対象のみ再取得して回復できる。
 
         const mergedActivities = shouldMergeWithCache
           ? mergeActivitiesByIdentity(cachedActivities, newActivities)

--- a/src/julesApiClient.ts
+++ b/src/julesApiClient.ts
@@ -44,8 +44,13 @@ export class JulesApiClient {
         return this.request<SourceType>(`/${sourceName}`);
     }
 
-    async getActivity(sessionId: string, activityId: string): Promise<Activity> {
-        return this.request<Activity>(`/${sessionId}/activities/${activityId}`);
+    /**
+     * Fetch a single activity detail.
+     * @param sessionName Full session resource name in the form `sessions/{id}`.
+     * @param activityId Activity identifier as a single raw path segment; encoded by this client.
+     */
+    async getActivity(sessionName: string, activityId: string): Promise<Activity> {
+        return this.request<Activity>(`/${sessionName}/activities/${encodeURIComponent(activityId)}`);
     }
 
     async listSources(options: ListSourcesOptions = {}): Promise<SourcesListResponse> {

--- a/src/julesApiClient.ts
+++ b/src/julesApiClient.ts
@@ -1,4 +1,5 @@
 import { Source as SourceType } from './types';
+import type { Activity } from './types';
 import { fetchWithTimeout } from './fetchUtils';
 
 interface SourcesListResponse {
@@ -41,6 +42,10 @@ export class JulesApiClient {
 
     async getSource(sourceName: string): Promise<SourceType> {
         return this.request<SourceType>(`/${sourceName}`);
+    }
+
+    async getActivity(sessionId: string, activityId: string): Promise<Activity> {
+        return this.request<Activity>(`/${sessionId}/activities/${activityId}`);
     }
 
     async listSources(options: ListSourcesOptions = {}): Promise<SourcesListResponse> {

--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -151,15 +151,15 @@ export async function sendMessage(
  */
 export async function fetchSingleActivity(
   apiKey: string,
-  sessionId: string,
+  sessionName: string,
   activityId: string,
 ): Promise<Activity> {
   const client = new JulesApiClient(apiKey, JULES_API_BASE_URL);
 
   try {
-    return await client.getActivity(sessionId, activityId);
+    return await client.getActivity(sessionName, activityId);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to fetch activity: ${message}`);
+    throw new Error(`Failed to fetch activity: ${message}`, { cause: error });
   }
 }

--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -1,8 +1,9 @@
 import * as vscode from "vscode";
 import { fetchWithTimeout } from "./fetchUtils";
 import { buildFinalPrompt } from "./promptUtils";
-import { SourceType } from "./types";
+import { Activity, SourceType } from "./types";
 import { JULES_API_BASE_URL } from "./julesApiConstants";
+import { JulesApiClient } from "./julesApiClient";
 
 export interface CreateSessionRequest {
   prompt: string;
@@ -142,5 +143,23 @@ export async function sendMessage(
     const errorText = await response.text();
     const message = errorText || `${response.status} ${response.statusText}`;
     throw new Error(message);
+  }
+}
+
+/**
+ * Fetch a single activity detail by activity ID.
+ */
+export async function fetchSingleActivity(
+  apiKey: string,
+  sessionId: string,
+  activityId: string,
+): Promise<Activity> {
+  const client = new JulesApiClient(apiKey, JULES_API_BASE_URL);
+
+  try {
+    return await client.getActivity(sessionId, activityId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to fetch activity: ${message}`);
   }
 }

--- a/src/test/julesApiClient.unit.test.ts
+++ b/src/test/julesApiClient.unit.test.ts
@@ -55,12 +55,12 @@ suite('JulesApiClient Test Suite', () => {
 
     suite('getActivity', () => {
         test('should make correct request', async () => {
-            const sessionId = 'sessions/abc123';
+            const sessionName = 'sessions/abc123';
             const activityId = 'activity-1';
             const mockResponse = {
                 ok: true,
                 json: async () => ({
-                    name: `${sessionId}/activities/${activityId}`,
+                    name: `${sessionName}/activities/${activityId}`,
                     createTime: '2026-01-01T00:00:00Z',
                     id: activityId,
                     description: 'activity detail'
@@ -68,14 +68,32 @@ suite('JulesApiClient Test Suite', () => {
             };
             fetchStub.resolves(mockResponse);
 
-            const result = await client.getActivity(sessionId, activityId);
+            const result = await client.getActivity(sessionName, activityId);
 
             assert.strictEqual(fetchStub.calledOnce, true);
             const [url, options] = fetchStub.firstCall.args;
-            assert.strictEqual(url, `${baseUrl}/${sessionId}/activities/${activityId}`);
+            assert.strictEqual(url, `${baseUrl}/${sessionName}/activities/${activityId}`);
             assert.strictEqual(options.headers['X-Goog-Api-Key'], apiKey);
             assert.strictEqual(options.headers['Content-Type'], 'application/json');
             assert.strictEqual(result.id, activityId);
+        });
+
+        test('should encode activity ID path segment', async () => {
+            const sessionName = 'sessions/abc123';
+            const activityId = 'activity with/slash';
+            fetchStub.resolves({
+                ok: true,
+                json: async () => ({
+                    name: `${sessionName}/activities/${activityId}`,
+                    createTime: '2026-01-01T00:00:00Z',
+                    id: activityId,
+                })
+            });
+
+            await client.getActivity(sessionName, activityId);
+
+            const [url] = fetchStub.firstCall.args;
+            assert.strictEqual(url, `${baseUrl}/${sessionName}/activities/activity%20with%2Fslash`);
         });
 
         test('should throw error on API failure', async () => {

--- a/src/test/julesApiClient.unit.test.ts
+++ b/src/test/julesApiClient.unit.test.ts
@@ -53,6 +53,54 @@ suite('JulesApiClient Test Suite', () => {
         });
     });
 
+    suite('getActivity', () => {
+        test('should make correct request', async () => {
+            const sessionId = 'sessions/abc123';
+            const activityId = 'activity-1';
+            const mockResponse = {
+                ok: true,
+                json: async () => ({
+                    name: `${sessionId}/activities/${activityId}`,
+                    createTime: '2026-01-01T00:00:00Z',
+                    id: activityId,
+                    description: 'activity detail'
+                })
+            };
+            fetchStub.resolves(mockResponse);
+
+            const result = await client.getActivity(sessionId, activityId);
+
+            assert.strictEqual(fetchStub.calledOnce, true);
+            const [url, options] = fetchStub.firstCall.args;
+            assert.strictEqual(url, `${baseUrl}/${sessionId}/activities/${activityId}`);
+            assert.strictEqual(options.headers['X-Goog-Api-Key'], apiKey);
+            assert.strictEqual(options.headers['Content-Type'], 'application/json');
+            assert.strictEqual(result.id, activityId);
+        });
+
+        test('should throw error on API failure', async () => {
+            fetchStub.resolves({
+                ok: false,
+                status: 404,
+                statusText: 'Not Found'
+            });
+
+            await assert.rejects(
+                client.getActivity('sessions/missing', 'activity-404'),
+                new Error('API request failed: 404 Not Found')
+            );
+        });
+
+        test('should throw error on network failure', async () => {
+            fetchStub.rejects(new Error('Network failure'));
+
+            await assert.rejects(
+                client.getActivity('sessions/abc123', 'activity-1'),
+                new Error('Network failure')
+            );
+        });
+    });
+
     suite('listAllSources', () => {
         test('should paginate through all sources with pageSize=100', async () => {
             fetchStub.onFirstCall().resolves({

--- a/src/test/sessionUtils.unit.test.ts
+++ b/src/test/sessionUtils.unit.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import * as sinon from "sinon";
-import { createJulesSession, sendMessage } from "../sessionUtils";
+import { createJulesSession, fetchSingleActivity, sendMessage } from "../sessionUtils";
 import * as fetchUtils from "../fetchUtils";
 
 suite("sessionUtils Test Suite", () => {
@@ -114,5 +114,37 @@ suite("sessionUtils Test Suite", () => {
         } catch (error: any) {
             assert.ok(error.message.includes("Session not found"));
         }
+    });
+
+    test("fetchSingleActivity returns activity details", async () => {
+        fetchStub.resolves({
+            ok: true,
+            json: async () => ({
+                name: "sessions/123/activities/a1",
+                createTime: "2026-01-01T00:00:00Z",
+                id: "a1",
+            }),
+        } as Response);
+
+        const activity = await fetchSingleActivity("dummy-key", "sessions/123", "a1");
+
+        assert.strictEqual(activity.id, "a1");
+        const [url, options] = fetchStub.firstCall.args;
+        assert.strictEqual(url, "https://jules.googleapis.com/v1alpha/sessions/123/activities/a1");
+        assert.strictEqual(options.headers["X-Goog-Api-Key"], "dummy-key");
+    });
+
+    test("fetchSingleActivity throws wrapped error on failure", async () => {
+        fetchStub.resolves({
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+            json: async () => ({}),
+        } as Response);
+
+        await assert.rejects(
+            fetchSingleActivity("dummy-key", "sessions/missing", "a404"),
+            /Failed to fetch activity: API request failed: 404 Not Found/
+        );
     });
 });

--- a/src/test/sessionUtils.unit.test.ts
+++ b/src/test/sessionUtils.unit.test.ts
@@ -147,4 +147,23 @@ suite("sessionUtils Test Suite", () => {
             /Failed to fetch activity: API request failed: 404 Not Found/
         );
     });
+
+    test("fetchSingleActivity preserves original error as cause", async () => {
+        fetchStub.resolves({
+            ok: false,
+            status: 500,
+            statusText: "Internal Server Error",
+            json: async () => ({}),
+        } as Response);
+
+        await assert.rejects(
+            async () => fetchSingleActivity("dummy-key", "sessions/missing", "a500"),
+            (error: Error & { cause?: unknown }) => {
+                assert.ok(error.message.includes("Failed to fetch activity:"));
+                assert.ok(error.cause instanceof Error);
+                assert.ok((error.cause as Error).message.includes("API request failed: 500 Internal Server Error"));
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
## Summary
- add getActivity(sessionId, activityId) to Jules API client
- add fetchSingleActivity(...) utility for targeted activity recovery
- add unit tests for both client and utility
- document lazy-loading integration points in activity/chat flow

## Validation
- pnpm run check-types
- pnpm run test:unit

Fixes #485

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはJulesAPIクライアントに`getActivity(sessionId, activityId)`メソッドを追加し、`fetchSingleActivity`ユーティリティ関数でラップすることで、ページング取得で欠損した単一アクティビティを個別に再取得できるようにします。ロジック自体は正しく、ユニットテストも充実していますが、P2レベルの命名の不統一が1点あります。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

P2のみのため、マージは安全です。

ロジックバグやセキュリティ問題はなく、テストカバレッジも十分です。`sessionId` vs `sessionName` の命名不統一はP2レベルのスタイル問題のみで、実害はありません。

src/julesApiClient.ts と src/sessionUtils.ts のパラメータ命名を統一するか確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/julesApiClient.ts | `getActivity(sessionId, activityId)` を追加。URL 構築ロジックは正しいが、`sessionId` というパラメータ名が実態（完全リソースパス）と乖離しており、誤用を招く可能性あり。 |
| src/sessionUtils.ts | `fetchSingleActivity` 関数を追加。エラーハンドリングは適切だが、`sessionId` の命名が既存の `sessionName` と不統一。他の関数と異なり `JulesApiClient` を都度インスタンス化している。 |
| src/chatView.ts | 将来の遅延読み込み対応を示す TODO コメントを追加のみ。ロジック変更なし。 |
| src/extension.ts | `fetchSingleActivity` の利用箇所を示す TODO コメントを追加のみ。ロジック変更なし。 |
| src/test/julesApiClient.unit.test.ts | `getActivity` の正常系・404 エラー・ネットワーク障害の 3 テストを追加。カバレッジ十分。 |
| src/test/sessionUtils.unit.test.ts | `fetchSingleActivity` の成功・失敗テストを追加。URL やヘッダーの検証も含まれており適切。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as 呼び出し元 (extension.ts)
    participant FSA as fetchSingleActivity (sessionUtils.ts)
    participant JAC as JulesApiClient
    participant API as Jules API

    Caller->>FSA: fetchSingleActivity(apiKey, sessionId, activityId)
    FSA->>JAC: new JulesApiClient(apiKey, baseUrl)
    FSA->>JAC: getActivity(sessionId, activityId)
    JAC->>API: GET /{sessionId}/activities/{activityId}
    alt 成功
        API-->>JAC: Activity JSON
        JAC-->>FSA: Activity
        FSA-->>Caller: Activity
    else 失敗 (404など)
        API-->>JAC: エラーレスポンス
        JAC-->>FSA: Error("API request failed: 404 Not Found")
        FSA-->>Caller: Error("Failed to fetch activity: API request failed: 404 Not Found")
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/julesApiClient.ts
Line: 47-49

Comment:
**パラメータ名 `sessionId` が実際の値と不一致**

`sessionId` という名前は ID（例: `abc123`）を示唆しますが、実際にはテストコードでも確認できるように `sessions/abc123` という完全なリソースパス（resource name）が渡されます。既存の `sendMessage` 関数では同様のパラメータを `sessionName` と命名しており、不一致が生じています。bare ID のみを渡すと、URLが `/abc123/activities/...` になりリクエストが 404 になります。

```suggestion
    async getActivity(sessionName: string, activityId: string): Promise<Activity> {
        return this.request<Activity>(`/${sessionName}/activities/${activityId}`);
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/sessionUtils.ts
Line: 152-165

Comment:
**`fetchSingleActivity` の `sessionId` も同様に不一致**

`julesApiClient.ts` の `getActivity` と同じく、このパラメータ名 `sessionId` はリソースパス（`sessions/abc123` 形式）を受け取りますが、bare ID と誤解されやすいです。既存の `sendMessage` の `sessionName` に揃えることを推奨します。また、同ファイル内の他の関数（`createJulesSession`、`sendMessage`）は `fetchWithTimeout` を直接使う一方、この関数だけ `JulesApiClient` のインスタンスを毎回生成しており、コーディングスタイルが不統一です。

```suggestion
export async function fetchSingleActivity(
  apiKey: string,
  sessionName: string,
  activityId: string,
): Promise<Activity> {
  const client = new JulesApiClient(apiKey, JULES_API_BASE_URL);

  try {
    return await client.getActivity(sessionName, activityId);
  } catch (error) {
    const message = error instanceof Error ? error.message : String(error);
    throw new Error(`Failed to fetch activity: ${message}`);
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add single activity fetch support ..."](https://github.com/hiroki-org/jules-extension/commit/638bf94a8fe6033e4f733bd8b9feb824cfa347f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29748335)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->