### PR TITLE
test: Add unit test for getActivityThemeIcon

### DIFF
--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -4,6 +4,7 @@ import {
     getActivityIcon,
     getActivityLabelPrefix,
     getActivitySummaryText,
+    getActivityThemeIcon,
     getActivityTypeLabel,
     isActivityCorrupted,
     summarizeArtifacts,
@@ -354,5 +355,19 @@ suite("activityUtils isActivityCorrupted", () => {
             type: "customUnknownType",
         });
         assert.strictEqual(isActivityCorrupted(activity), false);
+    });
+});
+
+suite("activityUtils getActivityThemeIcon", () => {
+    test("maps non-error activity events and artifact fallbacks to theme icon ids", () => {
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ planGenerated: { plan: { title: "p1", steps: [] } as any } }))?.id, "lightbulb");
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ planApproved: { planId: "p1" } }))?.id, "check");
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ sessionCompleted: {} }))?.id, "pass");
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ progressUpdated: { title: "Working", description: "" } }))?.id, "pulse");
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ agentMessaged: { agentMessage: "hello" } }))?.id, "comment");
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ userMessaged: {} }))?.id, "account");
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ artifacts: [{ changeSet: { source: "s1" } as any }] }))?.id, "diff");
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ artifacts: [{ bashOutput: { command: "pnpm test" } }] }))?.id, "terminal");
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ description: undefined }))?.id, undefined);
     });
 });

--- a/src/test/activityUtils.unit.test.ts
+++ b/src/test/activityUtils.unit.test.ts
@@ -359,15 +359,43 @@ suite("activityUtils isActivityCorrupted", () => {
 });
 
 suite("activityUtils getActivityThemeIcon", () => {
-    test("maps non-error activity events and artifact fallbacks to theme icon ids", () => {
+    test("sessionFailed maps to error icon", () => {
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ sessionFailed: { reason: "error" } }))?.id, "error");
+    });
+
+    test("planGenerated maps to lightbulb icon", () => {
         assert.strictEqual(getActivityThemeIcon(mockActivity({ planGenerated: { plan: { title: "p1", steps: [] } as any } }))?.id, "lightbulb");
+    });
+
+    test("planApproved maps to check icon", () => {
         assert.strictEqual(getActivityThemeIcon(mockActivity({ planApproved: { planId: "p1" } }))?.id, "check");
+    });
+
+    test("sessionCompleted maps to pass icon", () => {
         assert.strictEqual(getActivityThemeIcon(mockActivity({ sessionCompleted: {} }))?.id, "pass");
+    });
+
+    test("progressUpdated maps to pulse icon", () => {
         assert.strictEqual(getActivityThemeIcon(mockActivity({ progressUpdated: { title: "Working", description: "" } }))?.id, "pulse");
+    });
+
+    test("agentMessaged maps to comment icon", () => {
         assert.strictEqual(getActivityThemeIcon(mockActivity({ agentMessaged: { agentMessage: "hello" } }))?.id, "comment");
+    });
+
+    test("userMessaged maps to account icon", () => {
         assert.strictEqual(getActivityThemeIcon(mockActivity({ userMessaged: {} }))?.id, "account");
+    });
+
+    test("artifacts with changeSet maps to diff icon", () => {
         assert.strictEqual(getActivityThemeIcon(mockActivity({ artifacts: [{ changeSet: { source: "s1" } as any }] }))?.id, "diff");
+    });
+
+    test("artifacts with bashOutput maps to terminal icon", () => {
         assert.strictEqual(getActivityThemeIcon(mockActivity({ artifacts: [{ bashOutput: { command: "pnpm test" } }] }))?.id, "terminal");
-        assert.strictEqual(getActivityThemeIcon(mockActivity({ description: undefined }))?.id, undefined);
+    });
+
+    test("unhandled activity returns undefined", () => {
+        assert.strictEqual(getActivityThemeIcon(mockActivity({ description: "unknown event", artifacts: [] }))?.id, undefined);
     });
 });

