### PR TITLE
Refactor githubUtils exports

### DIFF
--- a/src/githubUtils.ts
+++ b/src/githubUtils.ts
@@ -47,10 +47,13 @@ export interface OctokitClient {
     };
 }
 
-// Helper factory function to abstract dynamic Octokit import and instantiation.
-export const getOctokitInstance = async (token: string): Promise<OctokitClient> => {
-    const { Octokit } = await import('@octokit/rest');
-    return new Octokit({ auth: token }) as unknown as OctokitClient;
+// Helper object containing dependencies to allow stubbing in unit tests without CommonJS 'exports' hacks
+export const deps = {
+    // Factory function to abstract dynamic Octokit import and instantiation.
+    getOctokitInstance: async (token: string): Promise<OctokitClient> => {
+        const { Octokit } = await import('@octokit/rest');
+        return new Octokit({ auth: token }) as unknown as OctokitClient;
+    }
 };
 
 export async function createRemoteBranch(
@@ -59,7 +62,7 @@ export async function createRemoteBranch(
     repo: string,
     branchName: string
 ): Promise<void> {
-    const octokit = await exports.getOctokitInstance(pat);
+    const octokit = await deps.getOctokitInstance(pat);
 
     // デフォルトブランチのSHAを取得
     const { data: repoData } = await octokit.repos.get({ owner, repo });
@@ -115,7 +118,7 @@ export async function getPullRequestBranchInfo(
     prNumber: number
 ): Promise<PullRequestBranchInfo | null> {
     try {
-        const octokit = await exports.getOctokitInstance(token);
+        const octokit = await deps.getOctokitInstance(token);
 
         const { data: pr } = await octokit.pulls.get({
             owner,

--- a/src/githubUtils.ts
+++ b/src/githubUtils.ts
@@ -47,21 +47,11 @@ export interface OctokitClient {
     };
 }
 
-// Function pointer to allow overriding the instance fetcher in unit tests without CommonJS 'exports' hacks
-let octokitFactory = async (token: string): Promise<OctokitClient> => {
+// Helper factory function to abstract dynamic Octokit import and instantiation.
+export const getOctokitInstance = async (token: string): Promise<OctokitClient> => {
     const { Octokit } = await import('@octokit/rest');
     return new Octokit({ auth: token }) as unknown as OctokitClient;
 };
-
-// Helper factory function to abstract dynamic Octokit import and instantiation.
-export async function getOctokitInstance(token: string): Promise<OctokitClient> {
-    return octokitFactory(token);
-}
-
-// Helper setter for unit tests to stub the factory
-export function setOctokitFactory(factory: (token: string) => Promise<OctokitClient>): void {
-    octokitFactory = factory;
-}
 
 export async function createRemoteBranch(
     pat: string,
@@ -69,7 +59,7 @@ export async function createRemoteBranch(
     repo: string,
     branchName: string
 ): Promise<void> {
-    const octokit = await getOctokitInstance(pat);
+    const octokit = await exports.getOctokitInstance(pat);
 
     // デフォルトブランチのSHAを取得
     const { data: repoData } = await octokit.repos.get({ owner, repo });
@@ -125,7 +115,7 @@ export async function getPullRequestBranchInfo(
     prNumber: number
 ): Promise<PullRequestBranchInfo | null> {
     try {
-        const octokit = await getOctokitInstance(token);
+        const octokit = await exports.getOctokitInstance(token);
 
         const { data: pr } = await octokit.pulls.get({
             owner,

--- a/src/test/githubUtils.unit.test.ts
+++ b/src/test/githubUtils.unit.test.ts
@@ -47,13 +47,13 @@ suite('githubUtils', () => {
     suite('getPullRequestBranchInfo', () => {
 
         test('should return null if API request fails', async () => {
-            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => Promise.reject(new Error('API error')));
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').rejects(new Error('API error'));
             const result = await githubUtils.getPullRequestBranchInfo('invalid-token', 'owner', 'repo', 1);
             assert.strictEqual(result, null);
         });
 
         test('should return null if API request fails with non-Error', async () => {
-            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => Promise.reject('String error'));
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').rejects('String error' as any);
             const result = await githubUtils.getPullRequestBranchInfo('invalid-token', 'owner', 'repo', 1);
             assert.strictEqual(result, null);
         });
@@ -72,7 +72,7 @@ suite('githubUtils', () => {
                     })
                 }
             };
-            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').resolves(mockOctokit as any);
 
             const result = await githubUtils.getPullRequestBranchInfo('token', 'owner', 'repo', 1);
             assert.strictEqual(result, null);
@@ -99,7 +99,7 @@ suite('githubUtils', () => {
                     })
                 }
             };
-            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').resolves(mockOctokit as any);
 
             const result = await githubUtils.getPullRequestBranchInfo('token', 'owner', 'repo', 1);
             assert.deepStrictEqual(result, {
@@ -134,7 +134,7 @@ suite('githubUtils', () => {
                     })
                 }
             };
-            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').resolves(mockOctokit as any);
 
             const result = await githubUtils.getPullRequestBranchInfo('token', 'owner', 'repo', 1);
             assert.strictEqual(result?.state, 'merged');
@@ -154,7 +154,7 @@ suite('githubUtils', () => {
                     createRef: mockCreateRef
                 }
             };
-            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').resolves(mockOctokit as any);
 
             await githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch');
 
@@ -167,7 +167,7 @@ suite('githubUtils', () => {
         });
 
         test('should throw error if factory throws', async () => {
-            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => Promise.reject(new Error('Auth failed')));
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').rejects(new Error('Auth failed'));
             await assert.rejects(githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'), /Auth failed/);
         });
 
@@ -181,7 +181,7 @@ suite('githubUtils', () => {
                     createRef: sandbox.stub().resolves()
                 }
             };
-            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').resolves(mockOctokit as any);
 
             await assert.rejects(
                 githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'),
@@ -199,7 +199,7 @@ suite('githubUtils', () => {
                     createRef: sandbox.stub().resolves()
                 }
             };
-            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').resolves(mockOctokit as any);
 
             await assert.rejects(
                 githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'),
@@ -217,7 +217,7 @@ suite('githubUtils', () => {
                     createRef: sandbox.stub().rejects(new Error('Failed to create ref'))
                 }
             };
-            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').resolves(mockOctokit as any);
 
             await assert.rejects(
                 githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'),

--- a/src/test/githubUtils.unit.test.ts
+++ b/src/test/githubUtils.unit.test.ts
@@ -37,7 +37,7 @@ suite('githubUtils', () => {
 
     suite('getOctokitInstance', () => {
         test('should use default factory to return an Octokit instance', async () => {
-            const instance = await githubUtils.getOctokitInstance('dummy-token');
+            const instance = await githubUtils.deps.getOctokitInstance('dummy-token');
             assert.strictEqual(typeof instance, 'object');
             // Check that it's a real Octokit instance using an internal method mapping
             assert.ok((instance as any).request);
@@ -47,13 +47,13 @@ suite('githubUtils', () => {
     suite('getPullRequestBranchInfo', () => {
 
         test('should return null if API request fails', async () => {
-            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => Promise.reject(new Error('API error')));
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => Promise.reject(new Error('API error')));
             const result = await githubUtils.getPullRequestBranchInfo('invalid-token', 'owner', 'repo', 1);
             assert.strictEqual(result, null);
         });
 
         test('should return null if API request fails with non-Error', async () => {
-            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => Promise.reject('String error'));
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => Promise.reject('String error'));
             const result = await githubUtils.getPullRequestBranchInfo('invalid-token', 'owner', 'repo', 1);
             assert.strictEqual(result, null);
         });
@@ -72,7 +72,7 @@ suite('githubUtils', () => {
                     })
                 }
             };
-            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             const result = await githubUtils.getPullRequestBranchInfo('token', 'owner', 'repo', 1);
             assert.strictEqual(result, null);
@@ -99,7 +99,7 @@ suite('githubUtils', () => {
                     })
                 }
             };
-            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             const result = await githubUtils.getPullRequestBranchInfo('token', 'owner', 'repo', 1);
             assert.deepStrictEqual(result, {
@@ -134,7 +134,7 @@ suite('githubUtils', () => {
                     })
                 }
             };
-            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             const result = await githubUtils.getPullRequestBranchInfo('token', 'owner', 'repo', 1);
             assert.strictEqual(result?.state, 'merged');
@@ -154,7 +154,7 @@ suite('githubUtils', () => {
                     createRef: mockCreateRef
                 }
             };
-            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             await githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch');
 
@@ -167,7 +167,7 @@ suite('githubUtils', () => {
         });
 
         test('should throw error if factory throws', async () => {
-            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => Promise.reject(new Error('Auth failed')));
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => Promise.reject(new Error('Auth failed')));
             await assert.rejects(githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'), /Auth failed/);
         });
 
@@ -181,7 +181,7 @@ suite('githubUtils', () => {
                     createRef: sandbox.stub().resolves()
                 }
             };
-            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             await assert.rejects(
                 githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'),
@@ -199,7 +199,7 @@ suite('githubUtils', () => {
                     createRef: sandbox.stub().resolves()
                 }
             };
-            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             await assert.rejects(
                 githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'),
@@ -217,7 +217,7 @@ suite('githubUtils', () => {
                     createRef: sandbox.stub().rejects(new Error('Failed to create ref'))
                 }
             };
-            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
+            sandbox.stub(githubUtils.deps, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             await assert.rejects(
                 githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'),

--- a/src/test/githubUtils.unit.test.ts
+++ b/src/test/githubUtils.unit.test.ts
@@ -45,22 +45,15 @@ suite('githubUtils', () => {
     });
 
     suite('getPullRequestBranchInfo', () => {
-        teardown(() => {
-            // Restore factory to its original implementation using dynamic import
-            githubUtils.setOctokitFactory(async (token: string) => {
-                const { Octokit } = await import('@octokit/rest');
-                return new Octokit({ auth: token }) as unknown as githubUtils.OctokitClient;
-            });
-        });
 
         test('should return null if API request fails', async () => {
-            githubUtils.setOctokitFactory(async () => Promise.reject(new Error('API error')));
+            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => Promise.reject(new Error('API error')));
             const result = await githubUtils.getPullRequestBranchInfo('invalid-token', 'owner', 'repo', 1);
             assert.strictEqual(result, null);
         });
 
         test('should return null if API request fails with non-Error', async () => {
-            githubUtils.setOctokitFactory(async () => Promise.reject('String error'));
+            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => Promise.reject('String error'));
             const result = await githubUtils.getPullRequestBranchInfo('invalid-token', 'owner', 'repo', 1);
             assert.strictEqual(result, null);
         });
@@ -79,7 +72,7 @@ suite('githubUtils', () => {
                     })
                 }
             };
-            githubUtils.setOctokitFactory(async () => mockOctokit as any);
+            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             const result = await githubUtils.getPullRequestBranchInfo('token', 'owner', 'repo', 1);
             assert.strictEqual(result, null);
@@ -106,7 +99,7 @@ suite('githubUtils', () => {
                     })
                 }
             };
-            githubUtils.setOctokitFactory(async () => mockOctokit as any);
+            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             const result = await githubUtils.getPullRequestBranchInfo('token', 'owner', 'repo', 1);
             assert.deepStrictEqual(result, {
@@ -141,7 +134,7 @@ suite('githubUtils', () => {
                     })
                 }
             };
-            githubUtils.setOctokitFactory(async () => mockOctokit as any);
+            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             const result = await githubUtils.getPullRequestBranchInfo('token', 'owner', 'repo', 1);
             assert.strictEqual(result?.state, 'merged');
@@ -149,12 +142,6 @@ suite('githubUtils', () => {
     });
 
     suite('createRemoteBranch', () => {
-        teardown(() => {
-            githubUtils.setOctokitFactory(async (token: string) => {
-                const { Octokit } = await import('@octokit/rest');
-                return new Octokit({ auth: token }) as unknown as githubUtils.OctokitClient;
-            });
-        });
 
         test('should create branch successfully', async () => {
             const mockCreateRef = sandbox.stub().resolves();
@@ -167,7 +154,7 @@ suite('githubUtils', () => {
                     createRef: mockCreateRef
                 }
             };
-            githubUtils.setOctokitFactory(async () => mockOctokit as any);
+            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             await githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch');
 
@@ -180,7 +167,7 @@ suite('githubUtils', () => {
         });
 
         test('should throw error if factory throws', async () => {
-            githubUtils.setOctokitFactory(async () => Promise.reject(new Error('Auth failed')));
+            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => Promise.reject(new Error('Auth failed')));
             await assert.rejects(githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'), /Auth failed/);
         });
 
@@ -194,7 +181,7 @@ suite('githubUtils', () => {
                     createRef: sandbox.stub().resolves()
                 }
             };
-            githubUtils.setOctokitFactory(async () => mockOctokit as any);
+            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             await assert.rejects(
                 githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'),
@@ -212,7 +199,7 @@ suite('githubUtils', () => {
                     createRef: sandbox.stub().resolves()
                 }
             };
-            githubUtils.setOctokitFactory(async () => mockOctokit as any);
+            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             await assert.rejects(
                 githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'),
@@ -230,7 +217,7 @@ suite('githubUtils', () => {
                     createRef: sandbox.stub().rejects(new Error('Failed to create ref'))
                 }
             };
-            githubUtils.setOctokitFactory(async () => mockOctokit as any);
+            sandbox.stub(githubUtils, 'getOctokitInstance').callsFake(async () => mockOctokit as any);
 
             await assert.rejects(
                 githubUtils.createRemoteBranch('token', 'owner', 'repo', 'new-branch'),


### PR DESCRIPTION
Refactored src/githubUtils.ts to export getOctokitInstance directly and remove the octokitFactory workaround, and updated unit tests to use sandbox.stub cleanly.

---
*PR created automatically by Jules for task [11408308362471551135](https://jules.google.com/task/11408308362471551135) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `src/githubUtils.ts` における Octokit インスタンス取得のテスト用依存注入パターンを、`octokitFactory` + `setOctokitFactory` という明示的なセッター方式から、`deps` オブジェクトをエクスポートして Sinon で直接スタブする方式に変更するリファクタリングです。

- `octokitFactory`（モジュールレベルの可変関数ポインタ）と `setOctokitFactory` / `getOctokitInstance` エクスポートを削除し、代わりに `export const deps = { getOctokitInstance }` を追加。内部呼び出しは `deps.getOctokitInstance(...)` に統一されています。
- テストでは `sandbox.stub(githubUtils.deps, 'getOctokitInstance')` でスタブし、外側の `teardown` にある `sandbox.restore()` で自動復元するため、各スイートに存在していた手動の `teardown` ブロック（ファクトリ復元）を削除しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はテスト容易性のためのリファクタリングのみで、本番ロジックに影響なく安全にマージできます。

削除された `setOctokitFactory` / `getOctokitInstance` エクスポートは他のファイルから直接呼ばれておらず、内部呼び出し（`deps.getOctokitInstance`）も正しく更新されています。Sinon の `sandbox.stub` によるスタブは `const` オブジェクトのプロパティ置換として正しく機能し、`sandbox.restore()` による自動復元でテスト間の独立性も保たれています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/githubUtils.ts | `deps` オブジェクトパターンへの切り替え。`octokitFactory`・`setOctokitFactory`・`getOctokitInstance` エクスポートを削除し、`export const deps` に集約。内部呼び出しも適切に更新されている。 |
| src/test/githubUtils.unit.test.ts | `setOctokitFactory` の呼び出しを `sandbox.stub(githubUtils.deps, 'getOctokitInstance')` に置き換え。`sandbox.restore()` による自動復元を活かし、冗長な手動 teardown を削除。テスト構造は整理されている。 |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Refactor githubUtils to use deps object ..."](https://github.com/hiroki-org/jules-extension/commit/c320c9c27e50dfe7025a54d67cfb5d194b92becb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30987008)</sub>

<!-- /greptile_comment -->