### PR TITLE
test: add unit test for getActivityIcon

### DIFF
--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -143,25 +143,63 @@ suite("activityUtils getActivitySummaryText", () => {
 });
 
 suite("activityUtils getActivityIcon", () => {
-    test("returns event-specific icons only for single active keys", () => {
-        const cases = [
-            [{ planGenerated: { plan: { title: "p1", steps: [] } as any } }, "📝"],
-            [{ planApproved: { planId: "p1" } }, "👍"],
-            [{ progressUpdated: { title: "Working", description: "" } }, "🔄"],
-            [{ sessionCompleted: {} }, "✅"],
-            [{ sessionFailed: { reason: "boom" } }, "❌"],
-            [{ agentMessaged: { agentMessage: "hello" } }, "💬"],
-            [{ userMessaged: {} }, "🗨️"],
-        ];
+    test("returns the plan generated icon", () => {
+        assert.strictEqual(
+            getActivityIcon(mockActivity({ planGenerated: { plan: { title: "p1", steps: [] } as any } })),
+            "📝",
+        );
+    });
 
-        for (const [overrides, expected] of cases as any[]) {
-            assert.strictEqual(getActivityIcon(mockActivity(overrides)), expected);
-        }
+    test("returns the plan approved icon", () => {
+        assert.strictEqual(
+            getActivityIcon(mockActivity({ planApproved: { planId: "p1" } })),
+            "👍",
+        );
+    });
 
+    test("returns the progress updated icon", () => {
+        assert.strictEqual(
+            getActivityIcon(mockActivity({ progressUpdated: { title: "Working", description: "" } })),
+            "🔄",
+        );
+    });
+
+    test("returns the session completed icon", () => {
+        assert.strictEqual(
+            getActivityIcon(mockActivity({ sessionCompleted: {} })),
+            "✅",
+        );
+    });
+
+    test("returns the session failed icon", () => {
+        assert.strictEqual(
+            getActivityIcon(mockActivity({ sessionFailed: { reason: "boom" } })),
+            "❌",
+        );
+    });
+
+    test("returns the agent messaged icon", () => {
+        assert.strictEqual(
+            getActivityIcon(mockActivity({ agentMessaged: { agentMessage: "hello" } })),
+            "💬",
+        );
+    });
+
+    test("returns the user messaged icon", () => {
+        assert.strictEqual(
+            getActivityIcon(mockActivity({ userMessaged: {} })),
+            "🗨️",
+        );
+    });
+
+    test("returns the fallback icon when multiple active keys are present", () => {
         assert.strictEqual(
             getActivityIcon(mockActivity({ agentMessaged: { agentMessage: "hi" }, userMessaged: {} })),
             "ℹ️",
         );
+    });
+
+    test("returns the fallback icon when no active key is present", () => {
         assert.strictEqual(getActivityIcon(mockActivity()), "ℹ️");
     });
 });

--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import {
     getActivityCategory,
+    getActivityIcon,
     getActivityLabelPrefix,
     getActivitySummaryText,
     isActivityCorrupted,
@@ -138,6 +139,30 @@ suite("activityUtils getActivitySummaryText", () => {
     test("sessionFailed with whitespace-only reason", () => {
         const activity = mockActivity({ sessionFailed: { reason: "   " } });
         assert.strictEqual(getActivitySummaryText(activity), "Session failed");
+    });
+});
+
+suite("activityUtils getActivityIcon", () => {
+    test("returns event-specific icons only for single active keys", () => {
+        const cases = [
+            [{ planGenerated: { plan: { title: "p1", steps: [] } as any } }, "📝"],
+            [{ planApproved: { planId: "p1" } }, "👍"],
+            [{ progressUpdated: { title: "Working", description: "" } }, "🔄"],
+            [{ sessionCompleted: {} }, "✅"],
+            [{ sessionFailed: { reason: "boom" } }, "❌"],
+            [{ agentMessaged: { agentMessage: "hello" } }, "💬"],
+            [{ userMessaged: {} }, "🗨️"],
+        ];
+
+        for (const [overrides, expected] of cases as any[]) {
+            assert.strictEqual(getActivityIcon(mockActivity(overrides)), expected);
+        }
+
+        assert.strictEqual(
+            getActivityIcon(mockActivity({ agentMessaged: { agentMessage: "hi" }, userMessaged: {} })),
+            "ℹ️",
+        );
+        assert.strictEqual(getActivityIcon(mockActivity()), "ℹ️");
     });
 });
 


### PR DESCRIPTION
Added exactly one non-duplicate unit test for `getActivityIcon` to improve Codecov coverage in `src/test/activityUtils.unit.test.ts`. This correctly leverages existing mock utility functions and tests edge case returns.

Tests were successfully verified locally:
- `pnpm run test:unit out/test/activityUtils.unit.test.js`
- `pnpm run test:coverage`
- `xvfb-run -a pnpm test`
- `pnpm run lint`

---
*PR created automatically by Jules for task [13527819623997075852](https://jules.google.com/task/13527819623997075852) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`getActivityIcon` の全7つのイベントキーとフォールバック（複数キー・キーなし）を網羅するユニットテストスイートを追加したPRです。実装との整合性は正しく、機能的な問題はありません。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はなく、マージは安全です。

機能的な誤りはなく、P2のスタイル指摘が1件のみ（複数ケースを1つの `test()` に集約している点）。既存のテストパターンとの一貫性に関する改善提案です。

`src/test/activityUtils.unit.test.ts` のテスト構造のスタイルのみ確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/activityUtils.unit.test.ts | `getActivityIcon` の全7ケース＋フォールバック2ケースをカバーする新テストスイートを追加。機能的な正確性に問題はないが、全アサーションが1つの `test()` ブロックに集約されており、既存のスタイルと一致しない。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/test/activityUtils.unit.test.ts:146-166
**複数の独立したアサーションが1つの `test()` に集約されている**

このテストスイート内のすべての検証（7つのアイコンマッピング＋2つのフォールバックケース）が1つの `test()` ブロックにまとめられています。ループ内の `assert.strictEqual` が最初に失敗すると例外が投げられ、それ以降のケース（例えばフォールバックの検証）はスキップされます。同じファイル内の `getActivityCategory` スイートでは各シナリオが個別の `test()` に分割されており、テスト名でどのケースが失敗したかが即座に識別できます。同じ粒度で分割することを推奨します。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add unit test for getActivityIcon"](https://github.com/hiroki-org/jules-extension/commit/906a91693b7139a3c6b17fc1337bcce334eb5907) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30547845)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->