### PR TITLE
🎨 Palette: コンポーザーUIのアクセシビリティと無効状態の改善

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -192,6 +192,7 @@ export function getComposerHtml(
     outline-offset: 2px;
   }
 
+  input[type="checkbox"]:disabled,
   input[type="checkbox"]:disabled + label {
     opacity: 0.5;
     cursor: not-allowed;
@@ -200,9 +201,22 @@ export function getComposerHtml(
   label {
     cursor: pointer;
   }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
 </style>
 </head>
 <body>
+  <div id="sr-status" class="sr-only" aria-live="polite"></div>
   <textarea id="message" aria-label="${placeholder || 'Message input'}" placeholder="${placeholder}" autofocus>${value}</textarea>
   <div class="actions">
     ${createPrCheckbox}
@@ -221,6 +235,7 @@ export function getComposerHtml(
       const isValid = textarea.value.trim().length > 0;
       submitButton.disabled = !isValid;
       submitButton.title = isValid ? 'Send (Cmd/Ctrl+Enter)' : 'Type a message to send';
+      submitButton.setAttribute('aria-label', isValid ? 'Send message (Cmd/Ctrl+Enter)' : 'Type a message to send');
       return isValid;
     };
 
@@ -231,8 +246,9 @@ export function getComposerHtml(
 
       submitButton.disabled = true;
       submitButton.innerText = 'Sending...';
-      submitButton.setAttribute('aria-busy', 'true');
-      submitButton.setAttribute('aria-label', 'Sending message...');
+      submitButton.removeAttribute('aria-busy');
+      const srStatus = document.getElementById('sr-status');
+      if (srStatus) srStatus.textContent = 'Sending message...';
       textarea.disabled = true;
       if (createPrCheckbox) createPrCheckbox.disabled = true;
       if (requireApprovalCheckbox) requireApprovalCheckbox.disabled = true;

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -124,6 +124,11 @@ export function getComposerHtml(
     outline: 1px solid var(--vscode-focusBorder);
   }
 
+  textarea:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
   .actions {
     display: flex;
     justify-content: flex-end;
@@ -187,6 +192,11 @@ export function getComposerHtml(
     outline-offset: 2px;
   }
 
+  input[type="checkbox"]:disabled + label {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
   label {
     cursor: pointer;
   }
@@ -210,6 +220,7 @@ export function getComposerHtml(
     const validate = () => {
       const isValid = textarea.value.trim().length > 0;
       submitButton.disabled = !isValid;
+      submitButton.title = isValid ? 'Send (Cmd/Ctrl+Enter)' : 'Type a message to send';
       return isValid;
     };
 
@@ -220,6 +231,8 @@ export function getComposerHtml(
 
       submitButton.disabled = true;
       submitButton.innerText = 'Sending...';
+      submitButton.setAttribute('aria-busy', 'true');
+      submitButton.setAttribute('aria-label', 'Sending message...');
       textarea.disabled = true;
       if (createPrCheckbox) createPrCheckbox.disabled = true;
       if (requireApprovalCheckbox) requireApprovalCheckbox.disabled = true;


### PR DESCRIPTION
🎨 Palette: 送信ボタンとテキストエリアのUI/アクセシビリティ改善

💡 What:
- `textarea` と `checkbox` の `disabled` 状態に視覚的なフィードバック (`opacity: 0.5`, `cursor: not-allowed`) を追加しました。
- 送信ボタンが無効な場合、ツールチップ（`title`）に「Type a message to send」という具体的な理由を表示するようにしました（有効な場合はショートカットキーのヒントを表示）。
- 送信処理中、送信ボタンにスクリーンリーダー向けの属性 (`aria-busy="true"`, `aria-label="Sending message..."`) を追加しました。

🎯 Why:
- 無効化された要素が視覚的にアクティブに見えてしまう問題を解消し、ユーザーの混乱を防ぐため。
- 送信ボタンが押せない理由をツールチップで明示することで、より直感的な操作をサポートするため。
- スクリーンリーダーを利用するユーザーが、メッセージ送信中である状態を正しく把握できるようにするため。

📸 Before/After:
（UIの変更はCSSとDOM属性の更新によるものです）

♿ Accessibility:
- `disabled` 状態のコントラストとカーソルの改善
- 送信処理中の `aria-busy` および `aria-label` 属性の追加

---
*PR created automatically by Jules for task [9339445662421672726](https://jules.google.com/task/9339445662421672726) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コンポーザー UI のアクセシビリティと disabled 状態の視覚フィードバックを改善するPRです。CSS による opacity/cursor スタイル追加、送信ボタンの `title` 動的更新、送信中の `aria-busy`/`aria-label` 付与が含まれます。

- `textarea:disabled` と `input[type="checkbox"]:disabled + label` に `opacity: 0.5` / `cursor: not-allowed` を追加し、視覚的な無効状態を明示。
- `validate()` で `submitButton.title` を切り替えてツールチップに無効理由を表示するが、`aria-label` は更新されないためスクリーンリーダーには理由が伝わらない問題がある。
- 送信処理中に `aria-busy="true"` と `aria-label="Sending message..."` を付与しているが、`disabled` ボタン上の `aria-busy` は一部スクリーンリーダーで読み上げられない可能性がある。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

アクセシビリティ改善を目的としたPRだが、aria-label の不整合により、スクリーンリーダーユーザーにかえって誤情報を伝えるケースが生じている。

validate() で title のみ更新し aria-label を更新しないため、ボタンが disabled のときもスクリーンリーダーは「Send message (Cmd/Ctrl+Enter)」と読み上げ続ける。アクセシビリティ向上を謳うPRで逆に誤アナウンスが発生する点は修正が必要。

src/composer.ts — validate() 内の aria-label 更新ロジックを要確認。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | テキストエリア・チェックボックスの disabled CSS、送信ボタンのツールチップ更新、aria-busy/aria-label の送信中付与を追加。ただし validate() で aria-label が更新されず、スクリーンリーダーへの無効理由が伝わらない問題あり。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as ユーザー
    participant Textarea as textarea
    participant Submit as 送信ボタン
    participant SR as スクリーンリーダー

    User->>Textarea: 入力 (空)
    Textarea->>Submit: validate() 呼び出し
    Submit-->>Submit: "disabled=true, title=Type a message to send, aria-label 未更新"
    SR->>Submit: フォーカス
    Submit-->>SR: Send message と読み上げ (誤情報)

    User->>Textarea: テキスト入力
    Textarea->>Submit: validate() 呼び出し
    Submit-->>Submit: "disabled=false, title=Send"

    User->>Submit: クリック / Cmd+Enter
    Submit-->>Submit: "disabled=true, innerText=Sending..., aria-busy=true"
    SR->>Submit: フォーカス
    Submit-->>SR: disabled 要素のためスキップの可能性
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/composer.ts:223
**`aria-label` が `validate()` で更新されないため、スクリーンリーダーに誤情報を伝える**

`validate()` では `submitButton.title` を動的に切り替えて無効理由を伝えていますが、`aria-label` は静的な HTML の `"Send message (Cmd/Ctrl+Enter)"` のまま更新されません。スクリーンリーダーは `title` より `aria-label` を優先するため、テキストエリアが空でボタンが `disabled` の状態でも「Send message (Cmd/Ctrl+Enter)」と読み上げられ、「なぜ押せないのか」が伝わりません。`title` と同様に `aria-label` も切り替えることで修正できます。

### Issue 2 of 3
src/composer.ts:232-235
**送信中の `aria-busy` を `disabled` ボタン本体ではなくステータス領域で通知する**

`aria-busy="true"` は「コンテナが更新中」を示す属性で、すでに `disabled` になったボタン自体に付与しても、スクリーンリーダーが無効要素をスキップするため読み上げられないケースがあります。`aria-live="polite"` を持つ隠しステータス領域を使うと、送信状態をより確実に通知できます。

### Issue 3 of 3
src/composer.ts:195-198
**チェックボックス入力要素自体の `cursor: not-allowed` が適用されない**

追加した CSS セレクタ `input[type="checkbox"]:disabled + label` はラベルにのみスタイルを適用します。チェックボックスの `input` 要素自体はブラウザのネイティブ disabled スタイルに任せているため、WebView 環境によってはカーソルが変わらない場合があります。`input[type="checkbox"]:disabled` にも `cursor: not-allowed` を追加すると一貫性が高まります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): improve accessibility and disa..."](https://github.com/hiroki-org/jules-extension/commit/e46e5fbae2e8d1ecf8cf108d1e16d10e288d34a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31182521)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->