### PR TITLE
🎨 Palette: コピーボタンにARIAラベルを追加

### DIFF
--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -56,7 +56,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -94,7 +94,7 @@ suite("chatAssets unit tests", () => {
     let messageListener: any = null;
     const mockWindow = {
       addEventListener: (evt: string, cb: any) => {
-        if (evt === "message") {messageListener = cb;}
+        if (evt === "message") messageListener = cb;
       },
     };
     const mockVscode = { postMessage: () => {} };

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -94,7 +94,7 @@ suite("chatAssets unit tests", () => {
     let messageListener: any = null;
     const mockWindow = {
       addEventListener: (evt: string, cb: any) => {
-        if (evt === "message") messageListener = cb;
+        if (evt === "message") {messageListener = cb;}
       },
     };
     const mockVscode = { postMessage: () => {} };

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -62,6 +62,7 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes("<ul>"));
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
+    assert.ok(rendered.includes('aria-label="Copy code"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {


### PR DESCRIPTION
アクセシビリティ向上のため、`src/chatView.ts`のコピーボタンにARIAラベルを追加しました。

---
*PR created automatically by Jules for task [4565094567571898534](https://jules.google.com/task/4565094567571898534) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コードブロックのコピーボタンに `aria-label=\"Copy code\"` を追加したアクセシビリティ改善PRです。`src/chatView.ts` の変更は1行のみで、対応するテストアサーションも `chatView.unit.test.ts` に追加されています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR はそのままマージ可能です。

変更箇所が非常に小さく（1行の属性追加）、テストも追加されており、既存動作への影響がありません。P1/P0 の問題は見当たりません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | コードブロックのコピーボタンに `aria-label="Copy code"` を追加。アクセシビリティ向上のための最小限の変更。 |
| src/test/chatView.unit.test.ts | 新しい `aria-label` 属性の存在を確認するアサーションを追加。適切なテストカバレッジ。 |
| src/test/chatAssets.unit.test.ts | `if` 文に波括弧を追加するスタイル変更のみ（機能的変更なし）。既存スタイルとの一貫性については前スレッドで指摘済み。 |

</details>

</details>

<sub>Reviews (4): Last reviewed commit: ["test: aria-label for copy code button"](https://github.com/hiroki-org/jules-extension/commit/19e831e8282ea9801426793a16cd04205cb59355) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30607016)</sub>

<!-- /greptile_comment -->