### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability by adding timeout to childProcess.execFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Add timeout to execFile to prevent DoS
+**Vulnerability:** childProcess.execFile does not have a timeout, which can cause the extension host to hang indefinitely if the git process stalls.
+**Learning:** External processes should always have a timeout to prevent DoS.
+**Prevention:** Always add a timeout option when using childProcess.execFile or similar functions.

--- a/src/applyPatchLocally.ts
+++ b/src/applyPatchLocally.ts
@@ -142,7 +142,7 @@ export async function applyPatchLocallyForSession(options: {
                 childProcess.execFile(
                     gitExecutable,
                     ["apply", "--3way", patchFilePath], 
-                    { cwd: repository.rootUri.fsPath }, 
+                    { cwd: repository.rootUri.fsPath, timeout: 30000 },
                     (error, stdout, stderr) => {
                         if (error) {
                             const failureDetails = stderr || error.message;

--- a/src/applyPatchLocally.ts
+++ b/src/applyPatchLocally.ts
@@ -142,7 +142,7 @@ export async function applyPatchLocallyForSession(options: {
                 childProcess.execFile(
                     gitExecutable,
                     ["apply", "--3way", patchFilePath], 
-                    { cwd: repository.rootUri.fsPath, timeout: 30000 },
+                    { cwd: repository.rootUri.fsPath, timeout: 30000, killSignal: "SIGKILL" },
                     (error, stdout, stderr) => {
                         if (error) {
                             const failureDetails = stderr || error.message;

--- a/src/test/applyPatchLocally.unit.test.ts
+++ b/src/test/applyPatchLocally.unit.test.ts
@@ -105,7 +105,7 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
             'base-sha',
         ]);
         assert.strictEqual(execFileStub.firstCall.args[0], '/custom/git');
-        assert.deepStrictEqual(execFileStub.firstCall.args[2], { cwd: '/repo', timeout: 30000 });
+        assert.deepStrictEqual(execFileStub.firstCall.args[2], { cwd: '/repo', timeout: 30000, killSignal: 'SIGKILL' });
         assert.strictEqual(repository.inputBox.value, 'feat: apply patch locally');
     });
 
@@ -226,6 +226,39 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
             if (process.platform !== 'win32') {
                 assert.strictEqual(patchStats.mode & 0o777, 0o600);
             }
+        } finally {
+            await fs.rm(expectedPath, { force: true });
+        }
+    });
+
+    test('git apply タイムアウト時は元ブランチへ戻し、patch ファイルを保持すること', async () => {
+        sandbox.stub(Date, 'now').returns(5678);
+        const expectedPath = path.join(os.tmpdir(), 'jules-abc-5678.patch');
+        await fs.rm(expectedPath, { force: true });
+        execFileStub.callsFake(((_file: string, _args: string[], _options: any, callback: any) => {
+            const timeoutError = Object.assign(new Error('Command failed: git apply timed out'), {
+                killed: true,
+                signal: 'SIGKILL',
+            });
+            callback(timeoutError, '', '');
+            return {} as childProcess.ChildProcess;
+        }) as any);
+
+        try {
+            await applyPatchLocallyForSession({
+                session: createSession(),
+                changeSet: createChangeSet(),
+                outputChannel,
+            });
+
+            assert.deepStrictEqual(execFileStub.firstCall.args[2], { cwd: '/repo', timeout: 30000, killSignal: 'SIGKILL' });
+            assert.strictEqual(repository.checkout.calledOnceWithExactly('main'), true);
+            assert.match(showErrorMessageStub.firstCall.args[0], /Failed to apply patch/);
+            assert.ok(
+                showErrorMessageStub.firstCall.args[0].includes(expectedPath),
+                'タイムアウト時も patch ファイルの保存先を含めるべき',
+            );
+            await fs.stat(expectedPath);
         } finally {
             await fs.rm(expectedPath, { force: true });
         }
@@ -364,7 +397,7 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
         });
 
         assert.strictEqual(execFileStub.firstCall.args[0], 'git');
-        assert.deepStrictEqual(execFileStub.firstCall.args[2], { cwd: '/repo', timeout: 30000 });
+        assert.deepStrictEqual(execFileStub.firstCall.args[2], { cwd: '/repo', timeout: 30000, killSignal: 'SIGKILL' });
         assert.strictEqual(
             (outputChannel.appendLine as sinon.SinonSpy).calledWithMatch(/falling back to 'git'/),
             true,

--- a/src/test/applyPatchLocally.unit.test.ts
+++ b/src/test/applyPatchLocally.unit.test.ts
@@ -105,6 +105,7 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
             'base-sha',
         ]);
         assert.strictEqual(execFileStub.firstCall.args[0], '/custom/git');
+        assert.deepStrictEqual(execFileStub.firstCall.args[2], { cwd: '/repo', timeout: 30000 });
         assert.strictEqual(repository.inputBox.value, 'feat: apply patch locally');
     });
 
@@ -363,6 +364,7 @@ suite('applyPatchLocallyForSession ユニットテスト', () => {
         });
 
         assert.strictEqual(execFileStub.firstCall.args[0], 'git');
