### PR TITLE
自動返信機能（autoReplyMessage）の実装とコード切り出し

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,12 @@
             "Use 'main' branch, or the repository's default if 'main' does not exist"
           ],
           "scope": "resource"
+        },
+        "jules-extension.autoReplyMessage": {
+          "type": "string",
+          "default": "",
+          "description": "Julesがユーザーのフィードバックを待機している状態（AWAITING_USER_FEEDBACK）になった際、自動的に送信するメッセージを指定します。空の場合は自動返信は無効になります。",
+          "markdownDescription": "Julesがユーザーのフィードバックを待機している状態（AWAITING_USER_FEEDBACK）になった際、自動的に送信するメッセージを指定します。空の場合は自動返信は無効になります。\n\n**例:**\n`内容を確認しました。PRを作成してください。`"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import { handleUserFeedbackRequired } from "./sessionUtils";
 import { recoverCorruptedActivities } from "./sessionUtils";
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
@@ -758,16 +759,7 @@ async function notifyPlanAwaitingApproval(
   }
 }
 
-async function notifyUserFeedbackRequired(session: Session): Promise<void> {
-  const selection = await vscode.window.showInformationMessage(
-    `Jules is waiting for your feedback in session: "${session.title}"`,
-    VIEW_DETAILS_ACTION,
-  );
 
-  if (selection === VIEW_DETAILS_ACTION) {
-    await vscode.commands.executeCommand(SHOW_ACTIVITIES_COMMAND, session.name);
-  }
-}
 
 export function areOutputsEqual(
   a?: SessionOutput[],
@@ -1868,7 +1860,7 @@ export class JulesSessionsProvider implements vscode.TreeDataProvider<vscode.Tre
         await this.sendNotifications(
           sessionsToNotifyFeedback,
           "user feedback",
-          notifyUserFeedbackRequired,
+          (session) => handleUserFeedbackRequired(session, apiKey || "", logChannel),
         );
 
         // Notify Completed (PR Created)

--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -1,3 +1,4 @@
+import type { Session } from "./types";
 import { isActivityCorrupted } from "./activityUtils";
 import * as vscode from "vscode";
 import { fetchWithTimeout } from "./fetchUtils";
@@ -244,3 +245,41 @@ export async function recoverCorruptedActivities(
     }
   }
 }
+
+
+/**
+ * Handles the logic when a session requires user feedback.
+ * If auto-reply is configured, it automatically sends the message.
+ * Otherwise, it shows an information prompt.
+ */
+export async function handleUserFeedbackRequired(
+  session: Session,
+  apiKey: string,
+  logChannel: vscode.OutputChannel,
+): Promise<void> {
+  const config = vscode.workspace.getConfiguration("jules-extension");
+  const autoReplyMessage = config.get<string>("autoReplyMessage", "");
+
+  if (autoReplyMessage && autoReplyMessage.trim().length > 0) {
+    try {
+      logChannel.appendLine(`Jules: Auto-replying to session "${session.title}" with message: "${autoReplyMessage}"`);
+      await sendMessage(apiKey, session.name, autoReplyMessage);
+      return;
+    } catch (err) {
+      logChannel.appendLine(`Jules: Failed to auto-reply to session "${session.title}": ${err}`);
+      // Fallback to manual prompt on error
+    }
+  }
+
+  const selection = await vscode.window.showInformationMessage(
+    `Jules is waiting for your feedback in session: "${session.title}"`,
+    "View Details"
+  );
+
+  if (selection === "View Details") {
+    await vscode.commands.executeCommand(SHOW_ACTIVITIES_COMMAND, session.name);
+  }
+}
+
+const VIEW_DETAILS_ACTION = "View Details";
+const SHOW_ACTIVITIES_COMMAND = "jules-extension.showActivities";

