### PR TITLE
ci: fix gemini cli trust workspace error in workflows

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -34,6 +34,7 @@ jobs:
       - name: "Check GEMINI_API_KEY presence (debug-only)"
         if: ${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
           GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
         run: |-
           if [ -z "${GEMINI_API_KEY}" ]; then
@@ -46,6 +47,7 @@ jobs:
         uses: "google-github-actions/run-gemini-cli@v0" # ratchet:exclude
         id: "gemini_invoke"
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
           GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
           ADDITIONAL_CONTEXT: "${{ inputs.additional_context }}"
         with:

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -30,6 +30,7 @@ jobs:
         id: "gemini_pr_review"
         continue-on-error: true
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
           GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
           GITHUB_TOKEN: "${{ github.token }}"
           ISSUE_TITLE: "${{ github.event.pull_request.title }}"

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -40,6 +40,7 @@ jobs:
         uses: "google-github-actions/run-gemini-cli@v0" # ratchet:exclude
         id: "gemini_pr_review"
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
           GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
           GITHUB_TOKEN: "${{ github.token }}"
           ISSUE_TITLE: "${{ github.event.pull_request.title || github.event.issue.title }}"

--- a/.github/workflows/gemini-triage-bulk.yml
+++ b/.github/workflows/gemini-triage-bulk.yml
@@ -70,6 +70,7 @@ jobs:
               id: "gemini_issue_analysis"
               uses: "google-github-actions/run-gemini-cli@v0" # ratchet:exclude
               env:
+                  GEMINI_CLI_TRUST_WORKSPACE: "true"
                   GITHUB_TOKEN: "${{ github.token }}"
                   ISSUES_TO_TRIAGE: "${{ inputs.issues_to_triage }}"
                   REPOSITORY: "${{ github.repository }}"


### PR DESCRIPTION
このPRは、複数のGitHub Actionsワークフロー（`gemini-invoke.yml`、`gemini-pr-review.yml`、`gemini-review.yml`、`gemini-triage-bulk.yml`）で発生していた、Gemini CLIが信頼されていないディレクトリで実行されているために失敗するエラーを修正します。

`google-github-actions/run-gemini-cli@v0` アクションの `env` ブロックに `GEMINI_CLI_TRUST_WORKSPACE: "true"` 環境変数を追加しました。

---
*PR created automatically by Jules for task [9568692364572804101](https://jules.google.com/task/9568692364572804101) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

4つの GitHub Actions ワークフローに `GEMINI_CLI_TRUST_WORKSPACE: "true"` 環境変数を追加し、Gemini CLI が信頼されていないワークスペースで実行できなかった問題を修正しています。

- `gemini-pr-review.yml`、`gemini-review.yml`、`gemini-triage-bulk.yml` の `run-gemini-cli@v0` ステップへの追加は適切で、エラーの直接原因を解消しています。
- `gemini-invoke.yml` では正しいステップに加えて、Gemini CLI を使用しないデバッグ用 bash ステップにも同変数が追加されており、そちらは効果がないため不要です。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

全体的にマージ安全。変更はシンプルな環境変数の追加であり、意図した修正は正しく適用されています。

Gemini CLI を実際に呼び出さないデバッグ専用 bash ステップへの余分な環境変数追加がありますが、動作に悪影響はありません。本質的な修正（`run-gemini-cli` ステップへの追加）は全ファイルで正確に行われています。

`gemini-invoke.yml` のデバッグステップに不要な変数が追加されている点のみ軽微な確認が必要。他のファイルは問題なし。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/gemini-invoke.yml | `GEMINI_CLI_TRUST_WORKSPACE: "true"` を `run-gemini-cli` ステップに追加（正しい対応）。ただしデバッグ専用のbashステップにも誤って追加されており、そこでは不要。 |
| .github/workflows/gemini-pr-review.yml | `run-gemini-cli` ステップの `env` に `GEMINI_CLI_TRUST_WORKSPACE: "true"` を追加。適切な場所への追加で問題なし。 |
| .github/workflows/gemini-review.yml | `run-gemini-cli` ステップの `env` に `GEMINI_CLI_TRUST_WORKSPACE: "true"` を追加。適切な場所への追加で問題なし。 |
| .github/workflows/gemini-triage-bulk.yml | `run-gemini-cli` ステップの `env` に `GEMINI_CLI_TRUST_WORKSPACE: "true"` を追加。適切な場所への追加で問題なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions Runner
    participant Action as run-gemini-cli@v0
    participant CLI as Gemini CLI
    participant API as Gemini API

    Note over GHA,CLI: Before this PR
    GHA->>Action: env without GEMINI_CLI_TRUST_WORKSPACE
    Action->>CLI: launch in workspace
    CLI-->>Action: Error: untrusted workspace

    Note over GHA,CLI: After this PR
    GHA->>Action: "env with GEMINI_CLI_TRUST_WORKSPACE=true"
    Action->>CLI: launch in workspace
    CLI->>API: request (with GEMINI_API_KEY)
    API-->>CLI: response
    CLI-->>Action: success
    Action-->>GHA: success
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/gemini-invoke.yml:37
**デバッグ専用のbashステップへの不要な環境変数追加**

`GEMINI_CLI_TRUST_WORKSPACE: "true"` は "Check GEMINI_API_KEY presence (debug-only)" ステップ（`run:` ブロック）に追加されていますが、このステップは Gemini CLI を呼び出しておらず、純粋に `GEMINI_API_KEY` の存在確認のみを行う bash スクリプトです。この環境変数はそのシェル内では全く参照されないため、実質的に無効です。実際に必要なのは直下の `google-github-actions/run-gemini-cli@v0` を使うステップのみです。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: fix gemini cli trust workspace error..."](https://github.com/hiroki-org/jules-extension/commit/1c9ba06099be274ce93a92be73c18bdeff74c5e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31419262)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->