### PR TITLE
🛡️ Sentinel: [MEDIUM] `git apply`実行プロセスにタイムアウトを設定し、ハングアップ（DoS）を防止

### DIFF
--- a/src/applyPatchLocally.ts
+++ b/src/applyPatchLocally.ts
@@ -142,7 +142,7 @@ export async function applyPatchLocallyForSession(options: {
                 childProcess.execFile(
                     gitExecutable,
                     ["apply", "--3way", patchFilePath], 
-                    { cwd: repository.rootUri.fsPath }, 
+                    { cwd: repository.rootUri.fsPath, timeout: 30000 },
                     (error, stdout, stderr) => {
                         if (error) {
                             const failureDetails = stderr || error.message;


### PR DESCRIPTION
🚨 **Severity**: MEDIUM

💡 **Vulnerability**: 
`src/applyPatchLocally.ts` において、`childProcess.execFile` を使用して `git apply` を実行する際、タイムアウト時間が設定されていませんでした。
万が一 git プロセスがハングアップした場合、Node.jsのイベントループや拡張機能のホストプロセスが永続的にブロックされ、リソース枯渇によるサービス運用妨害（DoS）状態に陥るリスクがありました。

🎯 **Impact**:
悪意のある、あるいは異常なパッチファイルによって `git apply` がハングした場合、ユーザーのVS Code拡張機能ホスト全体が応答しなくなり、強制終了が必要になる可能性があります。

🔧 **Fix**:
`childProcess.execFile` のオプションに `timeout: 30000` (30秒) を明示的に設定しました。これにより、プロセスが規定時間内に終了しない場合は自動的に強制終了（SIGTERM / SIGKILL）され、アプリケーションがハングアップから回復できるようになります。

✅ **Verification**:
- `pnpm run test:unit` を実行して、既存のテスト（`applyPatchLocally` のモックテストなど）が壊れていないことを確認しました。
- コード上で `timeout` オプションが正しく渡されていることを確認しました。

---
*PR created automatically by Jules for task [13945871346522391574](https://jules.google.com/task/13945871346522391574) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`src/applyPatchLocally.ts` で `git apply` を実行する `childProcess.execFile` に `timeout: 30000`（30秒）を追加し、プロセスのハングアップによる VS Code 拡張機能ホストの恒久的なブロックを防ぎます。

- **タイムアウト追加**: `execFile` のオプションに `timeout: 30000` を付与。タイムアウト超過時はプロセスが自動強制終了され、Promise が reject される既存のエラーハンドリングに流れる。
- **改善余地**: タイムアウト発生時（`error.killed === true`）を通常の git エラーと区別するメッセージ分岐がなく、ログ/ユーザー通知からタイムアウトと判断しづらい。また `killSignal` が未指定のため、デフォルトの `SIGTERM` で git プロセスが終了しないケースでは孤児プロセスが残る可能性がある。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更箇所は1行のオプション追加のみで、既存のコールバック・Promise・エラー処理フローには一切手が入っていないため、動作への悪影響はほぼありません。

タイムアウト付与自体は正しく機能しますが、タイムアウト時に error.killed を識別せずに汎用メッセージを返す点と、SIGTERM 無視リスクへの killSignal 未指定の点は改善が望ましい箇所です。

src/applyPatchLocally.ts — タイムアウトエラーのメッセージ分岐と killSignal の指定を確認してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/applyPatchLocally.ts | `execFile` に `timeout: 30000` を追加してハングアップを防止。タイムアウト時のエラーメッセージ区別と `killSignal` 指定が改善余地あり（いずれも軽微な提案レベル）。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as applyPatchLocallyForSession
    participant execFile as childProcess.execFile
    participant git as git apply プロセス
    participant Callback as コールバック

    Caller->>execFile: "execFile(git, [apply ...], { timeout: 30000 })"
    execFile->>git: プロセス起動

    alt 正常終了（30秒以内）
        git-->>Callback: exit(0)
        Callback->>Caller: resolve()
    else git apply 失敗（30秒以内）
        git-->>Callback: exit(非0), error
        Callback->>Caller: reject(new Error(...))
    else タイムアウト（30秒超過）
        execFile->>git: SIGTERM で強制終了
        git-->>Callback: "error.killed=true"
        Callback->>Caller: reject(new Error(git apply failed))
    end

    Caller->>Caller: catch → restoreOriginalBranch / showErrorMessage
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/applyPatchLocally.ts`, line 146-149 ([link](https://github.com/hiroki-org/jules-extension/blob/ada8a9671ba7900e8df9bd14c1cf7ccea779ba1a/src/applyPatchLocally.ts#L146-L149)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> タイムアウト発生時のエラーメッセージが不明確です。`error.killed` が `true` の場合（タイムアウトによるプロセス強制終了時）、`stderr` は空であることが多く、`error.message` も汎用的な "Command failed: git apply..." になります。ログやユーザー通知にタイムアウトであることが明示されないため、問題の切り分けが困難になります。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/applyPatchLocally.ts
   Line: 146-149

   Comment:
   タイムアウト発生時のエラーメッセージが不明確です。`error.killed` が `true` の場合（タイムアウトによるプロセス強制終了時）、`stderr` は空であることが多く、`error.message` も汎用的な "Command failed: git apply..." になります。ログやユーザー通知にタイムアウトであることが明示されないため、問題の切り分けが困難になります。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/applyPatchLocally.ts:146-149
タイムアウト発生時のエラーメッセージが不明確です。`error.killed` が `true` の場合（タイムアウトによるプロセス強制終了時）、`stderr` は空であることが多く、`error.message` も汎用的な "Command failed: git apply..." になります。ログやユーザー通知にタイムアウトであることが明示されないため、問題の切り分けが困難になります。

```suggestion
                    (error, stdout, stderr) => {
                        if (error) {
                            const isTimeout = (error as NodeJS.ErrnoException & { killed?: boolean }).killed === true;
                            const failureDetails = isTimeout
                                ? `git apply timed out after 30 seconds`
                                : stderr || error.message;
                            log(`Git apply failed for ${patchFilePath}: ${failureDetails});
```

### Issue 2 of 2
src/applyPatchLocally.ts:145
`execFile` のデフォルトの kill シグナルは `SIGTERM` ですが、git プロセスが SIGTERM を無視したり処理に時間がかかる場合、プロセスが残り続ける可能性があります。`killSignal: 'SIGKILL'` を明示することで、タイムアウト後に確実にプロセスを終了させられます。

```suggestion
                    { cwd: repository.rootUri.fsPath, timeout: 30000, killSignal: 'SIGKILL' },
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] 実行プロセスのハングアップ防止（D..."](https://github.com/hiroki-org/jules-extension/commit/ada8a9671ba7900e8df9bd14c1cf7ccea779ba1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31528775)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->