### PR TITLE
🛡️ Sentinel: [多層防御] DOMPurify の戻り値を明示的に文字列に制限するセキュリティ強化

### DIFF
--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -120,6 +120,8 @@ suite("chatAssets unit tests", () => {
       "data-detail-type",
       "data-index",
     ]);
+    assert.strictEqual(sanitizeConfig.RETURN_DOM, false);
+    assert.strictEqual(sanitizeConfig.RETURN_DOM_FRAGMENT, false);
   });
 
   test("CHAT_JS should fail closed when DOMPurify is unavailable", () => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -93,6 +93,8 @@ export const CHAT_JS = `(function() {
           ALLOWED_URI_REGEXP: DOMPURIFY_ALLOWED_URI_REGEXP,
           ADD_TAGS: ["details", "summary"],
           ADD_ATTR: ["data-activity-id", "data-detail-type", "data-index"],
+          RETURN_DOM: false,
+          RETURN_DOM_FRAGMENT: false,
         }),
       );
     } catch (error) {


### PR DESCRIPTION
🚨 **深刻度**: 低 (多層防御の強化)
💡 **脆弱性**: DOMPurify のデフォルト設定に依存している状態。将来的なライブラリのアップデートや設定の誤りにより、DOM ノードやフラグメントが意図せず返却されることで、予期せぬ実行経路（XSS等）を引き起こす潜在的なリスクがありました。
🎯 **影響**: DOM 要素が返却され不正に利用された場合、セキュリティバイパスの原因になる可能性があります。
🔧 **修正**: `src/webview/chatAssets.ts` 内の `DOMPurify.sanitize` 設定において、明示的に `RETURN_DOM: false` および `RETURN_DOM_FRAGMENT: false` を追加しました。これにより、常に無害化された HTML 文字列のみが返却されることが保証されます。また、`src/test/chatAssets.unit.test.ts` の該当するテストケースも更新しました。
✅ **検証方法**: `pnpm run test:unit` を実行し、既存および新規のテストがすべて成功することを確認しました。

---
*PR created automatically by Jules for task [11974854389971448959](https://jules.google.com/task/11974854389971448959) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

DOMPurify の `sanitize()` 呼び出しに `RETURN_DOM: false` と `RETURN_DOM_FRAGMENT: false` を明示的に追加した多層防御強化 PR です。いずれもデフォルト値と同一ですが、明記することで将来のライブラリアップデートや設定変更による意図しない DOM ノード返却リスクを排除します。

- `src/webview/chatAssets.ts`: `DOMPurify.sanitize` の設定オブジェクトに 2 つのオプションを追加し、常に文字列のみが返却されることをコード上で明示。
- `src/test/chatAssets.unit.test.ts`: 追加した設定値が正しく `false` であることを検証するアサーションを 2 行追加。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージして安全です。デフォルト値と同一の設定を明示するだけの変更で、既存の動作を変えません。

変更は DOMPurify のデフォルト設定をコード上に明文化したものであり、実行時の動作は変わりません。対応するテストも正しく追加されており、リグレッションリスクはほぼゼロです。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | DOMPurify.sanitize の設定に RETURN_DOM: false と RETURN_DOM_FRAGMENT: false を明示的に追加。デフォルト値を明文化することで将来的な誤設定やライブラリアップデートへの耐性を強化。 |
| src/test/chatAssets.unit.test.ts | RETURN_DOM および RETURN_DOM_FRAGMENT が false であることを検証するアサーションを追加。変更内容を適切にカバーしている。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(security): explicitly configure DO..."](https://github.com/hiroki-org/jules-extension/commit/73d233feaafd251c3c8199820698b60ccd0a92d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31382842)</sub>

<!-- /greptile_comment -->