### PR TITLE
🎨 Palette: 無効化されたボタンのホバースタイルを修正

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -159,11 +159,11 @@ export function getComposerHtml(
     color: var(--vscode-button-foreground);
   }
 
-  button.primary:hover {
+  button.primary:hover:not(:disabled) {
     background: var(--vscode-button-hoverBackground);
   }
 
-  button:not(.primary):hover {
+  button:not(.primary):hover:not(:disabled) {
     background: var(--vscode-button-secondaryHoverBackground);
   }
 

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -323,7 +323,14 @@ suite("Composer Test Suite", () => {
         { title: "Test" },
         "nonce-123"
       );
-      assert.ok(html.includes('button:not(.primary):hover:not(:disabled) {'));
+      assert.match(
+        html,
+        /button\.primary:hover:not\(:disabled\)\s*\{\s*background:\s*var\(--vscode-button-hoverBackground\);\s*\}/
+      );
+      assert.match(
+        html,
+        /button:not\(\.primary\):hover:not\(:disabled\)\s*\{\s*background:\s*var\(--vscode-button-secondaryHoverBackground\);\s*\}/
+      );
     });
 
     test("validation logic should work with empty initial value", () => {

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -323,10 +323,7 @@ suite("Composer Test Suite", () => {
         { title: "Test" },
         "nonce-123"
       );
-      assert.match(
-        html,
-        /button:not\(\.primary\):hover\s*{\s*background:\s*var\(--vscode-button-secondaryHoverBackground\);\s*}/
-      );
+      assert.ok(html.includes('button:not(.primary):hover:not(:disabled) {'));
     });
 
     test("validation logic should work with empty initial value", () => {


### PR DESCRIPTION
無効化されたボタンに対するホバー状態のスタイルを修正しました。

**変更内容:**
- `src/composer.ts` 内の `button.primary:hover` および `button:not(.primary):hover` セレクタに `:not(:disabled)` を追加し、無効化されたボタンがホバー時に色が変わらないように修正しました。
- 関連する単体テスト (`src/test/composer.unit.test.ts`) を更新し、この新しい動作を検証するようにしました。

**背景:**
無効化されたボタンがホバー状態のスタイルを示すと、ユーザーがクリック可能であると誤認する可能性がありました。今回の変更により、より直感的でアクセスしやすいユーザーインターフェースになります。

---
*PR created automatically by Jules for task [9477642228698411947](https://jules.google.com/task/9477642228698411947) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

無効化されたボタンがホバー時に色が変わらないよう、CSSセレクタに `:not(:disabled)` を追加した修正です。テストは正規表現を用いてセレクタと背景色プロパティの両方を検証するように改善されています。

- `src/composer.ts`: `button.primary:hover` と `button:not(.primary):hover` に `:not(:disabled)` を追加し、無効化ボタンへのホバースタイル適用を防止。
- `src/test/composer.unit.test.ts`: プライマリ・セカンダリ両方のホバースタイルを `assert.match` + 正規表現で検証するテストに更新（旧テストではセカンダリのみ確認していた）。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージしても安全です。変更はCSSセレクタの追記とテストの更新のみで、既存動作への副作用はありません。

変更内容はCSSセレクタへの `:not(:disabled)` 付加のみで、スコープが限定的かつ既存の `button:disabled` スタイルとも整合しています。テストも両方のセレクタを背景色プロパティを含む正規表現で検証しており、妥当なカバレッジが確保されています。

特に注意が必要なファイルはありません。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/composer.ts | プライマリ・セカンダリボタンのホバーセレクタに `:not(:disabled)` を追加。CSS の変更は正確で、既存の `button:disabled` スタイルと整合している。 |
| src/test/composer.unit.test.ts | テストを更新し、プライマリ・セカンダリ両方のホバーセレクタを正規表現（背景色プロパティも含む）で検証するように改善。テスト名のみ内容と不一致。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ボタンにホバー] --> B{disabled?}
    B -- Yes --> C[スタイル変更なし<br/>opacity: 0.5 / cursor: not-allowed を維持]
    B -- No --> D{.primary?}
    D -- Yes --> E[background: --vscode-button-hoverBackground]
    D -- No --> F[background: --vscode-button-secondaryHoverBackground]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/test/composer.unit.test.ts`, line 320-327 ([link](https://github.com/hiroki-org/jules-extension/blob/9f6f8e5a114093865ac579271d173f236163c41d/src/test/composer.unit.test.ts#L320-L327)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> プライマリボタンのホバースタイル (`button.primary:hover:not(:disabled)`) に対応するテストが存在しません。セカンダリボタン側の変更はテストされていますが、プライマリボタン側の `:not(:disabled)` 追加は検証されていないため、将来的に意図せず元に戻っても気づきにくい状態です。`button.primary:hover:not(:disabled)` と `--vscode-button-hoverBackground` を検証するテストを追加することを推奨します。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/composer.unit.test.ts
   Line: 320-327

   Comment:
   プライマリボタンのホバースタイル (`button.primary:hover:not(:disabled)`) に対応するテストが存在しません。セカンダリボタン側の変更はテストされていますが、プライマリボタン側の `:not(:disabled)` 追加は検証されていないため、将来的に意図せず元に戻っても気づきにくい状態です。`button.primary:hover:not(:disabled)` と `--vscode-button-hoverBackground` を検証するテストを追加することを推奨します。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/test/composer.unit.test.ts:320
テスト名がテスト内容と一致していません。テストはプライマリボタンとセカンダリボタン両方のホバースタイルを検証するようになりましたが、名前は "secondary button" のみを示しています。将来的にテストを分割・探索する際に混乱を招きます。

```suggestion
    test("should include primary and secondary button hover styles", () => {
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test: update composer test to strictly v..."](https://github.com/hiroki-org/jules-extension/commit/095a3ecf2f289d1ceb6695f651c3a1af5d33ac75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31097053)</sub>

<!-- /greptile_comment -->