### PR TITLE
🎨 Palette: チャット入力フィールドの無効化状態とアクセシビリティの改善

### DIFF
--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -66,4 +66,68 @@ suite("chatAssets unit tests", () => {
       "both success and failure paths should reset button text",
     );
   });
+
+  test("CHAT_JS updateUI should properly configure disabled states and ARIA attributes", () => {
+    const elements: any = {
+      chat: { innerHTML: "", scrollTop: 0, scrollHeight: 0, addEventListener: () => {}, querySelectorAll: () => [] },
+      typing: { classList: { toggle: () => {} } },
+      messageInput: { 
+        value: "", 
+        disabled: false, 
+        placeholder: "", 
+        setAttribute: function(k: string, v: string) { (this as any)[k] = v; }, 
+        addEventListener: () => {} 
+      },
+      sendButton: { 
+        disabled: false, 
+        title: "", 
+        setAttribute: function(k: string, v: string) { (this as any)[k] = v; }, 
+        addEventListener: () => {} 
+      },
+      sessionLabel: { textContent: "" },
+      composer: { addEventListener: () => {} },
+    };
+    
+    const mockDocument = {
+      getElementById: (id: string) => elements[id],
+    };
+    let messageListener: any = null;
+    const mockWindow = {
+      addEventListener: (evt: string, cb: any) => {
+        if (evt === "message") messageListener = cb;
+      },
+    };
+    const mockVscode = { postMessage: () => {} };
+
+    const runScript = new Function("document", "window", "acquireVsCodeApi", "navigator", CHAT_JS);
+    runScript(mockDocument, mockWindow, () => mockVscode, {});
+
+    // (1) state.sessionId = null
+    messageListener({ data: { type: "chatState", payload: { sessionId: null, messages: [], isTyping: false } } });
+    assert.strictEqual(elements.messageInput.disabled, true);
+    assert.strictEqual(elements.messageInput["aria-disabled"], "true");
+    assert.ok(elements.messageInput.placeholder.startsWith("Select a session"));
+    assert.strictEqual(elements.sendButton.disabled, true);
+    assert.strictEqual(elements.sendButton["aria-disabled"], "true");
+    assert.strictEqual(elements.sendButton.title, "Select a session to send a message");
+    assert.strictEqual(elements.sendButton["aria-label"], "Send (Select a session to send a message)");
+    assert.strictEqual(elements.sessionLabel.textContent, "Session: None selected");
+
+    // (2) sessionId present + empty input value
+    elements.messageInput.value = "   "; // whitespace
+    messageListener({ data: { type: "chatState", payload: { sessionId: "session-123", messages: [], isTyping: false } } });
+    assert.strictEqual(elements.sendButton.disabled, true);
+    assert.strictEqual(elements.sendButton["aria-disabled"], "true");
+    assert.strictEqual(elements.sendButton.title, "Type a message to send");
+    assert.strictEqual(elements.sendButton["aria-label"], "Send (Type a message to send)");
+    assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
+
+    // (3) sessionId present + non-empty input value
+    elements.messageInput.value = "Hello";
+    messageListener({ data: { type: "chatState", payload: { sessionId: "session-123", messages: [], isTyping: false } } });
+    assert.strictEqual(elements.sendButton.disabled, false);
+    assert.strictEqual(elements.sendButton["aria-disabled"], "false");
+    assert.strictEqual(elements.sendButton.title, "Send message (Ctrl/Cmd+Enter)");
+    assert.strictEqual(elements.sendButton["aria-label"], "Send message (Ctrl/Cmd+Enter)");
+  });
 });

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -29,12 +29,12 @@ p { margin: 0 0 8px; }
 #composer { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: var(--vscode-editor-background); border-top: 1px solid var(--vscode-widget-border, transparent); }
 #messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: vertical; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; }
 #messageInput:focus-visible { border-color: var(--vscode-focusBorder); }
