### PR TITLE
🛡️ Sentinel: [セキュリティ強化] Webview CSPにbase-uri 'none'を追加

### DIFF
--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -465,7 +465,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -89,7 +89,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -93,6 +93,7 @@ suite("Chat View Unit Test Suite", () => {
       /<script nonce="nonce-123" src="[^"]*dist(?:[\\/]|%5[cC])purify\.min\.js"><\/script>/,
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
+    assert.ok(html.includes("base-uri 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -494,6 +494,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes(`<script nonce="${testNonce}">`));
     });
 
+    test("should include base-uri 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("base-uri 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
Webview に `<base>` タグインジェクション攻撃を防ぐため、`Content-Security-Policy` メタタグに `base-uri 'none'` を追加し、セキュリティを強化しました。これにより、相対 URL が意図しないベース URI によって乗っ取られるリスクを軽減します。また、これらの変更を検証するために既存のユニットテストも更新しました。

---
*PR created automatically by Jules for task [5325905897893954882](https://jules.google.com/task/5325905897893954882) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

両Webview（`chatView.ts` と `composer.ts`）の Content-Security-Policy メタタグに `base-uri 'none'` ディレクティブを追加し、`<base>` タグインジェクション攻撃への対策を実施しました。変更はCSP文字列1行のみで最小限に抑えられており、既存テストの更新と新規テストの追加も行われています。

- `src/chatView.ts` および `src/composer.ts` のCSPに `base-uri 'none'` を追加。相対URLが外部ドメインに乗っ取られるリスクを解消。
- `src/test/chatView.unit.test.ts` に既存テストへのアサーション追加、`src/test/composer.unit.test.ts` に独立したテストケースを新規追加することで変更を検証。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージして問題ありません。

変更は両WebviewのCSPに `base-uri 'none'` を追加するのみで、既存の動作に影響を与えません。テストも追加・更新されており、変更が正しく適用されていることが確認できます。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | CSPに `base-uri 'none'` を追加。変更は1行のみで正確に適用されている。 |
| src/composer.ts | テンプレートリテラル内のCSPに `base-uri 'none'` を追加。変更は1行のみで正確に適用されている。 |
| src/test/chatView.unit.test.ts | 既存テストに `base-uri 'none'` の存在確認アサーションを追加。 |
| src/test/composer.unit.test.ts | `base-uri 'none'` の存在確認に特化した独立したテストケースを新規追加。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Add \`base-uri &#39;none&#39;\` to Webview Content..."](https://github.com/hiroki-org/jules-extension/commit/0d3463b3b92d640fcee36f9c10395e5568f41b13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31376989)</sub>

<!-- /greptile_comment -->