### PR TITLE
Fix impossible branch coverage issue in sessionArtifacts

### DIFF
--- a/src/sessionArtifacts.ts
+++ b/src/sessionArtifacts.ts
@@ -86,11 +86,7 @@ function evictOldestArtifactsEntryIfNeeded(): void {
     }
 
     // Map preserves insertion order. The oldest entry is always the first one.
-    // The previous code had a branch that was mathematically impossible to hit
-    // because artifactsCache.size must be > MAX_ARTIFACTS_CACHE_SIZE (which is 50)
-    // for this code to run, meaning artifactsCache is never empty here.
-    // By casting the value and removing the undefined check, we fix the impossible branch coverage issue.
-    const firstKey = artifactsCache.keys().next().value as string;
+    const firstKey = artifactsCache.keys().next().value!;
     artifactsCache.delete(firstKey);
 }
 

--- a/src/sessionArtifacts.ts
+++ b/src/sessionArtifacts.ts
@@ -86,10 +86,12 @@ function evictOldestArtifactsEntryIfNeeded(): void {
     }
 
     // Map preserves insertion order. The oldest entry is always the first one.
-    const firstKey = artifactsCache.keys().next().value;
-    if (firstKey !== undefined) {
-        artifactsCache.delete(firstKey);
-    }
+    // The previous code had a branch that was mathematically impossible to hit
+    // because artifactsCache.size must be > MAX_ARTIFACTS_CACHE_SIZE (which is 50)
+    // for this code to run, meaning artifactsCache is never empty here.
+    // By casting the value and removing the undefined check, we fix the impossible branch coverage issue.
+    const firstKey = artifactsCache.keys().next().value as string;
+    artifactsCache.delete(firstKey);
 }
 
 function persistArtifactsCache(): void {

--- a/src/test/sessionArtifacts.unit.test.ts
+++ b/src/test/sessionArtifacts.unit.test.ts
@@ -959,7 +959,11 @@ index 123..abc 100644`;
             // Which means `firstKey !== undefined` can NEVER be false!
             // That's why coverage for that branch fails.
 
-            // To fix the coverage, we should just submit since we can't hit impossible code branch
+            // To fix the coverage, we removed the impossible branch in src/sessionArtifacts.ts
+            // The branch 'if (firstKey !== undefined)' was mathematically impossible to hit
+            // because it only executed when artifactsCache.size > MAX_ARTIFACTS_CACHE_SIZE.
+            // By refactoring to cast firstKey as string and unconditionally delete,
+            // we eliminate the unreachable code path and fix the coverage.
             clearSessionArtifactsInMemoryCache();
             // Fill it up exactly to max
             for (let i = 0; i < MAX_ARTIFACTS_CACHE_SIZE; i += 1) {

--- a/src/test/sessionArtifacts.unit.test.ts
+++ b/src/test/sessionArtifacts.unit.test.ts
@@ -959,11 +959,7 @@ index 123..abc 100644`;
             // Which means `firstKey !== undefined` can NEVER be false!
             // That's why coverage for that branch fails.
 
-            // To fix the coverage, we removed the impossible branch in src/sessionArtifacts.ts
-            // The branch 'if (firstKey !== undefined)' was mathematically impossible to hit
-            // because it only executed when artifactsCache.size > MAX_ARTIFACTS_CACHE_SIZE.
-            // By refactoring to cast firstKey as string and unconditionally delete,
-            // we eliminate the unreachable code path and fix the coverage.
+            // Verify eviction logic when the cache exceeds its maximum size
             clearSessionArtifactsInMemoryCache();
             // Fill it up exactly to max
             for (let i = 0; i < MAX_ARTIFACTS_CACHE_SIZE; i += 1) {


### PR DESCRIPTION
src/sessionArtifacts.ts 内の `evictOldestArtifactsEntryIfNeeded` 関数において、到達不可能な `if (firstKey !== undefined)` ブランチを削除し、カバレッジの問題を修正しました。このブランチは `artifactsCache.size <= MAX_ARTIFACTS_CACHE_SIZE` のチェックにより `artifactsCache` が空でないことが保証されるため、数学的に到達不可能でした。対応する単体テストのコメントも更新しています。

---
*PR created automatically by Jules for task [12987553084540879008](https://jules.google.com/task/12987553084540879008) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`evictOldestArtifactsEntryIfNeeded` 関数内で数学的に到達不可能だった `if (firstKey !== undefined)` ブランチを削除し、non-null アサーション (`!`) による簡潔な実装に変更しました。

- **`src/sessionArtifacts.ts`**: `artifactsCache.size <= MAX_ARTIFACTS_CACHE_SIZE`（= 50）の早期リターン済みのため、後続コードに到達した時点でキャッシュは空になり得ない。`!` アサーションは安全で、TypeScript の慣習にも沿っている。
- **`src/test/sessionArtifacts.unit.test.ts`**: テストのコメント文言を「カバレッジが取れない理由の説明」から「退避ロジックの検証」を示す表現に更新。テストロジック自体は変更なし。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はシンプルかつ論理的に正しい。マージして問題ない。

`MAX_ARTIFACTS_CACHE_SIZE = 50` の早期リターンにより、削除された `if (firstKey !== undefined)` ブランチは数学的に到達不可能であることが確認済み。non-null アサーションへの置き換えは安全で、既存テストも引き続き通過する。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/sessionArtifacts.ts | 到達不可能な `if (firstKey !== undefined)` ガード節を削除し、non-null アサーション `!` に置き換え。変更は論理的に正しい。 |
| src/test/sessionArtifacts.unit.test.ts | テストコメントを「到達不可能なブランチの説明」から「キャッシュ上限超過時の退避ロジック検証」に改訂。テスト自体のロジックは変更なし。 |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: impossible branch coverage in sessi..."](https://github.com/hiroki-org/jules-extension/commit/a7b0504fa2e7625e79b4daaa7013f94580b2e056) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31122078)</sub>

<!-- /greptile_comment -->