### PR TITLE
test: improve coverage for getActivityTypeLabel

### DIFF
--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -3,6 +3,7 @@ import {
     getActivityCategory,
     getActivityLabelPrefix,
     getActivitySummaryText,
+    getActivityTypeLabel,
     isActivityCorrupted,
 } from "../activityUtils";
 import type { Activity } from "../types";
@@ -95,6 +96,18 @@ suite("activityUtils getActivityCategory", () => {
     test("empty activity -> Messages fallback", () => {
         const activity = mockActivity();
         assert.strictEqual(getActivityCategory(activity), "Messages");
+    });
+});
+
+suite("activityUtils getActivityTypeLabel", () => {
+    test("returns stable labels for every known union key", () => {
+        assert.strictEqual(getActivityTypeLabel("planGenerated"), "Plan generated");
+        assert.strictEqual(getActivityTypeLabel("planApproved"), "Plan approved");
+        assert.strictEqual(getActivityTypeLabel("agentMessaged"), "Agent messaged");
+        assert.strictEqual(getActivityTypeLabel("userMessaged"), "User messaged");
+        assert.strictEqual(getActivityTypeLabel("progressUpdated"), "Progress updated");
+        assert.strictEqual(getActivityTypeLabel("sessionCompleted"), "Session completed");
+        assert.strictEqual(getActivityTypeLabel("sessionFailed"), "Session failed");
     });
 });
 

--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -100,14 +100,29 @@ suite("activityUtils getActivityCategory", () => {
 });
 
 suite("activityUtils getActivityTypeLabel", () => {
-    test("returns stable labels for every known union key", () => {
+    test("planGenerated -> Plan generated", () => {
         assert.strictEqual(getActivityTypeLabel("planGenerated"), "Plan generated");
+    });
+    test("planApproved -> Plan approved", () => {
         assert.strictEqual(getActivityTypeLabel("planApproved"), "Plan approved");
+    });
+    test("agentMessaged -> Agent messaged", () => {
         assert.strictEqual(getActivityTypeLabel("agentMessaged"), "Agent messaged");
+    });
+    test("userMessaged -> User messaged", () => {
         assert.strictEqual(getActivityTypeLabel("userMessaged"), "User messaged");
+    });
+    test("progressUpdated -> Progress updated", () => {
         assert.strictEqual(getActivityTypeLabel("progressUpdated"), "Progress updated");
+    });
+    test("sessionCompleted -> Session completed", () => {
         assert.strictEqual(getActivityTypeLabel("sessionCompleted"), "Session completed");
+    });
+    test("sessionFailed -> Session failed", () => {
         assert.strictEqual(getActivityTypeLabel("sessionFailed"), "Session failed");
+    });
+    test("unknown key falls back to Activity", () => {
+        assert.strictEqual(getActivityTypeLabel("unknown" as any), "Activity");
     });
 });
 


### PR DESCRIPTION
Adds a unit test suite to improve code coverage for `getActivityTypeLabel` in `activityUtils.ts`.
Validates that it correctly resolves stable labels for all known union keys.

---
*PR created automatically by Jules for task [8833410998333815270](https://jules.google.com/task/8833410998333815270) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`activityUtils.ts` の `getActivityTypeLabel` 関数に対するユニットテストスイートを追加するPRです。全7つの `ActivityUnionKey`（`planGenerated`、`planApproved`、`agentMessaged`、`userMessaged`、`progressUpdated`、`sessionCompleted`、`sessionFailed`）と `default` フォールバック（`"Activity"`）を個別の `test()` ブロックでカバーしており、既存のコーディングスタイルにも準拠しています。期待値はすべて実装と一致しており、問題は見当たりません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テスト追加のみのPRで、プロダクションコードへの変更はなく、安全にマージ可能です。

全ユニオンキーと default ブランチをカバーする網羅的なテストが追加されており、既存スタイル（1ケース1 test()）にも準拠しています。期待値と実装の一致も確認済みで、問題点は見当たりません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/activityUtils.unit.test.ts | getActivityTypeLabel の新テストスイートを追加。全7ユニオンキーと default フォールバックをカバー、1ケース1 test() スタイルを遵守。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getActivityTypeLabel(key)"] --> B{key}
    B -->|planGenerated| C["'Plan generated'"]
    B -->|planApproved| D["'Plan approved'"]
    B -->|agentMessaged| E["'Agent messaged'"]
    B -->|userMessaged| F["'User messaged'"]
    B -->|progressUpdated| G["'Progress updated'"]
    B -->|sessionCompleted| H["'Session completed'"]
    B -->|sessionFailed| I["'Session failed'"]
    B -->|default| J["'Activity'"]

    subgraph テストカバレッジ
        C -.->|✅ テスト済| C
        D -.->|✅ テスト済| D
        E -.->|✅ テスト済| E
        F -.->|✅ テスト済| F
        G -.->|✅ テスト済| G
        H -.->|✅ テスト済| H
        I -.->|✅ テスト済| I
        J -.->|✅ テスト済| J
    end
```

<sub>Reviews (2): Last reviewed commit: ["Address review: split getActivityTypeLab..."](https://github.com/hiroki-org/jules-extension/commit/d76591117184a764018b0bd2517f621b2f92f240) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30547879)</sub>

<!-- /greptile_comment -->