### PR TITLE
🎨 Palette: キーボードフォーカスの視覚的フィードバック改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,4 +1,8 @@
 # 2024-03-10 - Activity details summary accessibility
 
-**Learning:** `outline: none;` on interactive `<summary>` tags inside `<details>` breaks keyboard navigation and makes it impossible for keyboard users to know which item has focus. It is better to rely on `:focus-visible` to hide outline from mouse users but preserve it for keyboard users.
-**Action:** When removing default outline from interactive elements, ensure `:focus-visible` is implemented (typically with `outline: 1px solid var(--vscode-focusBorder)`) to preserve keyboard accessibility.
+**Learning:** `<details>` 内のインタラクティブな `<summary>` タグに `outline: none;` を設定すると、キーボードナビゲーションが壊れ、キーボードユーザーがフォーカスの位置を把握できなくなります。マウスユーザーに対してはアウトラインを隠しつつ、キーボードユーザーのためにアウトラインを維持するには `:focus-visible` に頼るのがベストです。
+**Action:** インタラクティブ要素からデフォルトのアウトラインを削除する場合は、キーボードのアクセシビリティを維持するために、必ず `:focus-visible` （通常は `outline: 1px solid var(--vscode-focusBorder)`）を実装するようにします。
+
+## 2026-05-04 - フォーカス状態の視覚的フィードバックの改善
+**Learning:** チャットの送信ボタンやコピーボタンなどで、キーボード操作時に視覚的なアウトラインが欠落、もしくは不完全であることが分かりました。これにより、キーボード操作を利用するユーザーが現在位置を把握しにくくなっていました。
+**Action:** VS Code 標準の focusBorder トークンを利用し、`:focus-visible` ルールを追加することで、一貫したアクセシビリティのサポートを提供しました。

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -2,6 +2,10 @@ import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
 function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: any) => string }) {
+  const listeners: Record<string, Record<string, any>> = {
+    messageInput: {},
+    composer: {},
+  };
   const elements: Record<string, any> = {
     chat: {
       innerHTML: "",
@@ -15,8 +19,10 @@ function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: 
       value: "",
       disabled: false,
       placeholder: "",
+      style: { height: "" },
+      scrollHeight: 0,
       setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
-      addEventListener: () => {},
+      addEventListener: (evt: string, cb: any) => { listeners.messageInput[evt] = cb; },
     },
     sendButton: {
       disabled: false,
@@ -25,7 +31,7 @@ function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: 
       addEventListener: () => {},
     },
     sessionLabel: { textContent: "" },
-    composer: { addEventListener: () => {} },
+    composer: { addEventListener: (evt: string, cb: any) => { listeners.composer[evt] = cb; } },
   };
   const messageListeners: Array<(event: { data: any }) => void> = [];
   const mockDocument = {
@@ -37,8 +43,10 @@ function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: 
         messageListeners.push(cb);
       }
     },
+    getComputedStyle: () => ({ borderTopWidth: "1px", borderBottomWidth: "1px" }),
   };
