### PR TITLE
Fix codecov badge showing unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Installs](https://badgen.net/vs-marketplace/i/HirokiMukai.jules-extension?color=blue)](https://marketplace.visualstudio.com/items?itemName=HirokiMukai.jules-extension)
 [![Built with Jules](https://img.shields.io/badge/Built%20with-Jules-715cd7?link=https://jules.google)](https://jules.google)
 [![CI](https://img.shields.io/github/actions/workflow/status/Hiroki-org/jules-extension/ci.yml?branch=main&label=CI&logo=githubactions&logoColor=white)](https://github.com/Hiroki-org/jules-extension/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/Hiroki-org/jules-extension/branch/main/graph/badge.svg)](https://codecov.io/gh/Hiroki-org/jules-extension)
+[![codecov](https://codecov.io/gh/Hiroki-org/jules-extension/graph/badge.svg)](https://codecov.io/gh/Hiroki-org/jules-extension)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/Hiroki-org/jules-extension/issues)
 
 Jules Extension is an extension that allows you to operate Google's AI coding agent **Jules** directly from within VSCode.


### PR DESCRIPTION
This PR removes the branch path from the codecov badge URL in the README so that it properly displays the coverage percentage.

---
*PR created automatically by Jules for task [8902085675954034332](https://jules.google.com/task/8902085675954034332) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

codecovバッジURLの `/branch/main` パスを削除し、バッジが \"unknown\" と表示される問題を修正する変更です。Codecov の新しいバッジ URL 形式（`/graph/badge.svg`）に合わせた1行のドキュメント修正であり、機能的な影響はありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージ安全。README のバッジ URL を1行修正する変更のみで、コードやロジックへの影響はありません。

変更は README.md の1行のみで、バッジ URL のパスを修正するドキュメント変更です。コードの挙動に影響がなく、既知の Codecov URL フォーマット変更への正しい対応です。

特になし
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | codecovバッジURLから `/branch/main` パスを除去し、カバレッジが正常に表示されるよう修正 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant README as README.md
    participant Codecov as Codecov API
    participant Badge as バッジ表示

    Note over README,Badge: 変更前
    README->>Codecov: GET /gh/Hiroki-org/jules-extension/branch/main/graph/badge.svg
    Codecov-->>Badge: "unknown" (パス不正)

    Note over README,Badge: 変更後
    README->>Codecov: GET /gh/Hiroki-org/jules-extension/graph/badge.svg
    Codecov-->>Badge: カバレッジ% 正常表示
```

<sub>Reviews (1): Last reviewed commit: ["Fix codecov badge unknown issue"](https://github.com/hiroki-org/jules-extension/commit/48041bc44a9b6ddecb3963928b43becde7b291f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30457536)</sub>

<!-- /greptile_comment -->