### PR TITLE
test: add test block for getActivityLabelPrefix

### DIFF
--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -110,6 +110,18 @@ suite("activityUtils getActivityLabelPrefix", () => {
         const activity = mockActivity({ sessionFailed: { reason: "error" } });
         assert.strictEqual(getActivityLabelPrefix(activity), "FAILED: ");
     });
+
+    test("covers approval, completion, diff, and neutral label prefixes", () => {
+        assert.strictEqual(getActivityLabelPrefix(mockActivity({ planApproved: { planId: "p1" } })), "Approved: ")
+        assert.strictEqual(getActivityLabelPrefix(mockActivity({ sessionCompleted: {} })), "Completed: ")
+        assert.strictEqual(
+            getActivityLabelPrefix(
+                mockActivity({ artifacts: [{ changeSet: { source: "s1" } as any }] }),
+            ),
+            "(diff) ",
+        )
+        assert.strictEqual(getActivityLabelPrefix(mockActivity({ agentMessaged: { agentMessage: "hello" } })), "")
+    })
 });
 
 suite("activityUtils getActivitySummaryText", () => {

--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -111,17 +111,26 @@ suite("activityUtils getActivityLabelPrefix", () => {
         assert.strictEqual(getActivityLabelPrefix(activity), "FAILED: ");
     });
 
-    test("covers approval, completion, diff, and neutral label prefixes", () => {
-        assert.strictEqual(getActivityLabelPrefix(mockActivity({ planApproved: { planId: "p1" } })), "Approved: ")
-        assert.strictEqual(getActivityLabelPrefix(mockActivity({ sessionCompleted: {} })), "Completed: ")
+    test("planApproved -> Approved: ", () => {
+        assert.strictEqual(getActivityLabelPrefix(mockActivity({ planApproved: { planId: "p1" } })), "Approved: ");
+    });
+
+    test("sessionCompleted -> Completed: ", () => {
+        assert.strictEqual(getActivityLabelPrefix(mockActivity({ sessionCompleted: {} })), "Completed: ");
+    });
+
+    test("artifacts with changeSet -> (diff) ", () => {
         assert.strictEqual(
             getActivityLabelPrefix(
                 mockActivity({ artifacts: [{ changeSet: { source: "s1" } as any }] }),
             ),
             "(diff) ",
-        )
-        assert.strictEqual(getActivityLabelPrefix(mockActivity({ agentMessaged: { agentMessage: "hello" } })), "")
-    })
+        );
+    });
+
+    test("agentMessaged -> empty prefix", () => {
+        assert.strictEqual(getActivityLabelPrefix(mockActivity({ agentMessaged: { agentMessage: "hello" } })), "");
+    });
 });
 
 suite("activityUtils getActivitySummaryText", () => {


### PR DESCRIPTION
Adds a specific test block for `getActivityLabelPrefix` coverage.

---
*PR created automatically by Jules for task [16096010610068078984](https://jules.google.com/task/16096010610068078984) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `getActivityLabelPrefix` の未テストだった4つのコードパス（`planApproved`、`sessionCompleted`、`artifacts + changeSet`、`agentMessaged`）に対し、それぞれ独立した `test()` ブロックを追加してテストカバレッジを向上させます。追加された各アサーションは実装と正確に一致しており、論理的な誤りは見当たりません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、安全にマージ可能です。

追加された4つのテストはすべて実装と整合しており、P0/P1の問題は検出されませんでした。既存テストと同様のスタイルで記述されており、コードへの影響もありません。

特になし
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/activityUtils.unit.test.ts | 4つの新規テストケースを追加。各アサーションはすべて実装（getActivityLabelPrefix）と一致しており、論理的な誤りはなし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getActivityLabelPrefix] --> B{planGenerated?}
    B -- Yes --> C["'Plan: ' ✅ 既存テスト"]
    B -- No --> D{planApproved?}
    D -- Yes --> E["'Approved: ' ✅ 今回追加"]
    D -- No --> F{sessionFailed?}
    F -- Yes --> G["'FAILED: ' ✅ 既存テスト"]
    F -- No --> H{sessionCompleted?}
    H -- Yes --> I["'Completed: ' ✅ 今回追加"]
    H -- No --> J{artifacts に changeSet?}
    J -- Yes --> K["'(diff) ' ✅ 今回追加"]
    J -- No --> L["'' (空文字) ✅ 今回追加 agentMessaged"]
```

<sub>Reviews (2): Last reviewed commit: ["Address review: split getActivityLabelPr..."](https://github.com/hiroki-org/jules-extension/commit/aecda3d8135b52289d56da67a93ac30380714618) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30547890)</sub>

<!-- /greptile_comment -->