### PR TITLE
chore(ci): fail ci when codecov threshold is not met

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           files: ./coverage/lcov.info
           flags: unittests
           name: unit-node20
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   build-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
カバレッジの閾値が満たされていない場合にCIが失敗するようにするため、`.github/workflows/test.yml`内の`codecov-action`に対して`fail_ci_if_error: true`を設定しました。

---
*PR created automatically by Jules for task [14797247212861090780](https://jules.google.com/task/14797247212861090780) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `.github/workflows/test.yml` の `codecov/codecov-action` ステップで `fail_ci_if_error` を `false` から `true` に変更し、Codecovへのカバレッジアップロード時のエラー（ネットワーク障害・API障害など）でCIが失敗するようにします。変更自体は有益ですが、PRの説明にある「閾値未達によるCI失敗」はこのフラグではなく `codecov.yml` のステータスチェックで既に制御されています。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージ自体は安全。変更は1行でリスクは低い。

変更はシンプルかつ有益で、P2のセマンティック的な指摘のみ。動作上の問題はなく、マージ可能。

特になし。`.github/workflows/test.yml` の1行変更のみ。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/test.yml | `fail_ci_if_error` を `false` → `true` に変更。Codecovアップロードの失敗がCIに伝播するようになる有益な変更だが、閾値制御とは別の機能であることに注意。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as GitHub Actions CI
    participant Codecov as Codecov API

    CI->>Codecov: カバレッジデータをアップロード (lcov.info)
    alt アップロード成功
        Codecov-->>CI: 成功レスポンス
        Codecov->>CI: ステータスチェック (閾値判定: 75%/90%)
        CI-->>CI: ステップ成功
    else アップロードエラー (ネットワーク障害など)
        Codecov-->>CI: エラーレスポンス
        Note over CI: fail_ci_if_error: true により<br/>CIステップが失敗 (変更後)
        CI-->>CI: ❌ CIステップ失敗
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/test.yml
Line: 66

Comment:
**`fail_ci_if_error` はアップロードエラーを制御するもので、閾値違反ではありません**

PRの説明では「カバレッジの閾値が満たされていない場合にCIを失敗させる」と記載されていますが、`fail_ci_if_error: true` が制御するのはCodecovへのアップロード時のエラー（ネットワーク障害、APIトークン不正など）であり、カバレッジ閾値の違反ではありません。

カバレッジ閾値（`codecov.yml` で設定済みの `project: 75%` / `patch: 90%`）の違反は、CodecovがGitHubのステータスチェックとして報告するため、このフラグとは独立した仕組みです。`require_ci_to_pass: true` も `codecov.yml` に既に設定されています。

この変更自体は有益です（アップロードの失敗が無言でスルーされなくなる）が、閾値のCI制御という意味では既に `codecov.yml` のステータスチェックで実現されています。意図の認識を合わせておくとよいでしょう。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): fail ci when code coverage th..."](https://github.com/hiroki-org/jules-extension/commit/e0b5eb8d3cdfdfd02eee16b32e95efefd23ed0cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29755704)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->