### PR TITLE
test: add coverage for getActivitySummaryText fallback branches

### DIFF
--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -140,29 +140,56 @@ suite("activityUtils getActivitySummaryText", () => {
         assert.strictEqual(getActivitySummaryText(activity), "Session failed");
     });
 
-    test("falls back to description, artifacts, active key labels, and metadata", () => {
+    test("falls back to description", () => {
         assert.strictEqual(
             getActivitySummaryText(mockActivity({ description: "  described work  " })),
             "described work",
         );
+    });
+
+    test("falls back to artifacts summary", () => {
         assert.strictEqual(
             getActivitySummaryText(
                 mockActivity({
                     description: undefined,
-                    artifacts: [{ media: { uri: "file:///tmp/image.png" } } as any],
+                    artifacts: [{ media: { uri: "file:///tmp/image.png" } }],
                 }),
             ),
             "Artifacts: media",
         );
+    });
+
+    test("falls back to active key label", () => {
         assert.strictEqual(
             getActivitySummaryText(mockActivity({ description: undefined, planApproved: { planId: "p1" } })),
             "Plan approved",
         );
+    });
+
+    test("falls back to metadata (originator and time)", () => {
         assert.strictEqual(
             getActivitySummaryText(
                 mockActivity({ description: undefined, originator: "user", createTime: "2026-03-02T00:00:00Z" }),
             ),
             "Activity (originator=user, time=2026-03-02T00:00:00Z)",
+        );
+    });
+
+    test("falls back to metadata without createTime", () => {
+        assert.strictEqual(
+            getActivitySummaryText(
+                mockActivity({ description: undefined, createTime: undefined }),
+            ),
+            "Activity (originator=agent)",
+        );
+    });
+
+    test("falls back to metadata when multiple active keys present", () => {
+        assert.strictEqual(
+            getActivitySummaryText(
+                mockActivity({ description: undefined, planApproved: { planId: "p1" }, sessionCompleted: {} }),
+            ),
+            "Activity (originator=agent, time=2026-03-01T00:00:00Z)",
         );
     });
 });

--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -139,6 +139,32 @@ suite("activityUtils getActivitySummaryText", () => {
         const activity = mockActivity({ sessionFailed: { reason: "   " } });
         assert.strictEqual(getActivitySummaryText(activity), "Session failed");
     });
+
+    test("falls back to description, artifacts, active key labels, and metadata", () => {
+        assert.strictEqual(
+            getActivitySummaryText(mockActivity({ description: "  described work  " })),
+            "described work",
+        );
+        assert.strictEqual(
+            getActivitySummaryText(
+                mockActivity({
+                    description: undefined,
+                    artifacts: [{ media: { uri: "file:///tmp/image.png" } } as any],
+                }),
+            ),
+            "Artifacts: media",
+        );
+        assert.strictEqual(
+            getActivitySummaryText(mockActivity({ description: undefined, planApproved: { planId: "p1" } })),
+            "Plan approved",
+        );
+        assert.strictEqual(
+            getActivitySummaryText(
+                mockActivity({ description: undefined, originator: "user", createTime: "2026-03-02T00:00:00Z" }),
+            ),
+            "Activity (originator=user, time=2026-03-02T00:00:00Z)",
+        );
+    });
 });
 
 suite("activityUtils isActivityCorrupted", () => {


### PR DESCRIPTION
Added unit tests to cover the fallback branches of `getActivitySummaryText` in `src/activityUtils.ts`, including tests for `description`, `artifacts`, `planApproved`, and default fallback with originator/createTime.

This change ensures that all fallback logic in `getActivitySummaryText` is adequately tested and prevents regressions.

---
*PR created automatically by Jules for task [50727198653569562](https://jules.google.com/task/50727198653569562) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

前回レビューで指摘された3点（複数アサーション混在・`createTime` 未設定・`activeKeys.length > 1`）をすべて対応し、`getActivitySummaryText` のフォールバック分岐を個別テストケースに整理した変更です。全体的に網羅性が大幅に改善されています。唯一 `originator` が `undefined` の場合に `\"unknown\"` を返すブランチのみインラインコメントで指摘しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テスト追加のみの変更でプロダクションコードへの影響はなく、マージ安全です。

P0・P1 の問題はなく、P2（originator=undefined パス未テスト）のみ。前回指摘3点はすべて対応済み。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/activityUtils.unit.test.ts | 6つの新テストケースを追加し、description・artifacts・activeKey（1件）・metadata フォールバックを個別のテストに分割して網羅。前回レビューで指摘された3点はすべて対応済み。originator が undefined → "unknown" となるブランチのみ未テスト。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getActivitySummaryText] --> B{progressUpdated?}
    B -- あり --> C[return progressTitle/description]
    B -- なし --> D{sessionFailed?}
    D -- あり --> E[return 'Session failed: reason']
    D -- なし --> F{description?}
    F -- あり --> G[return description ✅ テスト済]
    F -- なし --> H{artifacts?}
    H -- あり --> I[return 'Artifacts: ...' ✅ テスト済]
    H -- なし --> J{activeKeys.length === 1?}
    J -- Yes --> K[return getActivityTypeLabel ✅ テスト済]
    J -- No --> L{createTime?}
    L -- あり --> M[return 'Activity originator=X, time=Y' ✅ テスト済]
    L -- なし --> N{originator?}
    N -- 設定済 --> O[return 'Activity originator=agent' ✅ テスト済]
    N -- undefined --> P[return 'Activity originator=unknown' ⚠️ 未テスト]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/test/activityUtils.unit.test.ts:178-185
**`originator` が未設定の場合の `"unknown"` フォールバックが未テスト**

`getActivitySummaryText` の末尾では `activity.originator ?? "unknown"` を使用しており、`originator` が `undefined` または `null` の場合は `"unknown"` が使われます。しかし `mockActivity` のデフォルトが `originator: "agent"` を持つため、現在の `createTime` 省略テストでは `"unknown"` パスは通りません。このパスが将来のリファクタで壊れても検知できません。

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address review: split fallback tests int..."](https://github.com/hiroki-org/jules-extension/commit/ed6ddc3eb80d7bb4af4c9c79c4b4265576339fc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30547877)</sub>

<!-- /greptile_comment -->