### PR TITLE
perf: optimize extractPRs implementation for issue #480

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -463,14 +463,26 @@ export function extractPRs(
   if (!sessionOrState.outputs) {
     return [];
   }
-  const prMap = new Map<string, PullRequestOutput>();
+  const urlToIndex = new Map<string, number>();
+  const deduped: PullRequestOutput[] = [];
+
   for (const output of sessionOrState.outputs) {
     const pr = output.pullRequest;
-    if (pr?.url) {
-      prMap.set(pr.url, pr);
+    if (!pr?.url) {
+      continue;
     }
+    const existingIndex = urlToIndex.get(pr.url);
+    if (existingIndex === undefined) {
+      urlToIndex.set(pr.url, deduped.length);
+      deduped.push(pr);
+      continue;
+    }
+
+    // Keep first-seen URL order while replacing payload with the latest PR data.
+    deduped[existingIndex] = pr;
   }
-  return Array.from(prMap.values());
+
+  return deduped;
 }
 
 export async function checkPRStatus(


### PR DESCRIPTION
## Summary
- optimize extractPRs deduplication to avoid extra conversion and repeated scans
- keep first-seen URL order while retaining latest PR payload for duplicates
- verify behavior with existing extension helper tests

## Validation
- pnpm run check-types
- pnpm run test:unit

Fixes #480

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`extractPRs` の重複排除処理を `Map<string, PullRequestOutput>` + `Array.from()` 方式から、`Map<string, number>`（URL→インデックス）と結果配列を組み合わせた方式へ最適化しています。最終的な `Array.from()` 変換を排除し、初見 URL の順序を保持しつつ重複 URL は最新ペイロードで上書きする動作はそのまま維持されています。既存のユニットテストも通過しており、ロジック的に問題は見当たりません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージしても問題ありません。ロジックが正確で既存テストも通過しています。

変更が1ファイル・1関数に限定されており、新旧の実装は機能的に等価です。JavaScript の Map はキーの挿入順序を維持するため、旧実装も初見 URL 順序 + 最新値という同じ動作をしていましたが、新実装では `Array.from()` の変換コストを削除した点は有効な最適化です。テストがカバレッジを担保しており、P0/P1 の問題は見つかりませんでした。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `extractPRs` の重複排除ロジックを `Map<url, PR>` から `Map<url, index> + 配列` 方式へリファクタリング。最終的な `Array.from()` 変換を削除し、最初に見た URL の順序を保持しつつ最新ペイロードを保存する動作はそのまま維持している。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractPRs 開始] --> B{sessionOrState.outputs が存在?}
    B -- いいえ --> C[return 空配列]
    B -- はい --> D[urlToIndex: Map, deduped: 配列を初期化]
    D --> E[各 output をイテレート]
    E --> F{pr?.url が存在?}
    F -- いいえ --> E
    F -- はい --> G{urlToIndex に url が存在?}
    G -- いいえ 新規URL --> H[urlToIndex に index を記録\ndeduped に pr を追加]
    H --> E
    G -- はい 重複URL --> I[deduped の既存 index を\n最新 pr で上書き]
    I --> E
    E --> J[return deduped]
```

<sub>Reviews (1): Last reviewed commit: ["perf: optimize extractPRs deduplication ..."](https://github.com/hiroki-org/jules-extension/commit/b3e259f255950bed17fef7e225ba77cf0bb32c1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29748453)</sub>

<!-- /greptile_comment -->