### PR TITLE
chore: pin debug override for issue #490

### DIFF
--- a/package.json
+++ b/package.json
@@ -417,12 +417,14 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "debug": "4.4.3"
   },
   "pnpm": {
     "overrides": {
       "serialize-javascript": "^7.0.5",
-      "diff": "^8.0.3"
+      "diff": "^8.0.3",
+      "debug": "4.4.3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -420,6 +420,11 @@
     "diff": "^8.0.3",
     "debug": "4.4.3"
   },
+  "resolutions": {
+    "serialize-javascript": "^7.0.5",
+    "diff": "^8.0.3",
+    "debug": "4.4.3"
+  },
   "pnpm": {
     "overrides": {
       "serialize-javascript": "^7.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   serialize-javascript: ^7.0.5
   diff: ^8.0.3
+  debug: 4.4.3
 
 importers:
 


### PR DESCRIPTION
## Summary
- add explicit debug override (4.4.3) for npm/yarn and pnpm
- make transitive debug resolution deterministic and explicit
- refresh lockfile metadata after override update

## Validation
- pnpm install --lockfile-only
- pnpm run check-types

Fixes #490

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

侵害された `debug@4.4.2`（サプライチェーン攻撃）を回避するため、npm `overrides`、Yarn `resolutions`、`pnpm.overrides` の3つすべてに `debug` を `4.4.3` へ明示的にピン留めするセキュリティ対応 PR です。`4.4.3` は npm が公式に「`4.4.1` と機能的に同一の安全な代替版」として公開したバージョンであり、ピンの選択は適切です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージ安全。セキュリティ上の理由から正しく実装された依存関係ピン留めのみの変更。

ロジックの変更はなく、侵害された debug@4.4.2 を回避するための明示的なオーバーライドを3つのパッケージマネージャーすべてに追加した、シンプルかつセキュリティ上必要な変更。バージョン 4.4.3 は npm 公式の安全な代替版であり、lockfile も一貫している。

特になし。両ファイルとも変更は最小限で正確。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | npm (overrides)・Yarn (resolutions)・pnpm (pnpm.overrides) の3つすべてに debug@4.4.3 の明示的ピンを追加。侵害された 4.4.2 を回避するためのセキュリティ対策として正しく実装されている。 |
| pnpm-lock.yaml | overrides セクションに debug: 4.4.3 の1行追加のみ。ロックファイル本体（解決済みバージョン）に変更がない点は、pnpm が既に 4.4.3 を解決していたことを示唆しており想定内の変更。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[依存関係ツリー内の debug 要求] --> B{パッケージマネージャー}
    B -->|npm| C[overrides: debug 4.4.3]
    B -->|Yarn| D[resolutions: debug 4.4.3]
    B -->|pnpm| E[pnpm.overrides: debug 4.4.3]
    C --> F[debug v4.4.3 解決済み - 安全]
    D --> F
    E --> F
    G[debug v4.4.2 - 侵害済み] -.->|ピンにより回避| F
```

<sub>Reviews (2): Last reviewed commit: ["chore: resolve merge conflict"](https://github.com/hiroki-org/jules-extension/commit/2986beb6e8259cf721308159040e7b8aa9535a54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29748523)</sub>

<!-- /greptile_comment -->