### PR TITLE
chore: pin lodash override for issue #489

### DIFF
--- a/package.json
+++ b/package.json
@@ -417,12 +417,14 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "lodash": "4.18.1"
   },
   "pnpm": {
     "overrides": {
       "serialize-javascript": "^7.0.5",
-      "diff": "^8.0.3"
+      "diff": "^8.0.3",
+      "lodash": "4.18.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -418,13 +418,13 @@
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "diff": "^8.0.3",
-    "lodash": "4.18.1"
+    "lodash": "^4.18.1"
   },
   "pnpm": {
     "overrides": {
       "serialize-javascript": "^7.0.5",
       "diff": "^8.0.3",
-      "lodash": "4.18.1"
+      "lodash": "^4.18.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   serialize-javascript: ^7.0.5
   diff: ^8.0.3
-  lodash: 4.18.1
+  lodash: ^4.18.1
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   serialize-javascript: ^7.0.5
   diff: ^8.0.3
+  lodash: 4.18.1
 
 importers:
 


### PR DESCRIPTION
## Summary
- add explicit lodash override (4.18.1) for npm/yarn and pnpm
- keep dependency resolution deterministic across package managers
- refresh lockfile metadata after override update

## Validation
- pnpm install --lockfile-only
- pnpm run check-types

Fixes #489

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Issue #489 に対応するため、`lodash` を `4.18.1` に固定するオーバーライドを `package.json`（npm/yarn 向けの `overrides` および pnpm 向けの `pnpm.overrides`）と `pnpm-lock.yaml` に追加するものです。バージョン 4.18.1 は npm 上に実在する最新の lodash バージョンであることを確認しました。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は軽微で技術的に正しく、P2 指摘のみのためマージ自体は安全です。

lodash 4.18.1 の存在確認・オーバーライド構文の正確性・ロックファイルの整合性はすべて問題なし。P2 として `lodash.merge` が未対象である点と完全固定による将来パッチ受け取り不可の懸念を指摘しているが、どちらも即時のブロッカーではない。

package.json — `lodash.merge` の扱いと完全固定の意図について確認が必要。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | `overrides` と `pnpm.overrides` の両方に `lodash: "4.18.1"` を追加。バージョン自体は有効で npm に存在するが、完全固定による将来パッチ受け取り不可の懸念と `lodash.merge` が未対象という点がある。 |
| pnpm-lock.yaml | overrides セクションに `lodash: 4.18.1` を追加。ロックファイル内の実際の解決済みパッケージ (`lodash@4.18.1`) はすでに最新バージョンであったため、他の変更はなし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json overrides"] -->|"lodash: 4.18.1"| B["lodash パッケージ解決"]
    A2["pnpm.overrides"] -->|"lodash: 4.18.1"| B
    B --> C{"lodash.merge は?"}
    C -->|"別パッケージ"| D["lodash.merge@4.6.2 未オーバーライド"]
    C -->|"主パッケージ"| E["lodash@4.18.1 ロックファイルに反映済み"]
    E --> F["pnpm-lock.yaml overrides セクション更新"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: package.json
Line: 420-421

Comment:
**`lodash.merge` は上書き対象に含まれていない**

ロックファイル (`pnpm-lock.yaml`) を確認すると `lodash.merge@4.6.2` も依存関係として存在していますが、今回の `overrides` では `lodash` のみが上書き対象となっており、`lodash.merge` は対象外です。`lodash` と `lodash.merge` は npm 上で別パッケージとして扱われるため、`lodash` のオーバーライドは `lodash.merge` には適用されません。Issue #489 がプロトタイプ汚染などの脆弱性に関するものであれば、`lodash.merge` にも同様の問題が存在する可能性があります。意図的に除外している場合はコメントで理由を記載することを推奨します。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: package.json
Line: 420-421

Comment:
**正確バージョン固定と既存オーバーライドとの非一貫性**

既存の `serialize-javascript: "^7.0.5"` や `diff: "^8.0.3"` はキャレット (`^`) によるマイナー・パッチ互換範囲指定ですが、今回追加した `lodash: "4.18.1"` は完全固定です。将来的に lodash でパッチセキュリティ修正（例: 4.18.2）がリリースされた場合、このオーバーライドが原因で自動的に取り込まれなくなります。セキュリティパッチを受け取り続けたいなら `"^4.18.1"` が適切です。意図的な完全固定であれば、その理由をコメントで明示することを推奨します。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: pin lodash override for issue #48..."](https://github.com/hiroki-org/jules-extension/commit/1af0cda3a73059cd502c73aa00616fbd46a2aa66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29748504)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->