### PR TITLE
chore: codecovカバレッジ閾値を75%に上げる

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 75%
         threshold: 0.5%
     patch:
       default:


### PR DESCRIPTION
ユーザーの要望に基づき、codecovのカバレッジ閾値をautoから75%に引き上げました。

---
*PR created automatically by Jules for task [516692476044414235](https://jules.google.com/task/516692476044414235) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Codecov のプロジェクト全体カバレッジターゲットを `auto` から固定値 `75%` に変更するシンプルな設定変更です。`patch` ターゲット（90%）は変更なし。

- `auto` は現在のカバレッジを動的基準とするため、プロジェクトの現カバレッジが 75% 超の場合、この変更で実質的に閾値が引き下げられる可能性があります。意図した変更かどうか、現在の実際のカバレッジ値と照らし合わせてご確認ください。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

P2 の指摘のみのシンプルな設定変更であり、マージ自体は安全です。

変更は1行のみで影響範囲は限定的。P2 の懸念（`auto` から固定値への変更による閾値緩和の可能性）はあるものの、ランタイムエラーや重大な問題は発生しないため 4/5。

codecov.yml — 意図したカバレッジ目標値かどうか確認が必要。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| codecov.yml | プロジェクトカバレッジのターゲットを `auto` から固定値 `75%` に変更。現在のカバレッジが 75% を超えている場合は要件が緩和される可能性あり。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CIパイプライン実行] --> B[テスト実行]
    B --> C[カバレッジ計測]
    C --> D{プロジェクト全体\nカバレッジ ≥ 75%?}
    D -- Yes --> E{パッチカバレッジ\n≥ 90%?}
    D -- No --> F[❌ Codecov チェック失敗\nproject target: 75%]
    E -- Yes --> G[✅ Codecov チェック通過]
    E -- No --> H[❌ Codecov チェック失敗\npatch target: 90%]

    style F fill:#ff6b6b,color:#fff
    style H fill:#ff6b6b,color:#fff
    style G fill:#51cf66,color:#fff
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: codecov.yml
Line: 8

Comment:
**`auto` から固定値への変更で要件が緩和される可能性**

`target: auto` は現在のカバレッジ率を動的に基準とし、カバレッジの後退を防ぐ設定です。もしプロジェクトの現在のカバレッジが 75% を超えている場合、この変更によってプロジェクト全体の閾値が実質的に引き下げられ、意図せずカバレッジの低下を許容してしまう可能性があります。現在のカバレッジ率が 75% 以下であれば問題ありません。

現在のカバレッジ実績を確認した上で、75% がプロジェクトの実態に合った値かご確認ください。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update codecov project target thr..."](https://github.com/hiroki-org/jules-extension/commit/749e8b006a3682da1a64a35a4a436987267649b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29755138)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->