### PR TITLE
⚡ Bolt: ツールチップ生成時のPR重複排除処理を最適化

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
+## 2024-05-01 - Avoid loop recreation of Sets
+**Learning:** During review, we noticed `new Set([ ... ])` being instantiated inside a loop for activity logging in `extension.ts`. While it is just logging, moving static `Set` declarations out of repeated execution paths is a fundamental performance practice in V8.
+**Action:** Move the activity log key `Set` declarations to module-level constants in `extension.ts` to prevent redundant garbage collection and allocation on hot code paths.
+
 ## 2025-02-23 - Avoid .map().filter() in Tooltip Rendering
 **Learning:** Chained `.map().filter()` followed by `Array.from(new Map(...))` in UI rendering functions like `buildSessionTooltip` cause unnecessary array allocations and iterations, which can negatively impact performance when rendering large lists of sessions.
 **Action:** Replace functional array chaining with direct single-pass `for` loops that populate the target collection (like a `Map`) directly when processing data for frequent UI rendering.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,4 +1,3 @@
-# 2024-05-01 - Avoid loop recreation of Sets
-
-**Learning:** During review, we noticed `new Set([ ... ])` being instantiated inside a loop for activity logging in `extension.ts`. While it is just logging, moving static `Set` declarations out of repeated execution paths is a fundamental performance practice in V8.
-**Action:** Move the activity log key `Set` declarations to module-level constants in `extension.ts` to prevent redundant garbage collection and allocation on hot code paths.
+## 2025-02-23 - Avoid .map().filter() in Tooltip Rendering
+**Learning:** Chained `.map().filter()` followed by `Array.from(new Map(...))` in UI rendering functions like `buildSessionTooltip` cause unnecessary array allocations and iterations, which can negatively impact performance when rendering large lists of sessions.
+**Action:** Replace functional array chaining with direct single-pass `for` loops that populate the target collection (like a `Map`) directly when processing data for frequent UI rendering.

--- a/src/tooltipUtils.ts
+++ b/src/tooltipUtils.ts
@@ -82,16 +82,22 @@ export function buildSessionTooltip(context: TooltipContext): vscode.MarkdownStr
   // PR情報の追加と重複排除（パフォーマンス最適化）
   // 以前の chained .map().filter() は複数の中間配列を生成していました。
   // ここでは単一のループで Map に直接格納することで、メモリ割り当てを削減し処理を高速化しています。
-  const prMap = new Map<string, NonNullable<PullRequestOutput>>();
+  const prs: NonNullable<PullRequestOutput>[] = [];
+  const urlToIndex = new Map<string, number>();
   if (session.outputs) {
     for (let i = 0; i < session.outputs.length; i += 1) {
       const pr = session.outputs[i].pullRequest;
       if (pr && pr.url) {
-        prMap.set(pr.url, pr);
+        const index = urlToIndex.get(pr.url);
+        if (index !== undefined) {
+          prs[index] = pr;
+        } else {
+          urlToIndex.set(pr.url, prs.length);
+          prs.push(pr);
+        }
       }
     }
   }
-  const prs = Array.from(prMap.values());
 
   if (prs.length > 0) {
     tooltip.appendMarkdown(`\n\n---`);

--- a/src/tooltipUtils.ts
+++ b/src/tooltipUtils.ts
@@ -79,13 +79,19 @@ export function buildSessionTooltip(context: TooltipContext): vscode.MarkdownStr
     tooltip.appendMarkdown(`\n\nMode: ${automationLabel}`);
   }
 
