### PR TITLE
test: add test for disabled code lens branch

### DIFF
--- a/src/test/inlineCommands.unit.test.ts
+++ b/src/test/inlineCommands.unit.test.ts
@@ -71,22 +71,21 @@ suite("inlineCommands Test Suite", () => {
     });
 
     test("JulesCodeLensProvider returns no lenses and skips symbol lookup when disabled", async () => {
-        const configStub = sandbox.stub(vscode.workspace, "getConfiguration").returns({
+        sandbox.stub(vscode.workspace, "getConfiguration").returns({
             get: () => false,
-        } as any);
-        const executeStub = sandbox.stub(vscode.commands, "executeCommand");
+        } as any)
+        const executeStub = sandbox.stub(vscode.commands, "executeCommand")
 
-        const provider = new JulesCodeLensProvider({ appendLine: sandbox.stub() } as any);
+        const provider = new JulesCodeLensProvider({ appendLine: sandbox.stub() } as any)
         const lenses = await provider.provideCodeLenses(
             { uri: vscode.Uri.parse("file:///sample.ts") } as any,
             { isCancellationRequested: false } as any,
-        );
+        )
 
-        assert.strictEqual(configStub.calledOnce, true);
-        assert.deepStrictEqual(lenses, []);
-        assert.strictEqual(executeStub.called, false);
-        provider.dispose();
-    });
+        assert.deepStrictEqual(lenses, [])
+        assert.strictEqual(executeStub.called, false)
+        provider.dispose()
+    })
 
     test("JulesCodeLensProvider returns lenses for nested symbols", async () => {
         const configStub = sandbox.stub(vscode.workspace, "getConfiguration").returns({

--- a/src/test/inlineCommands.unit.test.ts
+++ b/src/test/inlineCommands.unit.test.ts
@@ -70,6 +70,23 @@ suite("inlineCommands Test Suite", () => {
         assert.ok(prompt.includes(`\n${fence}\n`));
     });
 
+    test("JulesCodeLensProvider returns no lenses and skips symbol lookup when disabled", async () => {
+        sandbox.stub(vscode.workspace, "getConfiguration").returns({
+            get: () => false,
+        } as any)
+        const executeStub = sandbox.stub(vscode.commands, "executeCommand")
+
+        const provider = new JulesCodeLensProvider({ appendLine: sandbox.stub() } as any)
+        const lenses = await provider.provideCodeLenses(
+            { uri: vscode.Uri.parse("file:///sample.ts") } as any,
+            { isCancellationRequested: false } as any,
+        )
+
+        assert.deepStrictEqual(lenses, [])
+        assert.strictEqual(executeStub.called, false)
+        provider.dispose()
+    })
+
     test("JulesCodeLensProvider returns lenses for nested symbols", async () => {
         const configStub = sandbox.stub(vscode.workspace, "getConfiguration").returns({
             get: () => true,

--- a/src/test/inlineCommands.unit.test.ts
+++ b/src/test/inlineCommands.unit.test.ts
@@ -73,19 +73,19 @@ suite("inlineCommands Test Suite", () => {
     test("JulesCodeLensProvider returns no lenses and skips symbol lookup when disabled", async () => {
         sandbox.stub(vscode.workspace, "getConfiguration").returns({
             get: () => false,
-        } as any)
-        const executeStub = sandbox.stub(vscode.commands, "executeCommand")
+        } as any);
+        const executeStub = sandbox.stub(vscode.commands, "executeCommand");
 
-        const provider = new JulesCodeLensProvider({ appendLine: sandbox.stub() } as any)
+        const provider = new JulesCodeLensProvider({ appendLine: sandbox.stub() } as any);
         const lenses = await provider.provideCodeLenses(
             { uri: vscode.Uri.parse("file:///sample.ts") } as any,
             { isCancellationRequested: false } as any,
-        )
+        );
 
-        assert.deepStrictEqual(lenses, [])
-        assert.strictEqual(executeStub.called, false)
-        provider.dispose()
-    })
+        assert.deepStrictEqual(lenses, []);
+        assert.strictEqual(executeStub.called, false);
+        provider.dispose();
+    });
 
     test("JulesCodeLensProvider returns lenses for nested symbols", async () => {
         const configStub = sandbox.stub(vscode.workspace, "getConfiguration").returns({

--- a/src/test/inlineCommands.unit.test.ts
+++ b/src/test/inlineCommands.unit.test.ts
@@ -71,21 +71,22 @@ suite("inlineCommands Test Suite", () => {
     });
 
     test("JulesCodeLensProvider returns no lenses and skips symbol lookup when disabled", async () => {
-        sandbox.stub(vscode.workspace, "getConfiguration").returns({
+        const configStub = sandbox.stub(vscode.workspace, "getConfiguration").returns({
             get: () => false,
-        } as any)
-        const executeStub = sandbox.stub(vscode.commands, "executeCommand")
+        } as any);
+        const executeStub = sandbox.stub(vscode.commands, "executeCommand");
 
-        const provider = new JulesCodeLensProvider({ appendLine: sandbox.stub() } as any)
+        const provider = new JulesCodeLensProvider({ appendLine: sandbox.stub() } as any);
         const lenses = await provider.provideCodeLenses(
             { uri: vscode.Uri.parse("file:///sample.ts") } as any,
             { isCancellationRequested: false } as any,
-        )
+        );
 
-        assert.deepStrictEqual(lenses, [])
-        assert.strictEqual(executeStub.called, false)
-        provider.dispose()
-    })
+        assert.strictEqual(configStub.calledOnce, true);
+        assert.deepStrictEqual(lenses, []);
+        assert.strictEqual(executeStub.called, false);
+        provider.dispose();
+    });
 
     test("JulesCodeLensProvider returns lenses for nested symbols", async () => {
         const configStub = sandbox.stub(vscode.workspace, "getConfiguration").returns({


### PR DESCRIPTION
Added a test in `src/test/inlineCommands.unit.test.ts` to verify that `JulesCodeLensProvider.provideCodeLenses` skips symbol lookup and returns no lenses when disabled via configuration. This addresses code coverage for the disabled configuration edge-case.

---
*PR created automatically by Jules for task [2334577690087889489](https://jules.google.com/task/2334577690087889489) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

無効化設定時に `JulesCodeLensProvider.provideCodeLenses` がシンボル検索をスキップして空配列を返すブランチをカバーするテストを1件追加しています。テストのロジック（`getConfiguration` スタブ・`executeCommand` の未呼び出し検証・`dispose` 呼び出し）は本番コードの早期リターンパスを正確に反映しており、セミコロンやトレーリングカンマなどのスタイルもファイル全体と一貫しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージ安全。テスト専用の変更であり、本番コードへの影響はありません。

P0・P1の問題は見当たりません。テストロジックは本番コードの早期リターンパスを正確に検証しており、スタブ設定・アサーション・クリーンアップのいずれも適切です。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/inlineCommands.unit.test.ts | 無効化時のコードレンズブランチをカバーする新テストを追加。ロジックは正確で、コーディングスタイルもファイル全体と一貫している。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant Provider as JulesCodeLensProvider
    participant Config as vscode.workspace.getConfiguration (stub)
    participant Cmd as vscode.commands.executeCommand (stub)

    Test->>Config: stub → get() returns false
    Test->>Provider: new JulesCodeLensProvider(logChannel)
    Test->>Provider: provideCodeLenses(document, token)
    Provider->>Config: getConfiguration("jules-extension").get("enableCodeLens", true)
    Config-->>Provider: false
    Provider-->>Test: return [] (early exit, executeCommand skipped)
    Test->>Test: assert lenses === []
    Test->>Cmd: assert executeStub.called === false
    Test->>Provider: dispose()
```

<sub>Reviews (3): Last reviewed commit: ["style: add semicolons to JulesCodeLensPr..."](https://github.com/hiroki-org/jules-extension/commit/ec9c0904b2a75c8c42c9b6b549aa3e228de8e0f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30547909)</sub>

<!-- /greptile_comment -->