### PR TITLE
test: sessionContextMenuのテストカバレッジを向上

### DIFF
--- a/src/test/sessionContextMenu.checkout.unit.test.ts
+++ b/src/test/sessionContextMenu.checkout.unit.test.ts
@@ -375,11 +375,13 @@ suite('sessionContextMenu checkout coverage suite', () => {
     test('openPullRequestInBrowser handles success and failure paths', async () => {
         openExternalStub.onFirstCall().resolves(true);
         openExternalStub.onSecondCall().resolves(false);
+        openExternalStub.onThirdCall().rejects(new Error('Network error'));
 
         await sessionContextMenu.openPullRequestInBrowser('https://github.com/owner/repo/pull/123');
         await sessionContextMenu.openPullRequestInBrowser('https://github.com/owner/repo/pull/456');
+        await sessionContextMenu.openPullRequestInBrowser('https://github.com/owner/repo/pull/789');
 
-        assert.strictEqual(openExternalStub.callCount, 2);
-        assert.strictEqual(showErrorMessageStub.calledOnce, true);
+        assert.strictEqual(openExternalStub.callCount, 3);
+        assert.strictEqual(showErrorMessageStub.calledTwice, true);
     });
 });

--- a/src/test/sessionContextMenu.unit.test.ts
+++ b/src/test/sessionContextMenu.unit.test.ts
@@ -193,6 +193,11 @@ suite('sessionContextMenu Test Suite', () => {
             const result = parsePullRequestUrl('https://github.com/owner/repo/pull/-1');
             assert.strictEqual(result, null);
         });
+
+        test('should handle exception during parsePullRequestUrl', () => {
+            const result = parsePullRequestUrl({} as string); // Causes u = new URL(prUrl) to throw TypeError
+            assert.strictEqual(result, null);
+        });
     });
 
     suite('getPullRequestUrlForSession (Session fallback scenarios)', () => {


### PR DESCRIPTION
sessionContextMenu (`src/sessionContextMenu.ts`) 内の以下の関数におけるカバレッジを向上させるためにテストケースを追加しました。

* `parsePullRequestUrl`
  * 実行時に例外（TypeErrorなど）が発生した場合に `null` を正しく返すことを検証するテストを追加。
* `openPullRequestInBrowser`
  * `vscode.env.openExternal` が例外（Network error など）を throw / reject した際に、適切に捕捉してエラーメッセージを表示することを検証するテストを追加。

`test:unit` および `test:coverage` コマンドでテストがすべて通過することを確認済みです。

---
*PR created automatically by Jules for task [409241664578709451](https://jules.google.com/task/409241664578709451) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `sessionContextMenu.ts` の `parsePullRequestUrl` と `openPullRequestInBrowser` に対して、例外ケースをカバーするユニットテストを追加します。テストの実装は既存のスタブ設計と整合しており、アサーションも正しく機能します。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、安全にマージ可能です。

プロダクションコードへの変更はなく、追加されたテストのアサーションも実装の振る舞いと正確に一致しています。スタブの設定、callCount・calledTwice のアサーションいずれも正しい。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/sessionContextMenu.unit.test.ts | `parsePullRequestUrl({} as string)` テストを追加。`new URL({})` が `"[object Object]"` を URL として解析しようとして TypeError を投げ、catch ブロックが `null` を返すことを正しく検証している。 |
| src/test/sessionContextMenu.checkout.unit.test.ts | `openPullRequestInBrowser` の既存テストに reject シナリオを追加。callCount・showErrorMessage の呼び出し回数のアサーションが正しく更新されている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テストコード
    participant SUT as openPullRequestInBrowser
    participant Ext as vscode.env.openExternal
    participant Err as vscode.window.showErrorMessage

    Note over Test: 1回目: resolves(true)
    Test->>SUT: call("pull/123")
    SUT->>Ext: openExternal(uri)
    Ext-->>SUT: true
    Note over SUT: 成功 → エラーメッセージなし

    Note over Test: 2回目: resolves(false)
    Test->>SUT: call("pull/456")
    SUT->>Ext: openExternal(uri)
    Ext-->>SUT: false
    SUT->>Err: showErrorMessage("Failed...")
    Note over Err: 1回目のshowError

    Note over Test: 3回目: rejects(Error)
    Test->>SUT: call("pull/789")
    SUT->>Ext: openExternal(uri)
    Ext-->>SUT: throw Error('Network error')
    SUT->>Err: showErrorMessage("Failed...") [catch block]
    Note over Err: 2回目のshowError

    Test->>Test: assert callCount === 3 ✓
    Test->>Test: assert showError.calledTwice ✓
```

<sub>Reviews (1): Last reviewed commit: ["test: sessionContextMenuのテストカバレッジを向上 (pa..."](https://github.com/hiroki-org/jules-extension/commit/fed4e10a9b17d6d927392dcd9a8c6645d30323e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29948700)</sub>

<!-- /greptile_comment -->