### PR TITLE
test: add handleInlineTask missing API key test

### DIFF
--- a/src/test/inlineCommands.unit.test.ts
+++ b/src/test/inlineCommands.unit.test.ts
@@ -146,6 +146,34 @@ suite("inlineCommands Test Suite", () => {
         assert.strictEqual(showErrorStub.calledOnce, true);
     });
 
+    test("handleInlineTask stops before branch loading when the API key is missing", async () => {
+        const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
+        sandbox.stub(vscode.workspace, "openTextDocument").resolves({
+            getText: () => "const value = 1",
+            uri: vscode.Uri.parse("file:///workspace/file.ts"),
+            languageId: "typescript",
+        } as any);
+        (vscode.workspace as any).getWorkspaceFolder = sandbox.stub().returns({ uri: vscode.Uri.parse("file:///workspace") });
+        const branchStub = sandbox.stub(branchUtils, "getBranchesForSession");
+
+        await handleInlineTask(
+            {
+                globalState: {
+                    get: sandbox.stub().returns({ id: "source-1", name: "repo" }),
+                },
+                secrets: { get: sandbox.stub().resolves(undefined) },
+            } as any,
+            { appendLine: sandbox.stub() } as any,
+            vscode.Uri.parse("file:///workspace/file.ts"),
+            new vscode.Range(0, 0, 0, 10),
+            "Refactor",
+        );
+
+        assert.strictEqual(showErrorStub.calledOnce, true);
+        assert.match(showErrorStub.firstCall.args[0], /API Key not found/);
+        assert.strictEqual(branchStub.called, false);
+    });
+
     test("handleInlineTask stops when no specific source is selected", async () => {
         const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
         sandbox.stub(vscode.workspace, "openTextDocument").resolves({


### PR DESCRIPTION
This PR adds a unit test in `src/test/inlineCommands.unit.test.ts` to cover the scenario where `handleInlineTask` stops due to a missing API key. This improves codecov coverage for `src/inlineCommands.ts`.

---
*PR created automatically by Jules for task [2222485760209997353](https://jules.google.com/task/2222485760209997353) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

APIキーが未設定の場合に `handleInlineTask` が早期リターンすることを検証するユニットテストを追加したPRです。既存のテストパターンと一貫した実装で、ソース選択チェック通過後・ブランチ読み込み前というタイミングを正しく検証しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージ安全。テストのみの変更で既存コードに影響なし。

テストのみの変更であり、既存コードへの影響はゼロです。制御フローの検証（branchStub.called === false）、エラーメッセージの内容確認（正規表現マッチ）、エラー呼び出し回数（1回）という3つのアサーションが適切に組み合わされており、テストとして十分な品質を持っています。

特になし。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/inlineCommands.unit.test.ts | APIキー未設定シナリオをカバーする新しいユニットテストを追加。既存パターンと一貫しており、制御フローの検証も適切。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テスト
    participant handleInlineTask
    participant workspace as vscode.workspace
    participant globalState
    participant secrets
    participant branchUtils
    participant window as vscode.window

    Test->>handleInlineTask: 呼び出し (URI, Range, "Refactor")
    handleInlineTask->>workspace: openTextDocument(uri)
    workspace-->>handleInlineTask: mock document
    handleInlineTask->>workspace: getWorkspaceFolder(doc.uri)
    workspace-->>handleInlineTask: { uri: file:///workspace }
    Note over handleInlineTask: codeSnippet = "const value = 1" (非空)
    handleInlineTask->>globalState: get("selected-source")
    globalState-->>handleInlineTask: { id: "source-1", name: "repo" }
    Note over handleInlineTask: ソース選択チェック OK
    handleInlineTask->>secrets: get("jules-api-key")
    secrets-->>handleInlineTask: undefined
    handleInlineTask->>window: showErrorMessage("API Key not found...")
    Note over branchUtils: getBranchesForSession は呼ばれない
    handleInlineTask-->>Test: return
```

<sub>Reviews (1): Last reviewed commit: ["test: add unit test for handleInlineTask..."](https://github.com/hiroki-org/jules-extension/commit/4fe5c9eb1e2ad07802885b8fd72eaca4d9d091c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30547918)</sub>

<!-- /greptile_comment -->