--- a/src/test/sessionUtils.unit.test.ts
+++ b/src/test/sessionUtils.unit.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import * as sinon from "sinon";
-import { createJulesSession, fetchSingleActivity, recoverCorruptedActivities, sendMessage } from "../sessionUtils";
+import { createJulesSession, fetchSingleActivity, recoverCorruptedActivities, sendMessage, handleUserFeedbackRequired } from "../sessionUtils";
 import * as fetchUtils from "../fetchUtils";
 
 suite("sessionUtils Test Suite", () => {
@@ -331,4 +331,69 @@ suite("sessionUtils recoverCorruptedActivities", () => {
 
         assert.strictEqual(activities.length, 0); // Corrupted activity is filtered out
     });
+
+
+  suite("handleUserFeedbackRequired", () => {
+    let getConfigurationStub: sinon.SinonStub;
+    let showInformationMessageStub: sinon.SinonStub;
+    let executeCommandStub: sinon.SinonStub;
+    let logChannelStub: any;
+
+    setup(() => {
+      getConfigurationStub = sinon.stub(vscode.workspace, "getConfiguration");
+      showInformationMessageStub = sinon.stub(vscode.window, "showInformationMessage");
+      executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
+      logChannelStub = { appendLine: sinon.stub() };
+    });
+
+    teardown(() => {
+      sinon.restore();
+    });
+
+    test("should use autoReplyMessage when configured", async () => {
+      const configMock = { get: sinon.stub().returns("Test reply message") };
+      getConfigurationStub.returns(configMock);
+
+      const session = { name: "sessions/123", title: "Test Session" } as any;
+      const fetchStub = sinon.stub(fetchUtils, "fetchWithTimeout").resolves({
+        ok: true,
+        json: async () => ({})
+      } as any);
+
+      await handleUserFeedbackRequired(session, "dummy-key", logChannelStub);
+
+      assert.ok(fetchStub.calledOnce);
+      assert.strictEqual(showInformationMessageStub.called, false);
+      assert.ok(logChannelStub.appendLine.called);
+    });
+
+    test("should fallback to manual prompt when autoReplyMessage throws", async () => {
+      const configMock = { get: sinon.stub().returns("Test reply message") };
+      getConfigurationStub.returns(configMock);
+
+      const session = { name: "sessions/123", title: "Test Session" } as any;
+      const fetchStub = sinon.stub(fetchUtils, "fetchWithTimeout").resolves({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: async () => "Error"
+      } as any);
+
+      await handleUserFeedbackRequired(session, "dummy-key", logChannelStub);
+
+      assert.ok(fetchStub.calledOnce);
+      assert.ok(showInformationMessageStub.calledOnce);
+    });
+
+    test("should fallback to manual prompt when autoReplyMessage is empty", async () => {
+      const configMock = { get: sinon.stub().returns("") };
+      getConfigurationStub.returns(configMock);
+
+      const session = { name: "sessions/123", title: "Test Session" } as any;
+
+      await handleUserFeedbackRequired(session, "dummy-key", logChannelStub);
+
+      assert.ok(showInformationMessageStub.calledOnce);
+    });
+  });
 });


### PR DESCRIPTION
Julesからのフィードバック待機状態（AWAITING_USER_FEEDBACK）になった際、ユーザーが設定した任意のメッセージを自動的に送信する機能を追加しました。

*   `package.json` の `configuration` に `jules-extension.autoReplyMessage` を追加。
*   `src/extension.ts` にあった `notifyUserFeedbackRequired` の実装を、肥大化を防ぐために `src/sessionUtils.ts` 内に `handleUserFeedbackRequired` として切り出しました。
*   自動返信が設定されていれば `sendMessage` APIをコールし、設定されていなければこれまで通りVS Codeの情報メッセージでユーザーにアクションを促します。
*   単体テストおよび型チェック(`pnpm run check-types`)を完了しています。