-#messageInput:disabled { opacity: 0.6; cursor: not-allowed; resize: none; }
+#messageInput:disabled, #messageInput[aria-disabled="true"] { opacity: 0.6; cursor: not-allowed; resize: none; }
 .composer-actions { display: flex; justify-content: space-between; align-items: center; }
 .session-label { color: var(--vscode-descriptionForeground); font-size: 11px; user-select: none; max-width: 70%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #sendButton { padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }
 #sendButton:hover:not(:disabled) { background: var(--vscode-button-hoverBackground); }
-#sendButton:disabled { opacity: 0.5; cursor: not-allowed; }
+#sendButton:disabled, #sendButton[aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
 .activity-log { font-size: 0.9em; opacity: 0.75; margin-bottom: 2px; }
 .activity-details { margin-top: 4px; font-size: 0.9em; }
 .activity-details summary { cursor: pointer; user-select: none; font-weight: 600; opacity: 0.8; padding: 2px 0; outline: none; }
@@ -67,18 +67,30 @@ export const CHAT_JS = `(function() {
     const hasSession = !!state.sessionId;
     const hasText = messageInput.value.trim().length > 0;
 
-    sendButton.disabled = !hasSession || !hasText;
+    const sendDisabled = !hasSession || !hasText;
+    sendButton.disabled = sendDisabled;
+    sendButton.setAttribute("aria-disabled", sendDisabled ? "true" : "false");
+    
     messageInput.disabled = !hasSession;
+    messageInput.setAttribute("aria-disabled", !hasSession ? "true" : "false");
+
+    if (!hasSession) {
+      messageInput.value = "";
+    }
+
     messageInput.placeholder = hasSession
       ? "Enter message (Ctrl/Cmd+Enter to send)"
       : "Select a session to start typing";
 
     if (!hasSession) {
       sendButton.title = "Select a session to send a message";
+      sendButton.setAttribute("aria-label", "Send (Select a session to send a message)");
     } else if (!hasText) {
       sendButton.title = "Type a message to send";
+      sendButton.setAttribute("aria-label", "Send (Type a message to send)");
     } else {
       sendButton.title = "Send message (Ctrl/Cmd+Enter)";
+      sendButton.setAttribute("aria-label", "Send message (Ctrl/Cmd+Enter)");
     }
 
     sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
@@ -188,4 +200,5 @@ export const CHAT_JS = `(function() {
   });
 
   vscode.postMessage({ type: "requestInitialState" });
+  updateUI();
 })();`;

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -29,6 +29,7 @@ p { margin: 0 0 8px; }
 #composer { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: var(--vscode-editor-background); border-top: 1px solid var(--vscode-widget-border, transparent); }
 #messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: vertical; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; }
 #messageInput:focus-visible { border-color: var(--vscode-focusBorder); }
+#messageInput:disabled { opacity: 0.6; cursor: not-allowed; }
 .composer-actions { display: flex; justify-content: space-between; align-items: center; }
 .session-label { color: var(--vscode-descriptionForeground); font-size: 11px; user-select: none; max-width: 70%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #sendButton { padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }
@@ -64,7 +65,22 @@ export const CHAT_JS = `(function() {
 
   function updateUI() {
     const hasSession = !!state.sessionId;
-    sendButton.disabled = !hasSession || messageInput.value.trim().length === 0;
+    const hasText = messageInput.value.trim().length > 0;
+
+    sendButton.disabled = !hasSession || !hasText;
+    messageInput.disabled = !hasSession;
+    messageInput.placeholder = hasSession
+      ? "Enter message (Ctrl/Cmd+Enter to send)"
+      : "Select a session to start typing";
+
+    if (!hasSession) {
+      sendButton.title = "Select a session to send a message";
+    } else if (!hasText) {
+      sendButton.title = "Type a message to send";
+    } else {
+      sendButton.title = "Send message (Ctrl/Cmd+Enter)";
+    }
+
     sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
   }
 

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -29,7 +29,7 @@ p { margin: 0 0 8px; }
 #composer { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: var(--vscode-editor-background); border-top: 1px solid var(--vscode-widget-border, transparent); }
 #messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: vertical; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; }
 #messageInput:focus-visible { border-color: var(--vscode-focusBorder); }
-#messageInput:disabled { opacity: 0.6; cursor: not-allowed; }
+#messageInput:disabled { opacity: 0.6; cursor: not-allowed; resize: none; }
 .composer-actions { display: flex; justify-content: space-between; align-items: center; }
 .session-label { color: var(--vscode-descriptionForeground); font-size: 11px; user-select: none; max-width: 70%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #sendButton { padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }


### PR DESCRIPTION
**💡 What:** Added a disabled state logic and styling to the chat's input field (`messageInput`). The input is now properly disabled with reduced opacity (`0.6`) and a `not-allowed` cursor when no session is selected. The send button also gains dynamic, descriptive `title` tooltips.
**🎯 Why:** The previous implementation left the input field enabled even without an active session, which was confusing because sending was impossible. This ensures users immediately understand that they must pick a session before trying to type.
**📸 Before/After:** N/A (CSS/JS internal change).
**♿ Accessibility:** Added clearer visual cues (`opacity` and `cursor`) for screen readers/mouse users, as well as descriptive tooltips to explicitly inform the user why they cannot interact with the input or send button.

*Note: PR text requested in Japanese.*

---
*PR created automatically by Jules for task [5343292061327339885](https://jules.google.com/task/5343292061327339885) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

セッション未選択時にチャット入力フィールドを `disabled` にする変更です。CSS の無効化スタイル（`opacity: 0.6`、`cursor: not-allowed`）、動的プレースホルダー、送信ボタンへの状態別ツールチップを追加しています。ロジックは既存の `sendButton.disabled` 制御と整合しており、実質的なバグはありません。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

P2のみで実質的なバグはなく、マージは安全です。

変更はシンプルでロジックも既存コードと整合しています。P2レベルの軽微な改善点（resize:none の追加、初期化時のupdateUI呼び出し）のみです。

src/webview/chatAssets.ts（軽微な改善点あり）
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | チャット入力フィールドの無効化状態とツールチップを追加。ロジックは正しく、既存の sendButton 無効化ロジックと整合している。CSS の :disabled ルールに resize: none が不足している点が軽微な改善点。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[updateUI call] --> B{sessionId exists?}
    B -- No --> C[messageInput.disabled = true]
    B -- No --> D[sendButton.disabled = true]
    B -- No --> E[placeholder: Select a session to start typing]
    B -- No --> F[title: Select a session to send a message]
    B -- Yes --> G[messageInput.disabled = false]
    B -- Yes --> H[placeholder: Enter message Ctrl+Enter to send]
    B -- Yes --> I{has text?}
    I -- No --> J[sendButton.disabled = true]
    I -- No --> K[title: Type a message to send]
    I -- Yes --> L[sendButton.disabled = false]
    I -- Yes --> M[title: Send message Ctrl+Enter]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/webview/chatAssets.ts:32
`resize: vertical` が `:disabled` スタイルで上書きされていないため、一部のブラウザでは無効化されたテキスト入力エリアのリサイズハンドルが表示・操作可能になる場合があります。無効時には `resize: none` を明示的に追加することで、視覚的な不整合を防げます。

```suggestion
#messageInput:disabled { opacity: 0.6; cursor: not-allowed; resize: none; }
```

### Issue 2 of 2
src/webview/chatAssets.ts:66-85
**初期化時に `updateUI()` が呼ばれない**

スクリプト起動直後、`renderMessages()` が初めて呼ばれるまでの間（`chatState` レスポンス受信前）、`messageInput.disabled` および `sendButton.disabled` は HTML の初期状態のまま（おそらく有効）になります。`vscode.postMessage({ type: "requestInitialState" })` の直後に `updateUI()` を一度呼ぶことで、この短い空白期間を解消できます。なお、この問題は今回のPR以前から存在しています。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add disabled state styling and logic to ..."](https://github.com/hiroki-org/jules-extension/commit/e224fa67657587bc6c981003e48ceac78b4e4f1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30557772)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->