### PR TITLE
test: Add missing coverage test for branch cancellation in inline commands

### DIFF
--- a/src/test/inlineCommands.unit.test.ts
+++ b/src/test/inlineCommands.unit.test.ts
@@ -171,6 +171,39 @@ suite("inlineCommands Test Suite", () => {
         assert.strictEqual(showErrorStub.calledOnce, true);
     });
 
+    test("handleInlineTask stops when branch selection is cancelled", async () => {
+        const showWarningStub = sandbox.stub(vscode.window, "showWarningMessage");
+        sandbox.stub(vscode.workspace, "openTextDocument").resolves({
+            getText: () => "const value = 1",
+            uri: vscode.Uri.parse("file:///workspace/file.ts"),
+            languageId: "typescript",
+        } as any);
+        (vscode.workspace as any).getWorkspaceFolder = sandbox.stub().returns({ uri: vscode.Uri.parse("file:///workspace") });
+        sandbox.stub(branchUtils, "getBranchesForSession").resolves({
+            branches: ["main"],
+            defaultBranch: "main",
+            currentBranch: "main",
+            remoteBranches: ["main"],
+        } as any);
+        sandbox.stub(vscode.window, "showQuickPick").resolves(undefined);
+        const composerStub = sandbox.stub(composer, "showMessageComposer");
+
+        await handleInlineTask(
+            {
+                globalState: { get: sandbox.stub().returns({ id: "source-1", name: "repo" }) },
+                secrets: { get: sandbox.stub().resolves("api-key") },
+            } as any,
+            { appendLine: sandbox.stub() } as any,
+            vscode.Uri.parse("file:///workspace/file.ts"),
+            new vscode.Range(0, 0, 0, 10),
+            "Generate Tests",
+        );
+
+        assert.strictEqual(showWarningStub.calledOnce, true);
+        assert.strictEqual(showWarningStub.firstCall.args[0], "Branch selection was cancelled or invalid.");
+        assert.strictEqual(composerStub.called, false);
+    });
+
     test("handleInlineTask creates a session when all inputs are valid", async () => {
         sandbox.stub(vscode.workspace, "openTextDocument").resolves({
             getText: () => "const value = 1;",


### PR DESCRIPTION
This PR adds a missing branch cancellation unit test to `src/test/inlineCommands.unit.test.ts` to increase coverage for `handleInlineTask` and resolve the codecov issue.

The new test checks the correct exit path when `showQuickPick` for branch selection resolves to undefined.

- Add test for `handleInlineTask stops when branch selection is cancelled`.
- Passes `pnpm test:unit` and `pnpm test:coverage`.

---
*PR created automatically by Jules for task [7344663820611443496](https://jules.google.com/task/7344663820611443496) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`handleInlineTask` にてブランチ選択がキャンセルされた場合（`showQuickPick` が `undefined` を返す場合）の終了パスを対象としたユニットテストを1件追加しています。新テストは既存のテストパターンに沿って記述されており、`showWarningMessage` の呼び出しと `showMessageComposer` が呼ばれないことの両方を正しく検証しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更でロジックへの影響なし。安全にマージ可能。

変更はテストファイル1件のみ。テストのスタブ設定・アサーションは実装コード（inlineCommands.ts）の実際の分岐と正確に対応しており、既存テストと同じパターンを踏襲している。P0/P1相当の問題は見当たらない。

特に注意が必要なファイルはなし。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/test/inlineCommands.unit.test.ts | ブランチ選択キャンセル時の終了パスをカバーする新しいユニットテストを追加。実装コードの分岐と正確に対応している。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant handleInlineTask
    participant vscode.workspace
    participant branchUtils
    participant vscode.window

    Test->>handleInlineTask: 呼び出し (uri, range, "Generate Tests")
    handleInlineTask->>vscode.workspace: openTextDocument() → stub成功
    handleInlineTask->>vscode.workspace: getWorkspaceFolder() → stub成功
    handleInlineTask->>branchUtils: getBranchesForSession() → {branches:["main"],...}
    handleInlineTask->>vscode.window: showQuickPick([{label:"main",...}]) → undefined (キャンセル)
    handleInlineTask->>vscode.window: showWarningMessage("Branch selection was cancelled or invalid.")
    handleInlineTask-->>Test: return (composerは呼ばれない)
    Test->>Test: assert showWarningMessage called once ✓
    Test->>Test: assert composer NOT called ✓
```

<sub>Reviews (1): Last reviewed commit: ["test: add inline task branch cancellatio..."](https://github.com/hiroki-org/jules-extension/commit/497521690977bae9622dea6eca45acf80e08c27c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30547926)</sub>

<!-- /greptile_comment -->