---
*PR created automatically by Jules for task [4692864220378246411](https://jules.google.com/task/4692864220378246411) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Jules が `AWAITING_USER_FEEDBACK` 状態になった際に、ユーザーが設定したメッセージを自動送信する機能（`autoReplyMessage`）を追加し、既存の `notifyUserFeedbackRequired` ロジックを `sessionUtils.ts` の `handleUserFeedbackRequired` に切り出したPRです。

- **`package.json`**: `jules-extension.autoReplyMessage` 設定項目を追加。空文字列の場合は自動返信が無効になる。
- **`src/sessionUtils.ts`**: `handleUserFeedbackRequired` を新規エクスポート。自動返信が設定されていれば `sendMessage` APIを呼び出し、失敗時は情報メッセージにフォールバックする。`VIEW_DETAILS_ACTION` 定数が宣言されているが未使用で、テストも追加されていない点が要確認。
- **`src/extension.ts`**: `notifyUserFeedbackRequired` を削除し `handleUserFeedbackRequired` の呼び出しに置き換え。同一モジュールへの import 文が2行に分かれている。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

自動返信ロジック自体は動作するが、`VIEW_DETAILS_ACTION` 定数が未使用のままコードに残っており、テストが追加されていない点を修正してからマージするのが望ましい。

新機能のコアロジックは正しく実装されており、エラー時のフォールバックや既存の通知重複防止機構（`notifiedSessions`）との連携も適切。ただし `VIEW_DETAILS_ACTION` 定数が宣言されても参照されず、AGENTS.md で必須とされているテストが追加されていないため、コードの信頼性に不安が残る。

src/sessionUtils.ts — 定数の未使用とテスト不在の両方が集中しており、最も注意が必要。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/sessionUtils.ts | `handleUserFeedbackRequired` 関数を新規追加。`VIEW_DETAILS_ACTION` 定数が宣言されているが関数内では未使用（文字列リテラルが直接使われている）。テストなし。 |
| src/extension.ts | `notifyUserFeedbackRequired` を削除し `handleUserFeedbackRequired` の呼び出しに置き換え。`./sessionUtils` からの import が2行に分割されている。 |
| package.json | `jules-extension.autoReplyMessage` 設定項目を追加。`description` と `markdownDescription` が日本語で適切に記述されている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Poller as fetchAndProcessSessions
    participant SN as sendNotifications
    participant HFR as handleUserFeedbackRequired
    participant Config as VS Code Config
    participant API as Jules API (sendMessage)
    participant UI as VS Code UI

    Poller->>Poller: セッション状態チェック
    Poller->>SN: sessionsToNotifyFeedback
    SN->>HFR: handleUserFeedbackRequired(session, apiKey, logChannel)
    HFR->>Config: get("autoReplyMessage")
    alt autoReplyMessage が設定されている
        HFR->>API: sendMessage(apiKey, session.name, autoReplyMessage)
        alt 成功
            HFR-->>SN: return (自動返信完了)
        else エラー
            HFR->>UI: showInformationMessage (フォールバック)
        end
    else autoReplyMessage が空
        HFR->>UI: showInformationMessage("View Details")
        UI-->>HFR: ユーザー選択
        opt "View Details" 選択
            HFR->>HFR: executeCommand(showActivities)
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/sessionUtils.ts:274-285
`VIEW_DETAILS_ACTION` 定数はファイルの末尾で宣言されていますが、関数内では使われず `"View Details"` のリテラルが直接使われています。定数を先に宣言した上で参照することで、文字列の不一致リスクを防ぎましょう。

```suggestion
  const selection = await vscode.window.showInformationMessage(
    `Jules is waiting for your feedback in session: "${session.title}"`,
    VIEW_DETAILS_ACTION
  );

  if (selection === VIEW_DETAILS_ACTION) {
    await vscode.commands.executeCommand(SHOW_ACTIVITIES_COMMAND, session.name);
  }
}

const VIEW_DETAILS_ACTION = "View Details";
const SHOW_ACTIVITIES_COMMAND = "jules-extension.showActivities";
```

### Issue 2 of 4
src/extension.ts:1-2
同じモジュール `"./sessionUtils"` から2つの独立した `import` 文が存在しています。1つにまとめることで可読性が向上します。

```suggestion
import { handleUserFeedbackRequired, recoverCorruptedActivities } from "./sessionUtils";
```

### Issue 3 of 4
src/sessionUtils.ts:265
**自動返信メッセージが出力チャンネルに全文ログ出力される**

`autoReplyMessage` の全文がログに記録されるため、機密性のある内容（社内情報、個人情報など）をユーザーが設定していた場合、VS Code の出力パネル経由で意図せず露出する可能性があります。メッセージの先頭数十文字だけを記録するか、内容自体はログに含めない設計を検討してください。

### Issue 4 of 4
src/sessionUtils.ts:255-282
**`handleUserFeedbackRequired` の単体テストが追加されていない**

AGENTS.md では「新しい機能を追加した場合は、対応するテストも追加してください」と定められています。`sendMessage` 呼び出しのパス・エラー時のフォールバック・自動返信無効時の通知表示、それぞれのシナリオをカバーするテストが `sessionUtils.unit.test.ts` に存在しません。PR説明では「単体テストを完了」と記載されていますが、実際にはテストが追加されていないため、確認が必要です。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: AWAITING\_USER\_FEEDBACKに対する自動返信機能の実..."](https://github.com/hiroki-org/jules-extension/commit/d216f62eb5568a99e838360a2c265d953104f1df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31537855)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->