### PR TITLE
⚡ Bolt: PR重複排除処理のパフォーマンス最適化 (extractPRs)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -486,9 +486,9 @@ export function extractPRs(
     return [];
   }
 
-  // A Map inherently preserves insertion order of the first time a key is set.
-  // By iterating forward, we keep the first-seen URL order while storing
-  // the latest PR data for that URL.
+  // Map は最初にキーが挿入された位置を常に保持し、同じキーで再 set() しても
+  // 反復順序は変わらず、値だけが更新される。これにより、前方から走査するだけで
+  // 「初出 URL 順を維持しつつ最新の PR データで上書きする」動作が実現できる。
   const prMap = new Map<string, PullRequestOutput>();
 
   for (const output of sessionOrState.outputs) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -485,26 +485,20 @@ export function extractPRs(
   if (!sessionOrState.outputs) {
     return [];
   }
-  const urlToIndex = new Map<string, number>();
-  const deduped: PullRequestOutput[] = [];
+
+  // A Map inherently preserves insertion order of the first time a key is set.
+  // By iterating forward, we keep the first-seen URL order while storing
+  // the latest PR data for that URL.
+  const prMap = new Map<string, PullRequestOutput>();
 
   for (const output of sessionOrState.outputs) {
     const pr = output.pullRequest;
-    if (!pr?.url) {
-      continue;
+    if (pr?.url) {
+      prMap.set(pr.url, pr);
     }
-    const existingIndex = urlToIndex.get(pr.url);
-    if (existingIndex === undefined) {
-      urlToIndex.set(pr.url, deduped.length);
-      deduped.push(pr);
-      continue;
-    }
-
-    // Keep first-seen URL order while replacing payload with the latest PR data.
-    deduped[existingIndex] = pr;
   }
 
-  return deduped;
+  return Array.from(prMap.values());
 }
 
 export async function checkPRStatus(


### PR DESCRIPTION
💡 **What**: `extractPRs` 関数での配列重複排除ロジックをリファクタリングし、`Map` を使用するようにしました。
🎯 **Why**: 以前の実装では、URLのインデックスを手動で追跡（`urlToIndex`）し、`deduped` 配列の要素をインプレースで更新していました。`Map` を使用することで、挿入順序をネイティブに保持しつつ、最新のPRデータで値を更新できるため、コードが大幅にクリーンになり、手動の配列インデックス管理のオーバーヘッドがなくなります。
📊 **Impact**: インデックスマップとインプレース配列置換を排除することで、実行時のメモリ割り当てとオーバーヘッドを削減し、コードの可読性を向上させました（O(N)操作の最適化）。
🔬 **Measurement**: 既存の単体テスト（`extractPRs should deduplicate PRs by URL and keep first-seen order`）を実行し、動作が変わらないことを確認できます。

---
*PR created automatically by Jules for task [8917638485043724287](https://jules.google.com/task/8917638485043724287) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`extractPRs` 関数の重複排除ロジックを `urlToIndex` Map + `deduped` 配列の二重構造から、単一の `Map<string, PullRequestOutput>` に置き換えるリファクタリングです。Map の「最初の挿入位置を保持し、再 `set()` で値だけ更新する」という特性を利用しており、動作は旧実装と等価です。

- 旧実装の `urlToIndex` と `deduped` 配列を排除し、`prMap` 一本化でコードが簡潔になっています。
- `Array.from(prMap.values())` で返される順序は、Map が最初のキー挿入位置を不変に保つため、旧来の「初出 URL 順・最新データ」という仕様を維持しています。
- 既存テスト（`extractPRs should deduplicate PRs by URL and keep first-seen order` など）がこの動作を網羅しており、バグリスクは低いです。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージして問題ありません。変更は `extractPRs` 単一関数のリファクタリングに限定されており、動作は旧実装と等価です。

旧実装（`urlToIndex` + `deduped` 配列）と新実装（`prMap` 単独）は、Map が「最初の挿入位置を保持し再 `set()` で値のみ更新する」という特性により完全に等価な出力を返します。既存テストがこの挙動（初出順 + 最新データ）を直接カバーしており、機能上のリグレッションリスクはほぼありません。指摘事項はコメントの表現のみで、ロジックに問題はありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `extractPRs` 関数を `urlToIndex`+`deduped` の二重管理から単一 `Map` に整理。動作等価でテストが通る。コメントの表現が若干曖昧だが機能上の問題なし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractPRs 呼び出し] --> B{outputs が存在するか?}
    B -- No --> C[空配列を返す]
    B -- Yes --> D[prMap = new Map]
    D --> E[outputs を順にイテレート]
    E --> F{pr?.url が存在するか?}
    F -- No --> E
    F -- Yes --> G{prMap に url が既にあるか?}
    G -- No --> H[prMap.set url, pr - 新規挿入 → 末尾に追加]
    G -- Yes --> I[prMap.set url, pr - 値を更新 → 位置は不変]
    H --> E
    I --> E
    E -- 終了 --> J[Array.from prMap.values - 初出順・最新データで返却]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/extension.ts:489-491
`Map` が「キーを再 `set()` しても反復順序が変わらない」という点がこのリファクタリングの核心ですが、現在のコメントはその点が若干伝わりにくいです。将来の読者がなぜこれが正しく動くかを即座に理解できるよう、より明示的に書くと親切です。

```suggestion
  // Map は最初にキーが挿入された位置を常に保持し、同じキーで再 set() しても
  // 反復順序は変わらず、値だけが更新される。これにより、前方から走査するだけで
  // 「初出 URL 順を維持しつつ最新の PR データで上書きする」動作が実現できる。
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(extractPRs): optimize array dedupli..."](https://github.com/hiroki-org/jules-extension/commit/72cf5794f851f16f67ad05d0f5233b74b46d20fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31368000)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->