### PR TITLE
ci: guard junit report path before codecov upload (#488)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,16 @@ jobs:
         if: matrix.node-version == 20
         run: pnpm run test:coverage
 
+      - name: Verify JUnit report exists for Codecov
+        if: always()
+        shell: bash
+        run: |
+          if [[ ! -f ./test-results/junit.xml ]]; then
+            echo "Expected JUnit report was not found at ./test-results/junit.xml"
+            ls -la ./test-results || true
+            exit 1
+          fi
+
       - name: Upload test results to Codecov
         if: always()
         uses: codecov/codecov-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,8 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Verify JUnit report exists for Codecov
-        if: always()
+        id: verify-junit
+        if: always() && matrix.node-version == 20
         shell: bash
         run: |
           if [[ ! -f ./test-results/junit.xml ]]; then
@@ -48,7 +49,7 @@ jobs:
           fi
 
       - name: Upload test results to Codecov
-        if: always()
+        if: always() && matrix.node-version == 20 && steps.verify-junit.outcome == 'success'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- add a guard step to verify ./test-results/junit.xml exists before Codecov upload
- fail fast with diagnostics when the expected test-results artifact is missing
- keep existing Codecov upload path unchanged

## Validation
- pnpm run check-types

Fixes #488

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは Codecov アップロード前に `./test-results/junit.xml` の存在を検証するガードステップを追加するものです。ただし、2つの重大な論理バグが含まれています。

- ガードステップに `if: always()` のみが設定されており、`matrix.node-version == 20` の条件がないため、`pnpm run test:unit`（node 22）では junit.xml が生成されず、node 22 の CI が常に失敗します。
- `Upload test results to Codecov` ステップも `if: always()` のままのため、ガードが `exit 1` で失敗してもアップロードは実行されてしまい、ガードが無効化されています。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

P1 バグが2件あり、このままマージすると node 22 の CI が常に失敗し、かつガードが機能しないため修正が必要

ガードステップのマトリックス条件漏れと `if: always()` による無効化という2つの P1 ロジックバグが存在する。変更はワークフローファイル1ファイルのみで影響範囲は限定的だが、いずれのバグも修正なしでは意図した動作にならない。

.github/workflows/test.yml — ガードステップの条件と Upload ステップの条件を要修正
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/test.yml | ガードステップを追加したが、マトリックス条件の考慮が不足しており node 22 CI が壊れる P1 バグと、`if: always()` によりガード自体が無効化される P1 バグの2点がある |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[テスト実行] -->|node-version == 20| B["pnpm run test:coverage\njunit.xml 生成される"]
    A -->|node-version != 20| C["pnpm run test:unit\njunit.xml 生成されない"]

    B --> D["Verify JUnit report exists\nif: always()"]
    C --> D

    D -->|"node 20: ファイルあり"| E["成功"]
    D -->|"node 22: ファイルなし"| F["exit 1 で失敗\nCI が壊れる"]

    E --> G["Upload test results\nif: always()"]
    F --> G

    G --> H["always() により常に実行\nガード無効化"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/test.yml`, line 50-56 ([link](https://github.com/hiroki-org/jules-extension/blob/7ceaaacb8fedb74f82762eb5acaeda5046fc8aee/.github/workflows/test.yml#L50-L56)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`if: always()` によりガードが無効化されている**

   `Upload test results to Codecov` ステップの条件が `if: always()` のままのため、直前のガードステップが `exit 1` で失敗しても、このステップは必ず実行されます。GitHub Actions において `always()` はジョブのステータスを無視するため、ガードの目的（junit.xml が存在しない場合にアップロードを防ぐ）が達成されません。

   ガードが効果を発揮するには、このステップの条件を `always()` から外す必要があります。例えばステップ ID を使って制御する方法があります。

   ```yaml
         - name: Verify JUnit report exists for Codecov
           id: verify-junit
           if: always() && matrix.node-version == 20
           ...

         - name: Upload test results to Codecov
           if: always() && steps.verify-junit.outcome == 'success'
           uses: codecov/codecov-action@v6
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/test.yml
   Line: 50-56

   Comment:
   **`if: always()` によりガードが無効化されている**

   `Upload test results to Codecov` ステップの条件が `if: always()` のままのため、直前のガードステップが `exit 1` で失敗しても、このステップは必ず実行されます。GitHub Actions において `always()` はジョブのステータスを無視するため、ガードの目的（junit.xml が存在しない場合にアップロードを防ぐ）が達成されません。

   ガードが効果を発揮するには、このステップの条件を `always()` から外す必要があります。例えばステップ ID を使って制御する方法があります。

   ```yaml
         - name: Verify JUnit report exists for Codecov
           id: verify-junit
           if: always() && matrix.node-version == 20
           ...

         - name: Upload test results to Codecov
           if: always() && steps.verify-junit.outcome == 'success'
           uses: codecov/codecov-action@v6
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/test.yml
Line: 40-48

Comment:
**node 22 では junit.xml が生成されないため CI が常に失敗する**

`Verify JUnit report exists for Codecov` ステップは `if: always()` で両方のマトリックス（node 20 / node 22）で実行されますが、`./test-results/junit.xml` を生成するのは `pnpm run test:coverage`（`matrix.node-version == 20` のみ）だけです。node 22 では `pnpm run test:unit` が実行されるため junit.xml は存在せず、このガードステップは常に `exit 1` で失敗し、node 22 の CI 全体が壊れます。

ガードステップに `matrix.node-version == 20` の条件を追加してください。

```suggestion
      - name: Verify JUnit report exists for Codecov
        if: always() && matrix.node-version == 20
        shell: bash
        run: |
          if [[ ! -f ./test-results/junit.xml ]]; then
            echo "Expected JUnit report was not found at ./test-results/junit.xml"
            ls -la ./test-results || true
            exit 1
          fi
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/test.yml
Line: 50-56

Comment:
**`if: always()` によりガードが無効化されている**

`Upload test results to Codecov` ステップの条件が `if: always()` のままのため、直前のガードステップが `exit 1` で失敗しても、このステップは必ず実行されます。GitHub Actions において `always()` はジョブのステータスを無視するため、ガードの目的（junit.xml が存在しない場合にアップロードを防ぐ）が達成されません。

ガードが効果を発揮するには、このステップの条件を `always()` から外す必要があります。例えばステップ ID を使って制御する方法があります。

```yaml
      - name: Verify JUnit report exists for Codecov
        id: verify-junit
        if: always() && matrix.node-version == 20
        ...

      - name: Upload test results to Codecov
        if: always() && steps.verify-junit.outcome == 'success'
        uses: codecov/codecov-action@v6
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: verify junit path before codecov upl..."](https://github.com/hiroki-org/jules-extension/commit/7ceaaacb8fedb74f82762eb5acaeda5046fc8aee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29748477)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->