### PR TITLE
test: add unit test coverage for summarizeArtifacts

### DIFF
--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -5,6 +5,7 @@ import {
     getActivityLabelPrefix,
     getActivitySummaryText,
     isActivityCorrupted,
+    summarizeArtifacts,
 } from "../activityUtils";
 import type { Activity } from "../types";
 
@@ -201,6 +202,23 @@ suite("activityUtils getActivityIcon", () => {
 
     test("returns the fallback icon when no active key is present", () => {
         assert.strictEqual(getActivityIcon(mockActivity()), "ℹ️");
+    });
+});
+
+suite("activityUtils summarizeArtifacts", () => {
+    test("returns null for empty inputs and summarizes unique artifact types in insertion order", () => {
+        assert.strictEqual(summarizeArtifacts(undefined), null);
+        assert.strictEqual(summarizeArtifacts([]), null);
+        assert.strictEqual(summarizeArtifacts([{}]), null);
+        assert.strictEqual(
+            summarizeArtifacts([
+                { changeSet: {} },
+                { bashOutput: { command: "pnpm test" } as any },
+                { media: { uri: "file:///tmp/screenshot.png" } },
+                { changeSet: {} },
+            ]),
+            "Artifacts: changeSet, bashOutput, media",
+        );
     });
 });
 


### PR DESCRIPTION
This PR adds a specific unit test for `summarizeArtifacts` within `src/test/activityUtils.unit.test.ts` to improve Codecov coverage.

The test verifies that the function correctly returns `null` for empty inputs and appropriately summarizes artifact types exactly in insertion order when `changeSet`, `bashOutput`, and `media` elements are present in the activity array. The implementation also updates the imports using existing import boundaries.

---
*PR created automatically by Jules for task [7202062849947858049](https://jules.google.com/task/7202062849947858049) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`summarizeArtifacts` 関数に対する単体テストを追加するPRです。`undefined`・空配列・認識されないキーのみ・混合型という4つのシナリオが、それぞれ独立した `test()` ブロックに正しく分割されており、期待値も実装と一致しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はなく、安全にマージ可能です。

P2の軽微なスタイル指摘（不要な `as any` キャスト）のみで、P1/P0の問題はありません。テストロジックは実装と完全に一致しており、シナリオも適切に網羅されています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/activityUtils.unit.test.ts | `summarizeArtifacts` の単体テストを追加。各シナリオが独立したテストケースに分割されており、期待値も実装と一致している。`gitPatch: {} as any` の不要なキャストのみ軽微な指摘あり。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/test/activityUtils.unit.test.ts:161-164
`GitPatch` インターフェースのすべてのフィールドはオプションなので、`{}` は `GitPatch` を既に満たしています。`as any` キャストは不要であり、TypeScript の型チェックを無効にしてしまいます。型定義が将来変更された場合にコンパイルエラーで気づけなくなります。

```suggestion
                { changeSet: { source: "s1", gitPatch: {} } },
                { bashOutput: { command: "pnpm test", output: "", exitCode: 0 } },
                { media: { uri: "file:///tmp/screenshot.png" } },
                { changeSet: { source: "s2", gitPatch: {} } },
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address review: fix semicolons, remove a..."](https://github.com/hiroki-org/jules-extension/commit/b5bccf5de0fcdf6b8e28a8192e83f87ff667818a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30547881)</sub>

<!-- /greptile_comment -->