### PR TITLE
test: add missing unit tests for planUtils, markdownFencing, and constants

### DIFF
--- a/src/test/julesApiConstants.unit.test.ts
+++ b/src/test/julesApiConstants.unit.test.ts
@@ -1,0 +1,12 @@
+import * as assert from 'assert';
+import { JULES_API_BASE_URL, ALL_SOURCES_ID } from '../julesApiConstants';
+
+suite('julesApiConstants Unit Tests', () => {
+    test('JULES_API_BASE_URL should be correctly defined', () => {
+        assert.strictEqual(JULES_API_BASE_URL, 'https://jules.googleapis.com/v1alpha');
+    });
+
+    test('ALL_SOURCES_ID should be correctly defined', () => {
+        assert.strictEqual(ALL_SOURCES_ID, 'all_repos');
+    });
+});

--- a/src/test/markdownFencing.unit.test.ts
+++ b/src/test/markdownFencing.unit.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import { buildFencedCodeBlock } from '../markdownFencing';
+
+suite('markdownFencing Unit Tests', () => {
+    test('buildFencedCodeBlock should build a basic code block', () => {
+        const code = 'console.log("hello");';
+        const result = buildFencedCodeBlock(code, 'javascript');
+        assert.strictEqual(result, '```javascript\nconsole.log("hello");\n```');
+    });
+
+    test('buildFencedCodeBlock should adjust backticks if code contains 3 backticks', () => {
+        const code = 'const str = ````hello````;';
+        const result = buildFencedCodeBlock(code, 'typescript');
+        assert.strictEqual(result, '`````typescript\nconst str = ````hello````;\n`````');
+    });
+
+    test('buildFencedCodeBlock should handle empty code', () => {
+        const code = '';
+        const result = buildFencedCodeBlock(code, 'json');
+        assert.strictEqual(result, '```json\n\n```');
+    });
+
+    test('buildFencedCodeBlock should work with no backticks in code', () => {
+        const code = 'plain text';
+        const result = buildFencedCodeBlock(code, '');
+        assert.strictEqual(result, '```\nplain text\n```');
+    });
+});

--- a/src/test/planUtils.unit.test.ts
+++ b/src/test/planUtils.unit.test.ts
@@ -1,0 +1,105 @@
+import * as assert from 'assert';
+import { formatPlanStepText, formatPlanForNotification, formatFullPlan, Plan } from '../planUtils';
+
+suite('planUtils Unit Tests', () => {
+    suite('formatPlanStepText', () => {
+        test('should process valid string steps', () => {
+            assert.strictEqual(formatPlanStepText('  Step 1  '), 'Step 1');
+            assert.strictEqual(formatPlanStepText(''), null);
+            assert.strictEqual(formatPlanStepText('   '), null);
+        });
+
+        test('should process object steps with description', () => {
+            assert.strictEqual(formatPlanStepText({ description: '  desc  ' }), 'desc');
+            assert.strictEqual(formatPlanStepText({ description: '' }), null);
+        });
+
+        test('should fallback to title if description is missing or empty', () => {
+            assert.strictEqual(formatPlanStepText({ title: '  title  ' }), 'title');
+            assert.strictEqual(formatPlanStepText({ title: 'title', description: '' }), 'title');
+        });
+
+        test('should return null for invalid object formats', () => {
+            assert.strictEqual(formatPlanStepText({ unrelated: 'text' }), null);
+            assert.strictEqual(formatPlanStepText(null), null);
+            assert.strictEqual(formatPlanStepText(123), null);
+            assert.strictEqual(formatPlanStepText([]), null);
+        });
+    });
+
+    suite('formatPlanForNotification', () => {
+        test('should format plan with title and no steps', () => {
+            const plan: Plan = { title: 'Test Plan' };
+            const result = formatPlanForNotification(plan, 5, 50);
+            assert.strictEqual(result, '📋 Test Plan');
+        });
+
+        test('should format plan with title and steps', () => {
+            const plan: Plan = { title: 'Plan 1', steps: ['Step 1', { description: 'Step 2' }] };
+            const result = formatPlanForNotification(plan, 2, 50);
+            assert.strictEqual(result, '📋 Plan 1\n1. Step 1\n2. Step 2');
+        });
+
+        test('should truncate long steps', () => {
+            const plan: Plan = { steps: ['This is a very long step that should be truncated'] };
+            const result = formatPlanForNotification(plan, 1, 10);
+            assert.strictEqual(result, '1. This is...');
+        });
+
+        test('should truncate number of steps', () => {
+            const plan: Plan = { steps: ['Step 1', 'Step 2', 'Step 3'] };
+            const result = formatPlanForNotification(plan, 2, 50);
+            assert.strictEqual(result, '1. Step 1\n2. Step 2\n... and 1 more steps');
+        });
+
+        test('should ignore empty steps', () => {
+            const plan: Plan = { steps: ['Step 1', '', { title: ' ' }, 'Step 2'] };
+            const result = formatPlanForNotification(plan, 5, 50);
+            assert.strictEqual(result, '1. Step 1\n2. Step 2');
+        });
+
+        test('should clamp maxSteps to 0 and maxStepLength to 4', () => {
+            const plan: Plan = { steps: ['Step 1'] };
+            const result = formatPlanForNotification(plan, -5, 2);
+            assert.strictEqual(result, '');
+        });
+
+        test('should handle completely empty plan gracefully', () => {
+            const plan: Plan = {};
+            const result = formatPlanForNotification(plan, 5, 50);
+            assert.strictEqual(result, '');
+        });
+    });
+
+    suite('formatFullPlan', () => {
+        test('should format full plan with session title', () => {
+            const plan: Plan = { title: 'Plan Title', steps: ['Step 1', 'Step 2'] };
+            const result = formatFullPlan(plan, 'Session Name');
+
+            assert.ok(result.includes('# Plan Review: Session Name'));
+            assert.ok(result.includes('## 📋 Plan Title'));
+            assert.ok(result.includes('1. Step 1'));
+            assert.ok(result.includes('2. Step 2'));
+            assert.ok(result.includes('*Use the buttons'));
+        });
+
+        test('should format full plan without session title', () => {
+            const plan: Plan = { title: 'Plan Title', steps: ['Step 1'] };
+            const result = formatFullPlan(plan);
+            assert.ok(result.includes('# Plan Review'));
+            assert.ok(!result.includes('# Plan Review:'));
+        });
+
+        test('should handle empty plan or missing steps', () => {
+            const plan: Plan = {};
+            const result = formatFullPlan(plan);
+            assert.ok(result.includes('*No steps defined in this plan.*'));
+        });
+
+        test('should handle all steps being empty or invalid', () => {
+            const plan: Plan = { steps: ['', { title: ' ' }] };
+            const result = formatFullPlan(plan);
+            assert.ok(result.includes('*No steps defined in this plan.*'));
+        });
+    });
+});