-  // Add Pull Request info if available
-  const allPrs = session.outputs
-    ?.map(o => o.pullRequest)
-    .filter((pr): pr is NonNullable<PullRequestOutput> => !!pr && !!pr.url) || [];
-  
-  // De-duplicate PRs by URL to avoid redundant entries in the tooltip
-  const prs = Array.from(new Map(allPrs.map(pr => [pr.url, pr])).values());
+  // PR情報の追加と重複排除（パフォーマンス最適化）
+  // 以前の chained .map().filter() は複数の中間配列を生成していました。
+  // ここでは単一のループで Map に直接格納することで、メモリ割り当てを削減し処理を高速化しています。
+  const prMap = new Map<string, NonNullable<PullRequestOutput>>();
+  if (session.outputs) {
+    for (let i = 0; i < session.outputs.length; i += 1) {
+      const pr = session.outputs[i].pullRequest;
+      if (pr && pr.url) {
+        prMap.set(pr.url, pr);
+      }
+    }
+  }
+  const prs = Array.from(prMap.values());
 
   if (prs.length > 0) {
     tooltip.appendMarkdown(`\n\n---`);


### PR DESCRIPTION
💡 **What:**
`src/tooltipUtils.ts` 内の `buildSessionTooltip` 関数において、プルリクエストの重複排除処理を最適化しました。具体的には、複数の中間配列を生成する `.map().filter().map()` のメソッドチェーンを、単一の `for` ループに置き換えました。

🎯 **Why:**
ツールチップの生成処理は、多数のセッション情報を持つ環境において頻繁に呼び出されるUIレンダリングパスの一部です。元の実装では、中間配列の割り当てや複数回の配列反復処理が発生し、メモリ消費と処理時間のオーバーヘッドが存在していました（O(N)ですが定数倍が大きく、不要なGC圧力を引き起こします）。単一パスのループで直接 `Map` に挿入することで、このオーバーヘッドを排除し、パフォーマンスを向上させるためです。

📊 **Impact:**
ツールチップに表示するプルリクエスト一覧を生成する際の、配列反復処理の回数と中間配列のメモリ割り当てが大幅に削減されます。これにより、大規模なセッションリストを表示する際のVS Code拡張機能のUI応答性が向上します。

🔬 **Measurement:**
この最適化は、`session.outputs` の配列を反復処理する回数を3回（`map` -> `filter` -> `map`）から1回（`for` ループ）に削減します。VS Codeの拡張機能ホストプロセスでのメモリプロファイリングおよびCPUプロファイリングを実行することで、`buildSessionTooltip` の実行時間短縮を確認できます。

※ 本変更はコードの可読性を大きく損なうものではなく、TypeScriptの型推論を活用した安全なリファクタリングです。

---
*PR created automatically by Jules for task [10184831673230807731](https://jules.google.com/task/10184831673230807731) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ツールチップ生成時のPR重複排除処理を、`.map().filter().map()` のメソッドチェーンから単一の `for` ループ + `Map` への直接挿入に置き換えるリファクタリングです。ロジックの等価性は保たれており、機能的なリグレッションは確認されませんでした。

- `src/tooltipUtils.ts`: `session.outputs` を1回だけ走査してPR情報を `Map` に格納する形に変更。ただし末尾の `Array.from(prMap.values())` で中間配列が依然として生成されており、最適化目標を完全には達成していません。
- `.jules/bolt.md`: 新しいツールチップ最適化の学習を追加した際に、`extension.ts` の `Set` ループ内再生成に関する既存の学習記録が上書き削除されており、過去の知見が失われています。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

`tooltipUtils.ts` の変更は機能的に安全ですが、`.jules/bolt.md` の既存学習記録の削除はAIエージェントの将来の挙動に影響する可能性があります。

`extension.ts` の `Set` 再生成パターンに関する学習が `.jules/bolt.md` から削除されており、AIエージェントが今後同じファイルで同じアンチパターンを再導入するリスクがあります。コアのUI変更自体は安全ですが、このドキュメントの変更はリポジトリの長期的な整合性に影響します。

`.jules/bolt.md` — 削除された学習記録の内容を確認し、`extension.ts` の `Set` パターンが既に修正済みかどうかを確かめる必要があります。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/tooltipUtils.ts | 単一のforループでPR重複排除Mapを構築する最適化。ロジックは元の実装と機能的に等価だが、最後のArray.from(prMap.values())で依然として中間配列が生成されている。 |
| .jules/bolt.md | 新しいtooltipレンダリングの学習を追記するのではなく、extension.tsのSet再生成に関する既存の学習記録を丸ごと上書き削除している。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildSessionTooltip 呼び出し] --> B{session.outputs は存在するか?}
    B -- No --> E[prMap は空のまま]
    B -- Yes --> C[forループで各 output を走査]
    C --> D{pr && pr.url が存在するか?}
    D -- No --> C
    D -- Yes --> F[prMap.set pr.url, pr]
    F --> C
    C -- 走査完了 --> G[Array.from prMap.values]
    E --> G
    G --> H{prs.length > 0?}
    H -- No --> I[PRセクションをスキップ]
    H -- Yes --> J[tooltip にPR情報を追記]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.jules/bolt.md`, line 1-4 ([link](https://github.com/hiroki-org/jules-extension/blob/52e1c034bedb51790893bf69308e5bb21dba815d/.jules/bolt.md#L1-L4)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **以前の学習記録が上書き削除されています**

   本PRの変更により、`extension.ts` における `Set` のループ内インスタンス生成を避けるという以前の学習（2024-05-01）が完全に削除されています。`.jules/bolt.md` がAIエージェントへの学習記録として機能している場合、削除によって過去の知見が失われ、同じパターンが `extension.ts` で再度導入されるリスクがあります。新しい学習を追記する形にして、既存の記録を保持することを推奨します。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .jules/bolt.md
   Line: 1-4

   Comment:
   **以前の学習記録が上書き削除されています**

   本PRの変更により、`extension.ts` における `Set` のループ内インスタンス生成を避けるという以前の学習（2024-05-01）が完全に削除されています。`.jules/bolt.md` がAIエージェントへの学習記録として機能している場合、削除によって過去の知見が失われ、同じパターンが `extension.ts` で再度導入されるリスクがあります。新しい学習を追記する形にして、既存の記録を保持することを推奨します。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/tooltipUtils.ts`, line 94-100 ([link](https://github.com/hiroki-org/jules-extension/blob/52e1c034bedb51790893bf69308e5bb21dba815d/src/tooltipUtils.ts#L94-L100)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `Array.from(prMap.values())` は中間配列の割り当てを発生させます。PR説明で「中間配列の削減」が目標とされているため、`prs.length` の代わりに `prMap.size`、`prs.forEach` の代わりに `for...of` を使うことで、この最後の配列割り当ても排除できます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/tooltipUtils.ts
   Line: 94-100

   Comment:
   `Array.from(prMap.values())` は中間配列の割り当てを発生させます。PR説明で「中間配列の削減」が目標とされているため、`prs.length` の代わりに `prMap.size`、`prs.forEach` の代わりに `for...of` を使うことで、この最後の配列割り当ても排除できます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.jules/bolt.md:1-4
**以前の学習記録が上書き削除されています**

本PRの変更により、`extension.ts` における `Set` のループ内インスタンス生成を避けるという以前の学習（2024-05-01）が完全に削除されています。`.jules/bolt.md` がAIエージェントへの学習記録として機能している場合、削除によって過去の知見が失われ、同じパターンが `extension.ts` で再度導入されるリスクがあります。新しい学習を追記する形にして、既存の記録を保持することを推奨します。

### Issue 2 of 2
src/tooltipUtils.ts:94-100
`Array.from(prMap.values())` は中間配列の割り当てを発生させます。PR説明で「中間配列の削減」が目標とされているため、`prs.length` の代わりに `prMap.size`、`prs.forEach` の代わりに `for...of` を使うことで、この最後の配列割り当ても排除できます。

```suggestion
  if (prMap.size > 0) {
    tooltip.appendMarkdown(`\n\n---`);
    tooltip.appendMarkdown(`\n\n🔗 **Pull Request${prMap.size > 1 ? 's' : ''}**`);
    
    let index = 0;
    for (const pr of prMap.values()) {
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: optimize PR deduplication in t..."](https://github.com/hiroki-org/jules-extension/commit/52e1c034bedb51790893bf69308e5bb21dba815d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31183022)</sub>

<!-- /greptile_comment -->