### PR TITLE
⚡ Bolt: ループ処理 (`for...in` と `reduce`) のパフォーマンス最適化

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1742,13 +1742,11 @@ export class JulesSessionsProvider implements vscode.TreeDataProvider<vscode.Tre
       logChannel.appendLine(
         `Jules: Debug - Total sessions: ${allSessionsMapped.length}`,
       );
-      const stateCounts = allSessionsMapped.reduce(
-        (acc, s) => {
-          acc[s.rawState] = (acc[s.rawState] || 0) + 1;
-          return acc;
-        },
-        Object.create(null) as Record<string, number>,
-      );
+      const stateCounts = Object.create(null) as Record<string, number>;
+      for (let i = 0; i < allSessionsMapped.length; i += 1) {
+        const s = allSessionsMapped[i];
+        stateCounts[s.rawState] = (stateCounts[s.rawState] || 0) + 1;
+      }
       logChannel.appendLine(
         `Jules: Debug - State counts: ${JSON.stringify(stateCounts)}`,
       );
@@ -2469,7 +2467,9 @@ export function activate(context: vscode.ExtensionContext) {
   const now = Date.now();
   let expiredCount = 0;
 
-  for (const url in prStatusCache) {
+  const cacheKeys = Object.keys(prStatusCache);
+  for (let i = 0; i < cacheKeys.length; i += 1) {
+    const url = cacheKeys[i];
     const entry = prStatusCache[url];
     const ttl = entry.isError ? PR_ERROR_CACHE_DURATION : PR_CACHE_DURATION;
     if (now - entry.lastChecked > ttl) {
@@ -3247,11 +3247,10 @@ export function activate(context: vscode.ExtensionContext) {
               let keySummary = activeKeys.join(", ");
               if (activeKeys.length === 0) {
                 const inferredKeys: string[] = [];
-                for (const key in activity) {
-                  if (
-                    Object.prototype.hasOwnProperty.call(activity, key) &&
-                    isInferredActivityLogKey(key)
-                  ) {
+                const activityKeys = Object.keys(activity);
+                for (let i = 0; i < activityKeys.length; i += 1) {
+                  const key = activityKeys[i];
+                  if (isInferredActivityLogKey(key)) {
                     const value = (
                       activity as unknown as Record<string, unknown>
                     )[key];


### PR DESCRIPTION
💡 What: This PR optimizes `for...in` and `.reduce` operations in `src/extension.ts` by replacing them with `Object.keys()` and index-based `for` loops.
🎯 Why: In V8, `for...in` loops walk the prototype chain and are generally slower than `Object.keys()` coupled with index-based iteration. `.reduce` incurs callback overhead compared to standard `for` loops. This micro-optimization aligns with V8 best practices for performance-sensitive loops, avoiding unneeded garbage collection and redundant checks like `hasOwnProperty`.
📊 Impact: Eliminates callback overhead in `stateCounts` accumulation and avoids prototype chain traversal during PR cache cleanup and activity payload parsing, marginally improving loop execution speed and reducing memory pressure.
🔬 Measurement: Verified that tests pass via `pnpm run test:unit` and `xvfb-run -a pnpm test`. Benchmark manually by comparing CPU profiling on session array iterations before and after changes.

---
*PR created automatically by Jules for task [2223678918784566734](https://jules.google.com/task/2223678918784566734) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `src/extension.ts` 内の3か所のループ処理を、`reduce` や `for...in` から `Object.keys()` + インデックスベース `for` ループへ書き換えるマイクロ最適化です。いずれの変更も機能的に等価であり、動作への影響はありません。

- **`stateCounts`の集計**（L1742）: `reduce` コールバックを `for` ループに置き換え。初期値も同じ `Object.create(null)` を使用しており、完全に等価。
- **`prStatusCache`のクリーンアップ**（L2467）: `for...in` を `Object.keys()` 事前スナップショット方式に変更。ループ中に `delete` しても安全なコードになった。
- **`activity` キー列挙**（L3247）: `for...in` + `hasOwnProperty` を `Object.keys()` に置き換え。プロトタイプチェーンを除外する意図は同じで、よりシンプルな実装になった。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

いずれの変更も機能的に等価な書き換えであり、ロジックの破壊はなくマージ自体は安全です。

3か所すべての変換が正確で元の動作を完全に再現しています。`prStatusCache` のループ中 `delete` も `Object.keys()` スナップショット方式により安全性が向上しています。コードは問題なく動作するため、主な懸念はPR説明で謳うパフォーマンス効果が現実の計測値に現れるかどうかという点のみです。

特に問題のあるファイルはありませんが、`src/extension.ts` の変更箇所が広範なため、念のため目を通しておくと安心です。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 3か所のループを `for...in`/`reduce` から `Object.keys()` + インデックスループへ書き換え。いずれも機能的に等価な変換で、論理上のバグは確認されず。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/extension.ts:1742-1752
**パフォーマンス改善効果の過大評価に注意**

PR説明で言及されている「GC削減」「プロトタイプチェーントラバーサルの排除」は現代のV8（9.x以降）では既に内部最適化済みであり、この規模の処理（セッション数は通常数十〜数百件）では実測上の差はほぼ出ません。コード自体は正しく問題ありませんが、期待するパフォーマンス改善がベンチマークで確認できているかをご確認ください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Optimize \`for...in\` and \`reduce\` operati..."](https://github.com/hiroki-org/jules-extension/commit/e8a73f86323935a20d4bfe230ff93b6425d194c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30857700)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->