### PR TITLE
test: add test for handleInlineTask document open failure

### DIFF
--- a/src/test/inlineCommands.unit.test.ts
+++ b/src/test/inlineCommands.unit.test.ts
@@ -125,7 +125,7 @@ suite("inlineCommands Test Suite", () => {
 
     test("handleInlineTask logs and reports when the target document cannot be opened", async () => {
         const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
-        sandbox.stub(vscode.workspace, "openTextDocument").rejects(new Error("missing file\nsecret"));
+        sandbox.stub(vscode.workspace, "openTextDocument").rejects(new Error("cannot open file\ndetail info"));
         const appendLine = sandbox.stub();
 
         await handleInlineTask(
@@ -143,7 +143,8 @@ suite("inlineCommands Test Suite", () => {
         assert.strictEqual(showErrorStub.firstCall.args[0], "Could not open the target document.");
         assert.strictEqual(appendLine.calledOnce, true);
         assert.match(String(appendLine.firstCall.args[0]), /Error opening document/);
-        assert.match(String(appendLine.firstCall.args[0]), /missing file\\nsecret/);
+        assert.match(String(appendLine.firstCall.args[0]), /cannot open file\\ndetail info/);
+        assert.match(String(appendLine.firstCall.args[0]), /file:\/\/\/workspace\/missing\.ts/);
     });
 
     test("handleInlineTask shows an error when the file is outside the workspace", async () => {

--- a/src/test/inlineCommands.unit.test.ts
+++ b/src/test/inlineCommands.unit.test.ts
@@ -123,6 +123,29 @@ suite("inlineCommands Test Suite", () => {
         assert.strictEqual(appendLine.calledOnce, true);
     });
 
+    test("handleInlineTask logs and reports when the target document cannot be opened", async () => {
+        const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
+        sandbox.stub(vscode.workspace, "openTextDocument").rejects(new Error("missing file\nsecret"));
+        const appendLine = sandbox.stub();
+
+        await handleInlineTask(
+            {
+                globalState: { get: sandbox.stub() },
+                secrets: { get: sandbox.stub() },
+            } as any,
+            { appendLine } as any,
+            vscode.Uri.parse("file:///workspace/missing.ts"),
+            new vscode.Range(0, 0, 0, 10),
+            "Refactor",
+        );
+
+        assert.strictEqual(showErrorStub.calledOnce, true);
+        assert.strictEqual(showErrorStub.firstCall.args[0], "Could not open the target document.");
+        assert.strictEqual(appendLine.calledOnce, true);
+        assert.match(String(appendLine.firstCall.args[0]), /Error opening document/);
+        assert.match(String(appendLine.firstCall.args[0]), /missing file\\nsecret/);
+    });
+
     test("handleInlineTask shows an error when the file is outside the workspace", async () => {
         const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
         sandbox.stub(vscode.workspace, "openTextDocument").resolves({

--- a/src/test/inlineCommands.unit.test.ts
+++ b/src/test/inlineCommands.unit.test.ts
@@ -125,7 +125,7 @@ suite("inlineCommands Test Suite", () => {
 
     test("handleInlineTask logs and reports when the target document cannot be opened", async () => {
         const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
-        sandbox.stub(vscode.workspace, "openTextDocument").rejects(new Error("cannot open file\ndetail info"));
+        sandbox.stub(vscode.workspace, "openTextDocument").rejects(new Error("missing file\nsecret"));
         const appendLine = sandbox.stub();
 
         await handleInlineTask(
@@ -143,8 +143,7 @@ suite("inlineCommands Test Suite", () => {
         assert.strictEqual(showErrorStub.firstCall.args[0], "Could not open the target document.");
         assert.strictEqual(appendLine.calledOnce, true);
         assert.match(String(appendLine.firstCall.args[0]), /Error opening document/);
-        assert.match(String(appendLine.firstCall.args[0]), /cannot open file\\ndetail info/);
-        assert.match(String(appendLine.firstCall.args[0]), /file:\/\/\/workspace\/missing\.ts/);
+        assert.match(String(appendLine.firstCall.args[0]), /missing file\\nsecret/);
     });
 
     test("handleInlineTask shows an error when the file is outside the workspace", async () => {


### PR DESCRIPTION
Adds a unit test verifying handleInlineTask behaviour when it encounters an error opening a document.
The test asserts that the correct error message is shown to the user and correctly logged internally.
The change modifies `src/test/inlineCommands.unit.test.ts` entirely.

---
*PR created automatically by Jules for task [17690067763901096409](https://jules.google.com/task/17690067763901096409) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`handleInlineTask` がドキュメントオープンに失敗した際のエラーハンドリングを検証するユニットテストを追加しています。`showErrorMessage` の呼び出し内容、`appendLine` に渡されるログ文字列（`sanitizeForLogging` による改行エスケープを含む）、URI のフォーマットをそれぞれ正確にアサートしており、実装との整合性も確認できました。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、マージして問題ありません。

既存の実装に対してアサーションが正確に一致しており、P1/P0 相当の問題は見当たりません。前スレッドで指摘された命名の改善も反映済みです。

特になし。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/inlineCommands.unit.test.ts | handleInlineTask のドキュメントオープン失敗パスを検証するユニットテストを追加。実装との整合性に問題なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant handleInlineTask
    participant openTextDocument
    participant sanitizeForLogging
    participant logChannel
    participant showErrorMessage

    Test->>handleInlineTask: 呼び出し (missing.ts URI)
    handleInlineTask->>openTextDocument: openTextDocument(uri)
    openTextDocument-->>handleInlineTask: rejects Error("cannot open file\ndetail info")
    handleInlineTask->>sanitizeForLogging: sanitize(error.message)
    sanitizeForLogging-->>handleInlineTask: "cannot open file\\ndetail info"
    handleInlineTask->>sanitizeForLogging: sanitize(uri.toString())
    sanitizeForLogging-->>handleInlineTask: "file:///workspace/missing.ts"
    handleInlineTask->>logChannel: appendLine("[Jules] Error opening document ...")
    handleInlineTask->>showErrorMessage: "Could not open the target document."
    handleInlineTask-->>Test: return

    Test->>Test: assert showErrorMessage calledOnce
    Test->>Test: assert appendLine calledOnce
    Test->>Test: assert log contains /Error opening document/
    Test->>Test: assert log contains /cannot open file\\ndetail info/
    Test->>Test: assert log contains /file:\/\/\/workspace\/missing\.ts/
```

<sub>Reviews (2): Last reviewed commit: ["test: add test for handleInlineTask docu..."](https://github.com/hiroki-org/jules-extension/commit/a671e3cf557a422a045d83376e0beb40fbe84206) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30547914)</sub>

<!-- /greptile_comment -->