+        assert.deepStrictEqual(execFileStub.firstCall.args[2], { cwd: '/repo', timeout: 30000 });
         assert.strictEqual(
             (outputChannel.appendLine as sinon.SinonSpy).calledWithMatch(/falling back to 'git'/),
             true,


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** `src/applyPatchLocally.ts`内で`childProcess.execFile`を使用してgitプロセスを呼び出す際、タイムアウトが設定されていないため、プロセスがハングした場合に拡張機能のホストプロセス（Node.jsイベントループ）が無限にブロックされ、Denial of Service (DoS) 状態に陥るリスクがありました。
🎯 **Impact:** 万が一Gitプロセスが応答しなくなった場合、VS Codeの拡張機能全体がハングし、ユーザーの作業を妨害する可能性があります。
🔧 **Fix:** `childProcess.execFile`のオプションに`{ timeout: 30000 }`（30秒）を明示的に追加し、プロセスが指定時間内に完了しない場合は強制的にタイムアウトエラーとして処理されるように修正しました。また、関連するユニットテストの検証内容も更新し、タイムアウト設定が正しく渡されていることを確認しました。あわせて、`.jules/sentinel.md` にセキュリティジャーナルを追加しました。
✅ **Verification:** `pnpm run test:unit` および `xvfb-run -a pnpm test` が全て正常に通過することを確認済みです。

---
*PR created automatically by Jules for task [17668004741404362692](https://jules.google.com/task/17668004741404362692) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `childProcess.execFile` に `timeout: 30000`（30秒）を追加したシンプルなDoS修正です。変更自体は正しく、マージは概ね安全です。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージは概ね安全。タイムアウトオプションの追加は正しく機能するが、タイムアウト発生時のユーザーへのフィードバックに改善の余地がある。

変更は1行の追加のみで副作用のリスクは低い。タイムアウトエラーと通常のgitエラーを同じ汎用メッセージで処理しており、デバッグ時に原因の特定がしにくくなる点が残課題。

`src/applyPatchLocally.ts` のタイムアウトエラーハンドリング部分を確認するとよい。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/applyPatchLocally.ts | `execFile` に `timeout: 30000` を追加。変更自体は正しいが、タイムアウトエラーと通常のgitエラーを区別するハンドリングがない。 |
| src/test/applyPatchLocally.unit.test.ts | timeoutオプションが渡されることを検証するアサーションを2箇所追加。タイムアウト発生時の動作テストは含まれていない。 |
| .jules/sentinel.md | セキュリティジャーナルファイルの新規追加。今回の修正内容と学習事項を記録している。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/applyPatchLocally.ts`, line 147-150 ([link](https://github.com/hiroki-org/jules-extension/blob/9e5679a1bcb6a14b00f3986f9efff6334a768c4e/src/applyPatchLocally.ts#L147-L150)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **タイムアウトエラーが通常のgitエラーと区別されない**

   `execFile` がタイムアウトすると `error.killed === true` となり、`stderr` は通常空になります。現状では `stderr || error.message` というフォールバックで処理されますが、ユーザーには「git apply failed」という汎用メッセージしか表示されず、タイムアウトが原因なのかgit自体のエラーなのかが分かりません。`error.killed` を確認してタイムアウト専用のメッセージを出力すると、デバッグが大幅に楽になります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/applyPatchLocally.ts
   Line: 147-150

   Comment:
   **タイムアウトエラーが通常のgitエラーと区別されない**

   `execFile` がタイムアウトすると `error.killed === true` となり、`stderr` は通常空になります。現状では `stderr || error.message` というフォールバックで処理されますが、ユーザーには「git apply failed」という汎用メッセージしか表示されず、タイムアウトが原因なのかgit自体のエラーなのかが分かりません。`error.killed` を確認してタイムアウト専用のメッセージを出力すると、デバッグが大幅に楽になります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/applyPatchLocally.ts:147-150
**タイムアウトエラーが通常のgitエラーと区別されない**

`execFile` がタイムアウトすると `error.killed === true` となり、`stderr` は通常空になります。現状では `stderr || error.message` というフォールバックで処理されますが、ユーザーには「git apply failed」という汎用メッセージしか表示されず、タイムアウトが原因なのかgit自体のエラーなのかが分かりません。`error.killed` を確認してタイムアウト専用のメッセージを出力すると、デバッグが大幅に楽になります。

### Issue 2 of 2
src/test/applyPatchLocally.unit.test.ts:108
**タイムアウト発生時の動作がテストされていない**

追加されたアサーションは `timeout` オプションが正しく渡されているかを確認するのみです。実際にタイムアウトが発生したとき（`error.killed === true` のケース）にエラーハンドリングが正しく機能するか、またパッチファイルが保持されるかを確認するテストケースがあると、リグレッションへの安心感が増します。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(security): execFileのタイムアウト追加によるDoS脆..."](https://github.com/hiroki-org/jules-extension/commit/9e5679a1bcb6a14b00f3986f9efff6334a768c4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31608106)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->