### PR TITLE
Optimize performance by avoiding Set recreation in loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-05-01 - [Avoid loop recreation of Sets]
+**Learning:** During review, we noticed `new Set([ ... ])` being instantiated inside a loop for `activity` logging in `extension.ts` (`logChannel.appendLine`). While it's just logging, moving static `Set` declarations outside the loop is a fundamental performance practice in V8.
+
+**Action:** Move `baseKeys` and `unionKeys` `Set` instantiations outside the `forEach` loop in the `refreshActivities` loop inside `extension.ts` to prevent redundant garbage collection and allocation on hot code paths.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,4 +1,4 @@
-## 2024-05-01 - [Avoid loop recreation of Sets]
-**Learning:** During review, we noticed `new Set([ ... ])` being instantiated inside a loop for `activity` logging in `extension.ts` (`logChannel.appendLine`). While it's just logging, moving static `Set` declarations outside the loop is a fundamental performance practice in V8.
+# 2024-05-01 - Avoid loop recreation of Sets
 
-**Action:** Move `baseKeys` and `unionKeys` `Set` instantiations outside the `forEach` loop in the `refreshActivities` loop inside `extension.ts` to prevent redundant garbage collection and allocation on hot code paths.
+**Learning:** During review, we noticed `new Set([ ... ])` being instantiated inside a loop for activity logging in `extension.ts`. While it is just logging, moving static `Set` declarations out of repeated execution paths is a fundamental performance practice in V8.
+**Action:** Move the activity log key `Set` declarations to module-level constants in `extension.ts` to prevent redundant garbage collection and allocation on hot code paths.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,6 +96,13 @@ const ACTIVITY_LOG_BASE_KEYS = new Set([
 ]);
 const ACTIVITY_LOG_UNION_KEYS = new Set(ACTIVITY_UNION_KEYS);
 
+export function isInferredActivityLogKey(key: string): boolean {
+  return (
+    !ACTIVITY_LOG_BASE_KEYS.has(key) &&
+    !ACTIVITY_LOG_UNION_KEYS.has(key as ActivityUnionKey)
+  );
+}
+
 // Plan notification display constants
 const MAX_PLAN_STEPS_IN_NOTIFICATION = 5;
 const MAX_PLAN_STEP_LENGTH = 80;