### PR DESCRIPTION
### 追加機能

カバレッジ向上のため、以下のファイルに対するユニットテストを追加しました。

*   `src/test/markdownFencing.unit.test.ts`: バッククォートのネストへの対応など、フェンス作成機能のテスト。
*   `src/test/planUtils.unit.test.ts`: プランのステップテキストの抽出、通知用フォーマットの文字列切り詰めやデフォルト動作、完全なドキュメント作成のテスト。
*   `src/test/julesApiConstants.unit.test.ts`: 定数の基本的なアサーション。

### 検証

ローカルにてユニットテストをコンパイルおよび実行し、これら新規追加分を含めてすべてのテストがエラーなく成功することを確認しました。

---
*PR created automatically by Jules for task [15294236198687553442](https://jules.google.com/task/15294236198687553442) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `planUtils`・`markdownFencing`・`julesApiConstants` の3モジュールに対するユニットテストを新規追加し、カバレッジを向上させます。既存スレッドで2点（markdownFencing のテスト名誤り、`maxStepLength` クランプの未検証）が既に指摘済みで、それ以外のすべてのテストは実装と正しく一致しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

新規追加のテストのみで既存コードに変更なし。マージしても安全です。

P0/P1 の新規問題は検出されず。既存スレッドで指摘済みの2点（テスト名の不一致・maxStepLength クランプ未検証）は P2 レベルであり、スコアに影響しない。各テストの期待値はすべて実装ロジックと一致している。

特になし。既存スレッドの指摘事項が対応済みであれば問題ない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/julesApiConstants.unit.test.ts | JULES_API_BASE_URL と ALL_SOURCES_ID の定数値を検証するシンプルなテスト。実装との一致を確認済み。 |
| src/test/markdownFencing.unit.test.ts | buildFencedCodeBlock の4ケースをカバー。テスト名と実データの不一致（3 vs 4バッククォート）は既存スレッドで指摘済み。ロジック自体は実装と一致している。 |
| src/test/planUtils.unit.test.ts | formatPlanStepText / formatPlanForNotification / formatFullPlan の各関数を幅広くカバー。maxStepLength クランプの未検証問題は既存スレッドで指摘済み。それ以外の期待値はすべて実装と一致している。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ユニットテスト追加 PR #505] --> B[julesApiConstants.unit.test.ts]
    A --> C[markdownFencing.unit.test.ts]
    A --> D[planUtils.unit.test.ts]

    B --> B1[JULES_API_BASE_URL 検証]
    B --> B2[ALL_SOURCES_ID 検証]

    C --> C1[基本コードブロック生成]
    C --> C2[バッククォートエスケープ処理]
    C --> C3[空コード対応]
    C --> C4[言語ID なし対応]

    D --> D1[formatPlanStepText 文字列/オブジェクト/null/無効値]
    D --> D2[formatPlanForNotification タイトル/ステップ/切り詰め/クランプ]
    D --> D3[formatFullPlan セッションタイトル有無/空プラン]
```

<sub>Reviews (2): Last reviewed commit: ["test: add missing unit tests for planUti..."](https://github.com/hiroki-org/jules-extension/commit/2c8a9af877913091fa69142f9eafcfaea49c5ee9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29952427)</sub>

<!-- /greptile_comment -->