--- a/src/test/vscodeMock.ts
+++ b/src/test/vscodeMock.ts
@@ -229,6 +229,12 @@ const mockVscode = {
             this.color = color;
         }
     },
+    ThemeColor: class ThemeColor {
+        id: string;
+        constructor(id: string) {
+            this.id = id;
+        }
+    },
     StatusBarAlignment: {
         Left: 1,
         Right: 2,


### PR DESCRIPTION
Adding test coverage for `getActivityThemeIcon` in `src/activityUtils.ts` via a newly added test in `src/test/activityUtils.unit.test.ts`.

- Added test case verifying successful resolution of various valid activity configurations to their respective `ThemeIcon` mapped IDs.
- Ran formatting to ensure tests comply with project style constraints.

---
*PR created automatically by Jules for task [13609720085053513525](https://jules.google.com/task/13609720085053513525) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`getActivityThemeIcon` の全分岐（`sessionFailed`、各イベント種別、アーティファクト種別、`undefined` フォールバック）を独立したテストケースでカバーするユニットテストを追加し、`vscodeMock.ts` に `ThemeColor` モックを追加した PR です。以前の指摘（複数アサーションの分割、`sessionFailed` ケースの追加、不要な `description: undefined` の除去）はすべて対応済みです。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はないため安全にマージ可能です。

P2 の指摘（sessionFailed のカラー検証欠落）が 1 件あるものの、P0/P1 の問題はなく、テスト追加のみの変更のためスコアに影響しません。

src/test/activityUtils.unit.test.ts — sessionFailed テストのカラーアサーション欠落に注意。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/activityUtils.unit.test.ts | getActivityThemeIcon の全ブランチを独立したテストケースでカバー。sessionFailed のカラー検証が欠落している点以外は良好。 |
| src/test/vscodeMock.ts | ThemeColor クラスのモックを追加。既存の ThemeIcon モックとの整合性あり。実装は正しい。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getActivityThemeIcon] --> B{sessionFailed?}
    B -- Yes --> C["ThemeIcon('error', ThemeColor('errorForeground'))"]
    B -- No --> D{planGenerated?}
    D -- Yes --> E["ThemeIcon('lightbulb')"]
    D -- No --> F{planApproved?}
    F -- Yes --> G["ThemeIcon('check')"]
    F -- No --> H{sessionCompleted?}
    H -- Yes --> I["ThemeIcon('pass')"]
    H -- No --> J{progressUpdated?}
    J -- Yes --> K["ThemeIcon('pulse')"]
    J -- No --> L{agentMessaged?}
    L -- Yes --> M["ThemeIcon('comment')"]
    L -- No --> N{userMessaged?}
    N -- Yes --> O["ThemeIcon('account')"]
    N -- No --> P{artifacts changeSet?}
    P -- Yes --> Q["ThemeIcon('diff')"]
    P -- No --> R{artifacts bashOutput?}
    R -- Yes --> S["ThemeIcon('terminal')"]
    R -- No --> T[undefined]

    style C fill:#f66,color:#fff
    style T fill:#999,color:#fff
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/test/activityUtils.unit.test.ts:359-361
**`sessionFailed` アイコンのカラー検証が欠落**

`getActivityThemeIcon` は `sessionFailed` 時に `new vscode.ThemeIcon("error", new vscode.ThemeColor("errorForeground"))` を返しますが、このテストでは `id` のみを検証しており、第2引数の `ThemeColor` は確認されていません。今回 `vscodeMock.ts` に `ThemeColor` クラスを追加した主目的がこのテストのはずですが、色のアサーションがないと `ThemeColor` が誤って省略されたり別の値に変わっても検知できません。`icon.color?.id === "errorForeground"` のアサーションを追加することを検討してください。

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Address review: split getActivityThemeIc..."](https://github.com/hiroki-org/jules-extension/commit/2017a50f7e70ef07c060e45d8909ba4503e68b93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30547898)</sub>

<!-- /greptile_comment -->