### PR TITLE
🛡️ Sentinel: [HIGH] fetchWithTimeoutにおけるSSRF脆弱性の修正

### DIFF
--- a/src/fetchUtils.ts
+++ b/src/fetchUtils.ts
@@ -108,9 +108,17 @@ async function fetchViaProxy(
  */
 export async function fetchWithTimeout(input: string | URL | Request, init?: RequestInit & { timeout?: number }): Promise<Response> {
     const urlString = input instanceof Request ? input.url : input.toString();
-    const url = new URL(urlString);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-        throw new Error(`Unsupported protocol: ${url.protocol}. Only http: and https: are allowed.`);
+
+    try {
+        const url = new URL(urlString);
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+            throw new Error(`Unsupported protocol: ${url.protocol}. Only http: and https: are allowed.`);
+        }
+    } catch (err: unknown) {
+        if (err instanceof Error && err.message.includes('Unsupported protocol')) {
+            throw err;
+        }
+        // If new URL() fails, it's likely a relative URL which fetch natively supports
     }
 
     const timeout = init?.timeout ?? 30000;

--- a/src/fetchUtils.ts
+++ b/src/fetchUtils.ts
@@ -115,10 +115,10 @@ export async function fetchWithTimeout(input: string | URL | Request, init?: Req
             throw new Error(`Unsupported protocol: ${url.protocol}. Only http: and https: are allowed.`);
         }
     } catch (err: unknown) {
-        if (err instanceof Error && err.message.includes('Unsupported protocol')) {
+        if (!(err instanceof TypeError)) {
             throw err;
         }
-        // If new URL() fails, it's likely a relative URL which fetch natively supports
+        // If new URL() fails with TypeError, it's likely a relative URL which fetch natively supports
     }
 
     const timeout = init?.timeout ?? 30000;

--- a/src/fetchUtils.ts
+++ b/src/fetchUtils.ts
@@ -107,6 +107,12 @@ async function fetchViaProxy(
  * Defaults to 30 seconds.
  */
 export async function fetchWithTimeout(input: string | URL | Request, init?: RequestInit & { timeout?: number }): Promise<Response> {
+    const urlString = input instanceof Request ? input.url : input.toString();
+    const url = new URL(urlString);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        throw new Error(`Unsupported protocol: ${url.protocol}. Only http: and https: are allowed.`);
+    }
+
     const timeout = init?.timeout ?? 30000;
     let timer: ReturnType<typeof setTimeout> | undefined;
 

--- a/src/test/fetchUtils.unit.test.ts
+++ b/src/test/fetchUtils.unit.test.ts
@@ -32,6 +32,40 @@ suite('FetchUtils ユニットテスト', () => {
         sandbox.restore();
     });
 
+    test('fetchWithTimeout はサポートされていないプロトコルの絶対URLでエラーをスローすること', async () => {
+        await assert.rejects(async () => {
+            await fetchWithTimeout('file:///etc/passwd');
+        }, /Unsupported protocol: file:/);
+
+        await assert.rejects(async () => {
+            await fetchWithTimeout('ftp://example.com/data');
+        }, /Unsupported protocol: ftp:/);
+
+        await assert.rejects(async () => {
+            await fetchWithTimeout('gopher://example.com');
+        }, /Unsupported protocol: gopher:/);
+
+        // Whitespace parsing edge case bypass checks
+        await assert.rejects(async () => {
+            await fetchWithTimeout('  file:///etc/passwd');
+        }, /Unsupported protocol: file:/);
+
+        await assert.rejects(async () => {
+            await fetchWithTimeout('\tdata:text/plain;base64,SGVsbG8sIFdvcmxkIQ==');
+        }, /Unsupported protocol: data:/);
+
+        assert.strictEqual(fetchStub.called, false);
+    });
+
+    test('fetchWithTimeout は相対パスのURLを正しく通過させること', async () => {
+        const mockResponse = { ok: true, status: 200 } as Response;
+        fetchStub.resolves(mockResponse);
+
+        const response = await fetchWithTimeout('/api/v1/data');
+        assert.strictEqual(response, mockResponse);
+        assert.strictEqual(fetchStub.calledOnce, true);
+    });
+
     test('fetchWithTimeout はタイムアウト内に完了した場合、成功すること', async () => {
         const mockResponse = { ok: true, status: 200 } as Response;
         fetchStub.resolves(mockResponse);


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] `fetchWithTimeout`におけるSSRF（サーバーサイドリクエストフォージェリ）脆弱性の修正

🚨 **重大度:** HIGH (高)

💡 **脆弱性:**
`src/fetchUtils.ts`の`fetchWithTimeout`関数は、指定された入力URLに対してプロトコルの検証を行わずに、そのまま`fetch`やプロキシの実行へと処理を渡していました。これにより、攻撃者が入力URLを制御できる場合、`file://` や `data://`、`gopher://` などのスキームを用いて予期しない内部ネットワークのリソースやローカルファイルへアクセスさせる、SSRF（サーバーサイドリクエストフォージェリ）やLFIのリスクが存在していました。

🎯 **影響:**
予期しないプロトコルを利用することで、機密データ（例: `/etc/passwd`など）の読み出しや、内部サービスへの不正なリクエストが実行される可能性があります。

🔧 **修正内容:**
`fetchWithTimeout` 内で、入力URLが絶対URLの形式（`スキーム:`から始まる形式）を持つ場合にのみ `new URL()` でパースし、プロトコルが `http:` または `https:` であることを厳密に検証するロジックを追加しました。これにより、標準の `fetch` がサポートする相対パスを破壊することなく、不正なプロトコルスキームによるアクセスを安全にブロックします。

✅ **確認方法:**
- 単体テストおよび統合テスト (`pnpm run test:unit`, `xvfb-run -a pnpm test`) が全てパスすることを確認済みです。
- アプリケーション内の通常の相対パスや正常なHTTP/HTTPS通信には影響を与えない設計になっています。

---
*PR created automatically by Jules for task [5857225366709995620](https://jules.google.com/task/5857225366709995620) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `fetchWithTimeout` にSSRF対策としてプロトコル検証を追加します。ただし、`new URL()` を無条件に呼び出しているため、相対URLを渡す既存の呼び出し箇所が `TypeError: Invalid URL` でクラッシュするリグレッションが生じます。

- `src/fetchUtils.ts`: `fetchWithTimeout` の冒頭で `new URL(urlString)` を無条件に実行し、`http:` / `https:` 以外のプロトコルを拒否するガードを追加。
- PRの説明では「相対パスを破壊しない」と明記しているが、実装では絶対URLかどうかの事前チェックが欠落しており、相対パスで呼び出すと意図しない `TypeError` が発生する。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

相対URLを渡す既存の呼び出し箇所を壊すリグレッションが含まれているため、このままマージすることは推奨されない

プロトコル検証の意図は正しいが、`new URL()` を無条件に呼び出すことで相対URLを持つ呼び出しが全て `TypeError` でクラッシュする。PRの説明で「相対パスを破壊しない」と明記されているにもかかわらず、実装にはその条件分岐が欠落している。修正は1行の正規表現チェックを追加するだけで完結するが、本番でリグレッションが発生する前に対処が必要。

src/fetchUtils.ts — プロトコルチェックの前に絶対URLかどうかを確認する条件分岐が必要
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/fetchUtils.ts | SSRFをブロックするプロトコル検証を追加したが、`new URL()` を無条件に呼び出しているため相対URLが全て `TypeError` でクラッシュするリグレッションが発生する |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/fetchUtils.ts:110-114
`new URL(urlString)` は相対URLに対して `TypeError: Invalid URL` をスローするため、`fetchWithTimeout('/api/endpoint')` のような相対パスの呼び出しが全て壊れます。PRの説明では「相対パスを破壊しない」と明記されていますが、コードの実装はその意図と一致していません。絶対URLの場合のみ検証するよう条件チェックが必要です。

```suggestion
    const urlString = input instanceof Request ? input.url : input.toString();
    // 絶対URLの場合のみプロトコルを検証する（相対パスは通過させる）
    if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(urlString)) {
        const url = new URL(urlString);
        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
            throw new Error(`Unsupported protocol: ${url.protocol}. Only http: and https: are allowed.`);
        }
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(security): enforce http/https proto..."](https://github.com/hiroki-org/jules-extension/commit/146fbc468d40fa064625151f10d00a55b2755c05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31251916)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->