@@ -3241,8 +3248,7 @@ export function activate(context: vscode.ExtensionContext) {
                 for (const key in activity) {
                   if (
                     Object.prototype.hasOwnProperty.call(activity, key) &&
-                    !ACTIVITY_LOG_BASE_KEYS.has(key) &&
-                    !ACTIVITY_LOG_UNION_KEYS.has(key as ActivityUnionKey)
+                    isInferredActivityLogKey(key)
                   ) {
                     const value = (
                       activity as unknown as Record<string, unknown>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,6 +85,16 @@ const MAX_PAGINATION_PAGES = 100;
 const MAX_ACTIVITIES_CACHE_SIZE = 50;
 const ACTIVITIES_LATEST_CREATE_TIME_KEY_PREFIX =
   "jules.activities.latestCreateTime";
+const ACTIVITY_LOG_BASE_KEYS = new Set([
+  "name",
+  "createTime",
+  "description",
+  "originator",
+  "id",
+  "type",
+  "artifacts",
+]);
+const ACTIVITY_LOG_UNION_KEYS = new Set(ACTIVITY_UNION_KEYS);
 
 // Plan notification display constants
 const MAX_PLAN_STEPS_IN_NOTIFICATION = 5;
@@ -378,7 +388,6 @@ export async function createRemoteBranch(
     throw error;
   }
 }
-
 
 /**
  * Get privacy icon for a source
@@ -989,7 +998,9 @@ function startAutoRefresh(
 
   autoRefreshInterval = setInterval(() => {
     if (isAutoRefreshPipelineRunning) {
-      logChannel.appendLine("Jules: Auto-refresh pipeline already in progress. Skipping.");
+      logChannel.appendLine(
+        "Jules: Auto-refresh pipeline already in progress. Skipping.",
+      );
       return;
     }
     isAutoRefreshPipelineRunning = true;
@@ -997,7 +1008,10 @@ function startAutoRefresh(
     void sessionsProvider
       .refresh(true) // Pass true for background refresh
       .then(async () => {
-        await refreshActiveChatSessionFromAutoRefresh(context, chatViewProvider);
+        await refreshActiveChatSessionFromAutoRefresh(
+          context,
+          chatViewProvider,
+        );
       })
       .catch((error: unknown) => {
         logChannel.appendLine(
@@ -1144,7 +1158,8 @@ export async function refreshActiveChatSessionFromAutoRefresh(
 
   isRefreshingActiveChatSession = true;
   try {
-    const activeSessionId = context.globalState.get<string>("active-session-id");
+    const activeSessionId =
+      context.globalState.get<string>("active-session-id");
     if (!activeSessionId || !isValidSessionId(activeSessionId)) {
       return;
     }
@@ -1257,7 +1272,10 @@ type ActivityCategoryCountsCacheEntry = {
   length: number;
 };
 
-const arrayCategoryCountsCache = new WeakMap<Activity[], ActivityCategoryCountsCacheEntry>();
+const arrayCategoryCountsCache = new WeakMap<
+  Activity[],
+  ActivityCategoryCountsCacheEntry
+>();
 
 function createEmptyActivityCategoryCounts(): Record<ActivityCategory, number> {
   return {
@@ -1273,7 +1291,9 @@ function getActivityIdentityKey(activity: Activity): string | undefined {
   return activity.name || activity.id || undefined;
 }
 
-function countActivityCategoryCounts(activities: Activity[]): Record<ActivityCategory, number> {
+function countActivityCategoryCounts(
+  activities: Activity[],
+): Record<ActivityCategory, number> {
   const counts = createEmptyActivityCategoryCounts();
   for (const activity of activities) {
     counts[getActivityCategory(activity)] += 1;
@@ -2376,7 +2396,7 @@ export async function handleOpenInWebApp(
  * 環境変数からSOCKSプロキシが設定されているか確認し、最初に見つかった値を返す。
  * 設定されていない場合は null を返す。
  */
-function detectProxy(): { type: 'socks' | 'http', url: string } | null {
+function detectProxy(): { type: "socks" | "http"; url: string } | null {
   const proxyEnvVars: (string | undefined)[] = [
     process.env.HTTP_PROXY,
     process.env.http_proxy,
@@ -2400,10 +2420,10 @@ function detectProxy(): { type: 'socks' | 'http', url: string } | null {
     if (v) {
       const lower = v.toLowerCase();
       if (socksSchemes.some((s) => lower.startsWith(s))) {
-        return { type: 'socks', url: v };
+        return { type: "socks", url: v };
       }
       if (httpSchemes.some((s) => lower.startsWith(s))) {
-        return { type: 'http', url: v };
+        return { type: "http", url: v };
       }
     }
   }
@@ -2425,7 +2445,7 @@ export function activate(context: vscode.ExtensionContext) {
       );
       return;
     }
-    if (proxy.type === 'socks') {
+    if (proxy.type === "socks") {
       setSocksProxy(proxy.url);
       const safeProxy = stripUrlCredentials(proxy.url);
       vscode.window.showInformationMessage(
@@ -3159,18 +3179,6 @@ export function activate(context: vscode.ExtensionContext) {
           detailLines.push("No activities found for this session.");
         } else {
           let planDetected = false;
-          // Optimization: Pre-allocate sets outside the loop to avoid recreation on every activity
-          const logBaseKeys = new Set([
-            "name",
-            "createTime",
-            "description",
-            "originator",
-            "id",
-            "type",
-            "artifacts",
-          ]);
-          const logUnionKeys = new Set(ACTIVITY_UNION_KEYS);
-
           filteredActivities.forEach((activity) => {
             const icon = getActivityIcon(activity);
             const codicon = getActivityThemeIcon(activity)?.id;
@@ -3243,8 +3251,8 @@ export function activate(context: vscode.ExtensionContext) {
                 for (const key in activity) {
                   if (
                     Object.prototype.hasOwnProperty.call(activity, key) &&
-                    !logBaseKeys.has(key) &&
-                    !logUnionKeys.has(key as ActivityUnionKey)
+                    !ACTIVITY_LOG_BASE_KEYS.has(key) &&
+                    !ACTIVITY_LOG_UNION_KEYS.has(key as ActivityUnionKey)
                   ) {
                     const value = (
                       activity as unknown as Record<string, unknown>
@@ -3659,7 +3667,9 @@ export function activate(context: vscode.ExtensionContext) {
       if (!item) {
         return;
       }
-      let changeSet = getCachedSessionArtifacts(item.session.name)?.latestChangeSet;
+      let changeSet = getCachedSessionArtifacts(
+        item.session.name,
+      )?.latestChangeSet;
       if (!getChangeSetUnidiffPatch(changeSet)) {
         const apiKey = await getStoredApiKey(context);
         if (!apiKey) {
@@ -3673,16 +3683,22 @@ export function activate(context: vscode.ExtensionContext) {
           );
           changeSet = fresh.latestChangeSet;
         } catch (error) {
-          vscode.window.showErrorMessage(`Failed to fetch latest ChangeSet artifact: ${sanitizeError(error)}`);
+          vscode.window.showErrorMessage(
+            `Failed to fetch latest ChangeSet artifact: ${sanitizeError(error)}`,
+          );
           return;
         }
       }
       if (!changeSet) {
-        vscode.window.showErrorMessage("This session has no ChangeSet artifact.");
+        vscode.window.showErrorMessage(
+          "This session has no ChangeSet artifact.",
+        );
         return;
       }
       if (!getChangeSetUnidiffPatch(changeSet)) {
-        vscode.window.showErrorMessage("This session has no applicable patch artifact.");
+        vscode.window.showErrorMessage(
+          "This session has no applicable patch artifact.",
+        );
         return;
       }
       await applyPatchLocallyForSession({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -389,6 +389,7 @@ export async function createRemoteBranch(
   }
 }
 
+
 /**
  * Get privacy icon for a source
  * @param isPrivate - The isPrivate field from Source
@@ -998,9 +999,7 @@ function startAutoRefresh(
 
   autoRefreshInterval = setInterval(() => {
     if (isAutoRefreshPipelineRunning) {
-      logChannel.appendLine(
-        "Jules: Auto-refresh pipeline already in progress. Skipping.",
-      );
+      logChannel.appendLine("Jules: Auto-refresh pipeline already in progress. Skipping.");
       return;
     }
     isAutoRefreshPipelineRunning = true;
@@ -1008,10 +1007,7 @@ function startAutoRefresh(
     void sessionsProvider
       .refresh(true) // Pass true for background refresh
       .then(async () => {
-        await refreshActiveChatSessionFromAutoRefresh(
-          context,
-          chatViewProvider,
-        );
+        await refreshActiveChatSessionFromAutoRefresh(context, chatViewProvider);
       })
       .catch((error: unknown) => {
         logChannel.appendLine(
@@ -1158,8 +1154,7 @@ export async function refreshActiveChatSessionFromAutoRefresh(
 
   isRefreshingActiveChatSession = true;
   try {
-    const activeSessionId =
-      context.globalState.get<string>("active-session-id");
+    const activeSessionId = context.globalState.get<string>("active-session-id");
     if (!activeSessionId || !isValidSessionId(activeSessionId)) {
       return;
     }
@@ -1272,10 +1267,7 @@ type ActivityCategoryCountsCacheEntry = {
   length: number;
 };
 
-const arrayCategoryCountsCache = new WeakMap<
-  Activity[],
-  ActivityCategoryCountsCacheEntry
->();
+const arrayCategoryCountsCache = new WeakMap<Activity[], ActivityCategoryCountsCacheEntry>();
 
 function createEmptyActivityCategoryCounts(): Record<ActivityCategory, number> {
   return {
@@ -1291,9 +1283,7 @@ function getActivityIdentityKey(activity: Activity): string | undefined {
   return activity.name || activity.id || undefined;
 }
 
-function countActivityCategoryCounts(
-  activities: Activity[],
-): Record<ActivityCategory, number> {
+function countActivityCategoryCounts(activities: Activity[]): Record<ActivityCategory, number> {
   const counts = createEmptyActivityCategoryCounts();
   for (const activity of activities) {
     counts[getActivityCategory(activity)] += 1;
@@ -2396,7 +2386,7 @@ export async function handleOpenInWebApp(
  * 環境変数からSOCKSプロキシが設定されているか確認し、最初に見つかった値を返す。
  * 設定されていない場合は null を返す。
  */
-function detectProxy(): { type: "socks" | "http"; url: string } | null {
+function detectProxy(): { type: 'socks' | 'http', url: string } | null {
   const proxyEnvVars: (string | undefined)[] = [
     process.env.HTTP_PROXY,
     process.env.http_proxy,
@@ -2420,10 +2410,10 @@ function detectProxy(): { type: "socks" | "http"; url: string } | null {
     if (v) {
       const lower = v.toLowerCase();
       if (socksSchemes.some((s) => lower.startsWith(s))) {
-        return { type: "socks", url: v };
+        return { type: 'socks', url: v };
       }
       if (httpSchemes.some((s) => lower.startsWith(s))) {
-        return { type: "http", url: v };
+        return { type: 'http', url: v };
       }
     }
   }
@@ -2445,7 +2435,7 @@ export function activate(context: vscode.ExtensionContext) {
       );
       return;
     }
-    if (proxy.type === "socks") {
+    if (proxy.type === 'socks') {
       setSocksProxy(proxy.url);
       const safeProxy = stripUrlCredentials(proxy.url);
       vscode.window.showInformationMessage(
@@ -3667,9 +3657,7 @@ export function activate(context: vscode.ExtensionContext) {
       if (!item) {
         return;
       }
-      let changeSet = getCachedSessionArtifacts(
-        item.session.name,
-      )?.latestChangeSet;
+      let changeSet = getCachedSessionArtifacts(item.session.name)?.latestChangeSet;
       if (!getChangeSetUnidiffPatch(changeSet)) {
         const apiKey = await getStoredApiKey(context);
         if (!apiKey) {
@@ -3683,22 +3671,16 @@ export function activate(context: vscode.ExtensionContext) {
           );
           changeSet = fresh.latestChangeSet;
         } catch (error) {
-          vscode.window.showErrorMessage(
-            `Failed to fetch latest ChangeSet artifact: ${sanitizeError(error)}`,
-          );
+          vscode.window.showErrorMessage(`Failed to fetch latest ChangeSet artifact: ${sanitizeError(error)}`);
           return;
         }
       }
       if (!changeSet) {
-        vscode.window.showErrorMessage(
-          "This session has no ChangeSet artifact.",
-        );
+        vscode.window.showErrorMessage("This session has no ChangeSet artifact.");
         return;
       }
       if (!getChangeSetUnidiffPatch(changeSet)) {
-        vscode.window.showErrorMessage(
-          "This session has no applicable patch artifact.",
-        );
+        vscode.window.showErrorMessage("This session has no applicable patch artifact.");
         return;
       }
       await applyPatchLocallyForSession({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3159,6 +3159,18 @@ export function activate(context: vscode.ExtensionContext) {
           detailLines.push("No activities found for this session.");
         } else {
           let planDetected = false;
+          // Optimization: Pre-allocate sets outside the loop to avoid recreation on every activity
+          const logBaseKeys = new Set([
+            "name",
+            "createTime",
+            "description",
+            "originator",
+            "id",
+            "type",
+            "artifacts",
+          ]);
+          const logUnionKeys = new Set(ACTIVITY_UNION_KEYS);
+
           filteredActivities.forEach((activity) => {
             const icon = getActivityIcon(activity);
             const codicon = getActivityThemeIcon(activity)?.id;
@@ -3227,22 +3239,12 @@ export function activate(context: vscode.ExtensionContext) {
             } else {
               let keySummary = activeKeys.join(", ");
               if (activeKeys.length === 0) {
-                const baseKeys = new Set([
-                  "name",
-                  "createTime",
-                  "description",
-                  "originator",
-                  "id",
-                  "type",
-                  "artifacts",
-                ]);
-                const unionKeys = new Set(ACTIVITY_UNION_KEYS);
                 const inferredKeys: string[] = [];
                 for (const key in activity) {
                   if (
                     Object.prototype.hasOwnProperty.call(activity, key) &&
-                    !baseKeys.has(key) &&
-                    !unionKeys.has(key as ActivityUnionKey)
+                    !logBaseKeys.has(key) &&
+                    !logUnionKeys.has(key as ActivityUnionKey)
                   ) {
                     const value = (
                       activity as unknown as Record<string, unknown>

--- a/src/test/extensionHelpers.unit.test.ts
+++ b/src/test/extensionHelpers.unit.test.ts
@@ -15,6 +15,7 @@ import {
   getSourceDisplayName,
   getSourceIsPrivate,
   handleOpenInWebApp,
+  isInferredActivityLogKey,
   mapApiStateToSessionState,
   mergeActivitiesByIdentity,
   resetUpdatePreviousStatesCachesForTests,
@@ -105,6 +106,13 @@ suite("Extension helper unit tests", () => {
   });
 
   suite("comparison and activity helpers", () => {
+    test("isInferredActivityLogKey should exclude known base and union keys", () => {
+      assert.strictEqual(isInferredActivityLogKey("id"), false);
+      assert.strictEqual(isInferredActivityLogKey("type"), false);
+      assert.strictEqual(isInferredActivityLogKey("planGenerated"), false);
+      assert.strictEqual(isInferredActivityLogKey("customDiagnostic"), true);
+    });
+
     test("session comparison helpers should detect equality and mismatches", () => {
       const outputsA: SessionOutput[] = [
         {


### PR DESCRIPTION
This pull request optimizes the `refreshActivities` logic in `extension.ts` by moving the instantiation of certain `Set` objects outside of a frequently executed loop. This reduces unnecessary memory allocation and improves performance, especially in hot code paths. The change is also documented in the `.jules/bolt.md` changelog.

**Performance improvements:**

* Moved the instantiation of `baseKeys` and `unionKeys` `Set` objects (now named `logBaseKeys` and `logUnionKeys`) outside of the `filteredActivities.forEach` loop in `extension.ts` to avoid recreating them on each iteration. This prevents redundant garbage collection and allocation, improving performance in V8. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R3162-R3173) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L3230-R3247)

**Documentation:**

* Added a changelog entry in `.jules/bolt.md` explaining the optimization and the reasoning behind moving `Set` instantiations outside the loop.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `extension.ts` のループ内で毎回生成されていた `Set` オブジェクトをモジュールレベルの定数（`ACTIVITY_LOG_BASE_KEYS`・`ACTIVITY_LOG_UNION_KEYS`）に移動し、不要なメモリアロケーションとGCの負荷を削減するパフォーマンス改善です。また、処理を `isInferredActivityLogKey` という関数に抽出してテストを追加しており、可読性・テスタビリティの向上も見られます。変更は機能的に同等で、全体的に問題のないリファクタリングです。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージ安全です。機能的に同等なリファクタリングで、既存動作への影響はありません。

P0/P1 の問題は見当たらず、変更は機能的に同等です。新しい関数にはテストも追加されており、品質基準を満たしています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | モジュールレベルの定数 `ACTIVITY_LOG_BASE_KEYS`・`ACTIVITY_LOG_UNION_KEYS` と `isInferredActivityLogKey` 関数を追加し、ループ内の Set 再生成を解消。機能的に同等で問題なし。 |
| src/test/extensionHelpers.unit.test.ts | 新しい `isInferredActivityLogKey` 関数に対するユニットテストを追加。base キー・union キー・inferred キーの各ケースをカバー。 |
| .jules/bolt.md | 変更の背景を記録した新規チェンジログファイル。コード上の問題はなし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[refreshActivities 呼び出し] --> B[filteredActivities.forEach ループ]
    B --> C{activeKeys.length === 0?}
    C -- No --> D[keySummary を使用]
    C -- Yes --> E[inferredKeys 収集]
    E --> F{各キーについて isInferredActivityLogKey チェック}

    subgraph Before["変更前（ループ内）"]
        G["new Set([...baseKeys])"]
        H["new Set(ACTIVITY_UNION_KEYS)"]
        G --> I[key チェック]
        H --> I
    end

    subgraph After["変更後（モジュール定数）"]
        J["ACTIVITY_LOG_BASE_KEYS（定数）"]
        K["ACTIVITY_LOG_UNION_KEYS（定数）"]
        J --> L["isInferredActivityLogKey(key)"]
        K --> L
    end

    F --> After
```

<sub>Reviews (2): Last reviewed commit: ["test: cover activity log key filtering"](https://github.com/hiroki-org/jules-extension/commit/4501a6243f3349006c0b3e94fa377046a5e08b75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30418444)</sub>

<!-- /greptile_comment -->