-  const mockVscode = { postMessage: () => {} };
+  const sentMessages: any[] = [];
+  const mockVscode = { postMessage: (msg: any) => sentMessages.push(msg) };
   const mockNavigator = { clipboard: { writeText: async () => {} } };
 
   const runScript = new Function(
@@ -53,6 +61,8 @@ function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: 
 
   return {
     elements,
+    listeners,
+    sentMessages,
     postWindowMessage: (data: any) => {
       messageListeners.forEach((listener) => listener({ data }));
     },
@@ -259,6 +269,48 @@ suite("chatAssets unit tests", () => {
     );
   });
 
+  test("CHAT_JS should adjust height to scrollHeight plus border height on input", () => {
+    const harness = createChatScriptHarness();
+    harness.postWindowMessage({
+      type: "chatState",
+      payload: { sessionId: "session-1", messages: [], isTyping: false },
+    });
+    harness.elements.messageInput.scrollHeight = 50;
+    harness.listeners.messageInput.input();
+    assert.strictEqual(harness.elements.messageInput.style.height, "52px");
+  });
+
+  test("CHAT_JS chatState should clear input and reset height to auto if no session", () => {
+    const harness = createChatScriptHarness();
+    harness.elements.messageInput.value = "old text";
+    harness.elements.messageInput.style.height = "52px";
+    harness.postWindowMessage({
+      type: "chatState",
+      payload: { sessionId: null, messages: [], isTyping: false },
+    });
+    assert.strictEqual(harness.elements.messageInput.value, "");
+    assert.strictEqual(harness.elements.messageInput.style.height, "auto");
+  });
+
+  test("CHAT_JS submit should send trimmed message, clear input, and reset height to auto", () => {
+    const harness = createChatScriptHarness();
+    harness.postWindowMessage({
+      type: "chatState",
+      payload: { sessionId: "session-1", messages: [], isTyping: false },
+    });
+
+    harness.elements.messageInput.value = "  hello world  ";
+    harness.elements.messageInput.style.height = "52px";
+
+    harness.listeners.composer.submit({ preventDefault: () => {} });
+
+    const sendMessages = harness.sentMessages.filter((m: any) => m.type === "sendMessage");
+    assert.strictEqual(sendMessages.length, 1);
+    assert.deepStrictEqual(sendMessages[0], { type: "sendMessage", sessionId: "session-1", text: "hello world" });
+    assert.strictEqual(harness.elements.messageInput.value, "");
+    assert.strictEqual(harness.elements.messageInput.style.height, "auto");
+  });
+
   test("CHAT_JS updateUI should properly configure disabled states and ARIA attributes", () => {
     const elements: any = {
       chat: { innerHTML: "", scrollTop: 0, scrollHeight: 0, addEventListener: () => {}, querySelectorAll: () => [] },
@@ -267,6 +319,7 @@ suite("chatAssets unit tests", () => {
         value: "",
         disabled: false,
         placeholder: "",
+        style: { height: "" },
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
       },

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -2,10 +2,6 @@ import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
 function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: any) => string }) {
-  const listeners: Record<string, Record<string, any>> = {
-    messageInput: {},
-    composer: {},
-  };
   const elements: Record<string, any> = {
     chat: {
       innerHTML: "",
@@ -19,10 +15,8 @@ function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: 
       value: "",
       disabled: false,
       placeholder: "",
-      style: { height: "" },
-      scrollHeight: 0,
       setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
-      addEventListener: (evt: string, cb: any) => { listeners.messageInput[evt] = cb; },
+      addEventListener: () => {},
     },
     sendButton: {
       disabled: false,
@@ -31,7 +25,7 @@ function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: 
       addEventListener: () => {},
     },
     sessionLabel: { textContent: "" },
-    composer: { addEventListener: (evt: string, cb: any) => { listeners.composer[evt] = cb; } },
+    composer: { addEventListener: () => {} },
   };
   const messageListeners: Array<(event: { data: any }) => void> = [];
   const mockDocument = {
@@ -43,10 +37,8 @@ function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: 
         messageListeners.push(cb);
       }
     },
-    getComputedStyle: () => ({ borderTopWidth: "1px", borderBottomWidth: "1px" }),
   };
-  const sentMessages: any[] = [];
-  const mockVscode = { postMessage: (msg: any) => sentMessages.push(msg) };
+  const mockVscode = { postMessage: () => {} };
   const mockNavigator = { clipboard: { writeText: async () => {} } };
 
   const runScript = new Function(
@@ -61,8 +53,6 @@ function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: 
 
   return {
     elements,
-    listeners,
-    sentMessages,
     postWindowMessage: (data: any) => {
       messageListeners.forEach((listener) => listener({ data }));
     },
@@ -269,48 +259,6 @@ suite("chatAssets unit tests", () => {
     );
   });
 
-  test("CHAT_JS should adjust height to scrollHeight plus border height on input", () => {
-    const harness = createChatScriptHarness();
-    harness.postWindowMessage({
-      type: "chatState",
-      payload: { sessionId: "session-1", messages: [], isTyping: false },
-    });
-    harness.elements.messageInput.scrollHeight = 50;
-    harness.listeners.messageInput.input();
-    assert.strictEqual(harness.elements.messageInput.style.height, "52px");
-  });
-
-  test("CHAT_JS chatState should clear input and reset height to auto if no session", () => {
-    const harness = createChatScriptHarness();
-    harness.elements.messageInput.value = "old text";
-    harness.elements.messageInput.style.height = "52px";
-    harness.postWindowMessage({
-      type: "chatState",
-      payload: { sessionId: null, messages: [], isTyping: false },
-    });
-    assert.strictEqual(harness.elements.messageInput.value, "");
-    assert.strictEqual(harness.elements.messageInput.style.height, "auto");
-  });
-
-  test("CHAT_JS submit should send trimmed message, clear input, and reset height to auto", () => {
-    const harness = createChatScriptHarness();
-    harness.postWindowMessage({
-      type: "chatState",
-      payload: { sessionId: "session-1", messages: [], isTyping: false },
-    });
-
-    harness.elements.messageInput.value = "  hello world  ";
-    harness.elements.messageInput.style.height = "52px";
-
-    harness.listeners.composer.submit({ preventDefault: () => {} });
-
-    const sendMessages = harness.sentMessages.filter((m: any) => m.type === "sendMessage");
-    assert.strictEqual(sendMessages.length, 1);
-    assert.deepStrictEqual(sendMessages[0], { type: "sendMessage", sessionId: "session-1", text: "hello world" });
-    assert.strictEqual(harness.elements.messageInput.value, "");
-    assert.strictEqual(harness.elements.messageInput.style.height, "auto");
-  });
-
   test("CHAT_JS updateUI should properly configure disabled states and ARIA attributes", () => {
     const elements: any = {
       chat: { innerHTML: "", scrollTop: 0, scrollHeight: 0, addEventListener: () => {}, querySelectorAll: () => [] },
@@ -319,7 +267,6 @@ suite("chatAssets unit tests", () => {
         value: "",
         disabled: false,
         placeholder: "",
-        style: { height: "" },
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
       },

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -311,6 +311,26 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(harness.elements.messageInput.style.height, "auto");
   });
 
+  test("CHAT_JS keydown Ctrl+Enter should send trimmed message, clear input, and reset height to auto", () => {
+    const harness = createChatScriptHarness();
+    harness.postWindowMessage({
+      type: "chatState",
+      payload: { sessionId: "session-1", messages: [], isTyping: false },
+    });
+
+    harness.elements.messageInput.value = "  hello keydown  ";
+    harness.listeners.messageInput.input();
+    harness.elements.messageInput.style.height = "52px";
+
+    harness.listeners.messageInput.keydown({ ctrlKey: true, metaKey: false, key: "Enter", preventDefault: () => {} });
+
+    const sendMessages = harness.sentMessages.filter((m: any) => m.type === "sendMessage");
+    assert.strictEqual(sendMessages.length, 1);
+    assert.deepStrictEqual(sendMessages[0], { type: "sendMessage", sessionId: "session-1", text: "hello keydown" });
+    assert.strictEqual(harness.elements.messageInput.value, "");
+    assert.strictEqual(harness.elements.messageInput.style.height, "auto");
+  });
+
   test("CHAT_JS updateUI should properly configure disabled states and ARIA attributes", () => {
     const elements: any = {
       chat: { innerHTML: "", scrollTop: 0, scrollHeight: 0, addEventListener: () => {}, querySelectorAll: () => [] },

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,7 +1,10 @@
 import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
-function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: any) => string }) {
+function createChatScriptHarness(
+  domPurify?: { sanitize: (html: string, config: any) => string },
+  computedStyle = { borderTopWidth: "1px", borderBottomWidth: "1px" },
+) {
   const listeners: Record<string, Record<string, any>> = {
     messageInput: {},
     composer: {},
@@ -43,7 +46,7 @@ function createChatScriptHarness(domPurify?: { sanitize: (html: string, config: 
         messageListeners.push(cb);
       }
     },
-    getComputedStyle: () => ({ borderTopWidth: "1px", borderBottomWidth: "1px" }),
+    getComputedStyle: () => computedStyle,
   };
   const sentMessages: any[] = [];
   const mockVscode = { postMessage: (msg: any) => sentMessages.push(msg) };
@@ -396,5 +399,16 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton["aria-disabled"], "false");
     assert.strictEqual(elements.sendButton.title, "Send message (Ctrl/Cmd+Enter)");
     assert.strictEqual(elements.sendButton["aria-label"], "Send message (Ctrl/Cmd+Enter)");
+  });
+
+  test("CHAT_JS should preserve fractional border widths when auto-resizing", () => {
+    const harness = createChatScriptHarness(undefined, { borderTopWidth: "1.5px", borderBottomWidth: "1.5px" });
+    harness.postWindowMessage({
+      type: "chatState",
+      payload: { sessionId: "session-1", messages: [], isTyping: false },
+    });
+    harness.elements.messageInput.scrollHeight = 50;
+    harness.listeners.messageInput.input();
+    assert.strictEqual(harness.elements.messageInput.style.height, "53px");
   });
 });

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -28,7 +28,7 @@ p { margin: 0 0 8px; }
 .typing-dot:nth-child(3) { animation-delay: -0.16s; }
 @keyframes typing { 0%, 80%, 100% { transform: scale(0); } 40% { transform: scale(1); } }
 #composer { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: var(--vscode-editor-background); border-top: 1px solid var(--vscode-widget-border, transparent); }
-#messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: none; overflow-y: auto; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; box-sizing: border-box; }
+#messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: none; overflow-y: auto; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; }
 #messageInput:focus-visible { border-color: var(--vscode-focusBorder); }
 #messageInput:disabled, #messageInput[aria-disabled="true"] { opacity: 0.6; cursor: not-allowed; resize: none; }
 .composer-actions { display: flex; justify-content: space-between; align-items: center; }
@@ -116,6 +116,7 @@ export const CHAT_JS = `(function() {
 
     if (!hasSession) {
       messageInput.value = "";
+      messageInput.style.height = "auto";
     }
 
     messageInput.placeholder = hasSession
@@ -158,9 +159,16 @@ export const CHAT_JS = `(function() {
     updateUI();
   }
 
+  function getVerticalBorderHeight(el) {
+    const style = window.getComputedStyle(el);
+    const top = parseFloat(style.borderTopWidth) || 0;
+    const bottom = parseFloat(style.borderBottomWidth) || 0;
+    return top + bottom;
+  }
+
   messageInput.addEventListener("input", () => {
     messageInput.style.height = "auto";
-    messageInput.style.height = messageInput.scrollHeight + "px";
+    messageInput.style.height = (messageInput.scrollHeight + getVerticalBorderHeight(messageInput)) + "px";
     updateUI();
   });
 

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -18,6 +18,7 @@ p { margin: 0 0 8px; }
 .copy-code-button { position: absolute; top: 6px; right: 6px; opacity: 0; transition: opacity .15s ease; border: 1px solid var(--vscode-button-border, transparent); background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 11px; }
 .code-block:hover .copy-code-button, .copy-code-button:focus-visible { opacity: 1; }
 .copy-code-button:hover { background: var(--vscode-button-secondaryHoverBackground); }
+.copy-code-button:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
 .copy-code-button:active { transform: scale(0.96); }
 @keyframes slide-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 .typing { display: none; align-items: center; gap: 4px; color: var(--vscode-descriptionForeground); font-size: 12px; font-style: italic; padding: 0 8px 8px; }
@@ -27,13 +28,14 @@ p { margin: 0 0 8px; }
 .typing-dot:nth-child(3) { animation-delay: -0.16s; }
 @keyframes typing { 0%, 80%, 100% { transform: scale(0); } 40% { transform: scale(1); } }
 #composer { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: var(--vscode-editor-background); border-top: 1px solid var(--vscode-widget-border, transparent); }
-#messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: vertical; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; }
+#messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: none; overflow-y: auto; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; box-sizing: border-box; }
 #messageInput:focus-visible { border-color: var(--vscode-focusBorder); }
 #messageInput:disabled, #messageInput[aria-disabled="true"] { opacity: 0.6; cursor: not-allowed; resize: none; }
 .composer-actions { display: flex; justify-content: space-between; align-items: center; }
 .session-label { color: var(--vscode-descriptionForeground); font-size: 11px; user-select: none; max-width: 70%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #sendButton { padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }
 #sendButton:hover:not(:disabled) { background: var(--vscode-button-hoverBackground); }
+#sendButton:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
 #sendButton:disabled, #sendButton[aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
 .activity-log { font-size: 0.9em; opacity: 0.75; margin-bottom: 2px; }
 .activity-details { margin-top: 4px; font-size: 0.9em; }
@@ -156,7 +158,12 @@ export const CHAT_JS = `(function() {
     updateUI();
   }
 
-  messageInput.addEventListener("input", updateUI);
+  messageInput.addEventListener("input", () => {
+    messageInput.style.height = "auto";
+    messageInput.style.height = messageInput.scrollHeight + "px";
+    updateUI();
+  });
+
   messageInput.addEventListener("keydown", e => {
     if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
       e.preventDefault();
@@ -164,6 +171,7 @@ export const CHAT_JS = `(function() {
         const text = messageInput.value.trim();
         vscode.postMessage({ type: "sendMessage", sessionId: state.sessionId, text });
         messageInput.value = "";
+        messageInput.style.height = "auto";
         updateUI();
       }
     }
@@ -175,6 +183,7 @@ export const CHAT_JS = `(function() {
     if (state.sessionId && text) {
       vscode.postMessage({ type: "sendMessage", sessionId: state.sessionId, text });
       messageInput.value = "";
+      messageInput.style.height = "auto";
       updateUI();
     }
   });

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -162,7 +162,7 @@ export const CHAT_JS = `(function() {
   messageInput.addEventListener("input", () => {
     messageInput.style.height = "auto";
     const computed = window.getComputedStyle(messageInput);
-    const borderY = parseInt(computed.borderTopWidth, 10) + parseInt(computed.borderBottomWidth, 10);
+    const borderY = parseFloat(computed.borderTopWidth) + parseFloat(computed.borderBottomWidth);
     messageInput.style.height = (messageInput.scrollHeight + (isNaN(borderY) ? 0 : borderY)) + "px";
     updateUI();
   });

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -28,7 +28,7 @@ p { margin: 0 0 8px; }
 .typing-dot:nth-child(3) { animation-delay: -0.16s; }
 @keyframes typing { 0%, 80%, 100% { transform: scale(0); } 40% { transform: scale(1); } }
 #composer { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: var(--vscode-editor-background); border-top: 1px solid var(--vscode-widget-border, transparent); }
-#messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: none; overflow-y: auto; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; }
+#messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: none; overflow-y: auto; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; box-sizing: border-box; }
 #messageInput:focus-visible { border-color: var(--vscode-focusBorder); }
 #messageInput:disabled, #messageInput[aria-disabled="true"] { opacity: 0.6; cursor: not-allowed; resize: none; }
 .composer-actions { display: flex; justify-content: space-between; align-items: center; }
@@ -116,7 +116,6 @@ export const CHAT_JS = `(function() {
 
     if (!hasSession) {
       messageInput.value = "";
-      messageInput.style.height = "auto";
     }
 
     messageInput.placeholder = hasSession
@@ -159,16 +158,11 @@ export const CHAT_JS = `(function() {
     updateUI();
   }
 
-  function getVerticalBorderHeight(el) {
-    const style = window.getComputedStyle(el);
-    const top = parseFloat(style.borderTopWidth) || 0;
-    const bottom = parseFloat(style.borderBottomWidth) || 0;
-    return top + bottom;
-  }
-
   messageInput.addEventListener("input", () => {
     messageInput.style.height = "auto";
-    messageInput.style.height = (messageInput.scrollHeight + getVerticalBorderHeight(messageInput)) + "px";
+    const computed = window.getComputedStyle(messageInput);
+    const borderY = parseInt(computed.borderTopWidth, 10) + parseInt(computed.borderBottomWidth, 10);
+    messageInput.style.height = (messageInput.scrollHeight + (isNaN(borderY) ? 0 : borderY)) + "px";
     updateUI();
   });
 


### PR DESCRIPTION
チャットビュー内の送信ボタンとコードコピーボタンに対して、キーボードフォーカス時に視覚的なフィードバックが得られるよう `:focus-visible` スタイル（VS Code標準の `--vscode-focusBorder`）を追加しました。これにより、キーボードを利用するユーザーのアクセシビリティが向上します。また、チャット入力欄が内容に合わせて自動リサイズされるように微調整し、全体的な操作性を高めました。これらの変更と学びは `.Jules/palette.md` に日本語で追記されています。

---
*PR created automatically by Jules for task [1084557960611584297](https://jules.google.com/task/1084557960611584297) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

送信ボタン・コードコピーボタンへの `:focus-visible` アウトライン追加と、`#messageInput` の JS 自動リサイズ（`resize: none` + `scrollHeight` ベースの高さ計算）への切り替えが主な変更です。セッション解除・送信の両パスで `style.height = "auto"` をリセットする修正も含まれており、前回のレビュー指摘への対応も完了しています。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

CSS アクセシビリティ改善と JS の高さリセットロジックはいずれも局所的な変更で、既存の送受信フローや DOMPurify によるサニタイズ処理には影響しません。

変更範囲はスタイルと UI 状態管理に限定されており、セキュリティ・データフロー・API 契約に関わるロジックは一切触れていません。新規テストも主要な動作パスをカバーしており、安全にマージできます。

特に注意が必要なファイルはありません。`src/test/chatAssets.unit.test.ts` の Ctrl+Enter パスのテスト欠落は軽微で、マージのブロッカーにはなりません。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | `:focus-visible` アウトラインスタイルを送信ボタン・コードコピーボタンに追加、`#messageInput` を JS 自動リサイズ方式（`resize: none` + `overflow-y: auto`）に変更し、送信・セッション解除時に高さをリセットするロジックを追加。CSS・JS ともに変更内容は正確で既存ロジックとの整合性も問題なし。 |
| src/test/chatAssets.unit.test.ts | 入力時の高さ自動調整・セッション解除時の高さリセット・フォーム submit 時の高さリセットを検証するテストを追加。ただし、Ctrl/Cmd+Enter キーボードショートカット経由の送信後に高さがリセットされるパスはテストされていない。 |
| .Jules/palette.md | 既存の英文ノートを日本語訳し、今回のフォーカス改善に関する新しいラーニングセクションを追記。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ユーザーがメッセージを入力] --> B[input イベント発火]
    B --> C[style.height = 'auto']
    C --> D[scrollHeight + borderHeight を計算]
    D --> E[style.height を px 値にセット]
    E --> F[updateUI 呼び出し]

    G[送信: Ctrl/Cmd+Enter] --> H[messageInput.value.trim を送信]
    H --> I[value = '']
    I --> J[style.height = 'auto']
    J --> K[updateUI]

    L[送信: composer submit] --> M[messageInput.value.trim を送信]
    M --> N[value = '']
    N --> O[style.height = 'auto']
    O --> P[updateUI]

    Q[chatState: sessionId = null] --> R[value = '']
    R --> S[style.height = 'auto']
    S --> T[UI を無効化]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/webview/chatAssets.ts`, line 117-119 ([link](https://github.com/hiroki-org/jules-extension/blob/068dcb33ae1160e8d9187ce3ea149f9bd7f48f3b/src/webview/chatAssets.ts#L117-L119)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `updateUI` でセッションが解除されたとき `messageInput.value = ""` は実行されますが、インラインの `style.height` はリセットされません。ユーザーが長いテキストを入力してテキストエリアが拡張された後にセッションが切れると、テキストエリアが不必要に大きいまま表示され続けます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 117-119

   Comment:
   `updateUI` でセッションが解除されたとき `messageInput.value = ""` は実行されますが、インラインの `style.height` はリセットされません。ユーザーが長いテキストを入力してテキストエリアが拡張された後にセッションが切れると、テキストエリアが不必要に大きいまま表示され続けます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/test/chatAssets.unit.test.ts:295-312
**Ctrl+Enter 送信パスの高さリセットが未テスト**

`composer.submit` イベントによる高さリセットはテストされていますが、`keydown`（Ctrl/Cmd+Enter）経由の送信後に `messageInput.style.height` が `"auto"` にリセットされるパスは現在テストがありません。`src/webview/chatAssets.ts` の `keydown` ハンドラー（`messageInput.style.height = "auto"` を含む行）が回帰しても検知できない状態です。`listeners.messageInput.keydown({ metaKey: true, key: "Enter", preventDefault: () => {} })` を使ったテストを追加することで、両送信パスのカバレッジが揃います。


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ux): add border height calculation t..."](https://github.com/hiroki-org/jules-extension/commit/006c1ca21cddaf958f355ea2209491955d3c19fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30709427)</sub>

<!-- /greptile_comment -->