### PR TITLE
🎨 Palette: Composer のステータス領域に aria-atomic を追加してアクセシビリティを改善

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -239,7 +239,7 @@ export function getComposerHtml(
 </style>
 </head>
 <body>
-  <div id="sr-status" class="sr-only" aria-live="polite"></div>
+  <div id="sr-status" class="sr-only" aria-live="polite" aria-atomic="true"></div>
   <textarea id="message" aria-label="${placeholder || 'Message input'}" placeholder="${placeholder}" autofocus>${value}</textarea>
   <div class="actions">
     ${createPrCheckbox}


### PR DESCRIPTION
## 🎨 Palette: アクセシビリティ（ARIA）の改善

**💡 What:** `src/composer.ts` 内のスクリーンリーダー用ステータス通知領域 (`<div id="sr-status">`) に `aria-atomic="true"` を追加しました。

**🎯 Why:** `aria-live="polite"` と合わせて `aria-atomic="true"` を設定することで、ステータス変更（例: "Sending message..."）があった際に、DOMの一部分ではなくノード全体のコンテンツがスクリーンリーダーによって読み上げられることが保証されます。これにより視覚障害のあるユーザーが現在の状態を正確に把握しやすくなります。

**♿ Accessibility:** ステータス更新時のスクリーンリーダーのアナウンスの信頼性と一貫性が向上しました。

（※このリポジトリの推奨事項に従い、日本語でPRを作成しています。）

---
*PR created automatically by Jules for task [7730738513035123660](https://jules.google.com/task/7730738513035123660) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`src/composer.ts` 内のスクリーンリーダー向けステータス通知領域 (`#sr-status`) に `aria-atomic="true"` を追加した、1行のアクセシビリティ改善です。既存の `aria-live="polite"` と組み合わせることで、送信中などのステータス変更時にノード全体のテキストが確実に読み上げられるようになります。

- `aria-live="polite"` 単体では部分的な DOM 変更しかアナウンスされない場合があるため、`aria-atomic="true"` を追加することで読み上げの一貫性が保証されます。
- `chatView.ts` でも同様のパターンが既に使用されており、コードベース全体でのアクセシビリティ実装が統一されます。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更はマージ可能です。既存の動作に影響を与えない純粋なアクセシビリティ属性の追加です。

`aria-atomic="true"` を追加するだけの1行変更で、HTML属性のみの変更のためランタイムロジックへの影響は一切ありません。`chatView.ts` での同パターンとも一致しており、リグレッションリスクはほぼゼロです。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | `aria-atomic="true"` を `#sr-status` の `aria-live` 領域に追加するアクセシビリティ改善の1行変更。ロジックへの影響なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as ユーザー
    participant UI as Composer UI
    participant SR as スクリーンリーダー

    User->>UI: 送信ボタンをクリック
    UI->>UI: "srStatus.textContent = 'Sending message...'"
    Note over UI: #sr-status (aria-live="polite" aria-atomic="true")
    UI-->>SR: DOM変更を検知
    SR-->>User: ノード全体 "Sending message..." を読み上げ
```

<sub>Reviews (1): Last reviewed commit: ["fix: add aria-atomic to live region in c..."](https://github.com/hiroki-org/jules-extension/commit/bbaae5efacad2a6516cd171b6a455726ee6b9640) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31794302)</sub>

<!-- /greptile_comment -->