### PR TITLE
⚡ Bolt: O(N log N) のソートを O(N) の Map ルックアップに最適化

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-02-23 - Avoid .map().filter() in Tooltip Rendering
 **Learning:** Chained `.map().filter()` followed by `Array.from(new Map(...))` in UI rendering functions like `buildSessionTooltip` cause unnecessary array allocations and iterations, which can negatively impact performance when rendering large lists of sessions.
 **Action:** Replace functional array chaining with direct single-pass `for` loops that populate the target collection (like a `Map`) directly when processing data for frequent UI rendering.
+
+## 2024-05-12 - Replacing .sort() for array equality checks
+**Learning:** Using `.sort()` followed by index-based iteration is a common, but slow O(N log N) way to determine multiset equality (when order doesn't matter). Replacing it with an O(N) Map lookup eliminates memory reallocation and algorithmic overhead.
+**Action:** When comparing arrays where element order is independent (e.g. file paths or branch names), build a Map of element counts rather than `.sort()`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-12 - Replacing .sort() for array equality checks
 **Learning:** Using `.sort()` followed by index-based iteration is a common, but slow O(N log N) way to determine multiset equality (when order doesn't matter). Replacing it with an O(N) Map lookup eliminates memory reallocation and algorithmic overhead.
 **Action:** When comparing arrays where element order is independent (e.g. file paths or branch names), build a Map of element counts rather than `.sort()`.
+
+## 2024-05-12 - Handling Multiset arrays composed of Objects
+**Learning:** A simple tally map works well to compare arrays composed of strings or numbers, but you need to be careful when the array contains objects. Simply matching lengths and hashing the stringified keys or specific properties (e.g. `path + status`) correctly allows a Frequency Map representation of a Multiset of Objects without the memory allocation and O(N log N) overhead of sorts.
+**Action:** Always verify if arrays you are comparing allow duplicate items. Use `.length` validation, then build a Frequency map and decrement values when comparing.

--- a/src/branchUtils.ts
+++ b/src/branchUtils.ts
@@ -98,12 +98,18 @@ function areArraysEqual(a: string[], b: string[]): boolean {
     if (a.length !== b.length) {
         return false;
     }
-    const sortedA = [...a].sort();
-    const sortedB = [...b].sort();
-    for (let i = 0; i < sortedA.length; i++) {
-        if (sortedA[i] !== sortedB[i]) {
+    // ⚡ Bolt 最適化: O(N log N) のソート処理を O(N) の Map 集計に置換
+    // SetではなくMapを使用することで、多重集合（重複する要素を持つ配列）を正しく処理します。
+    const counts = new Map<string, number>();
+    for (const item of a) {
+        counts.set(item, (counts.get(item) || 0) + 1);
+    }
+    for (const item of b) {
+        const count = counts.get(item);
+        if (!count) {
             return false;
         }
+        counts.set(item, count - 1);
     }
     return true;
 }

--- a/src/sessionArtifacts.ts
+++ b/src/sessionArtifacts.ts
@@ -500,17 +500,21 @@ function areChangeSetFilesEqual(a?: ChangeSetSummary, b?: ChangeSetSummary): boo
         return false;
     }
 
-    // Sort files by path to ensure order-independence
-    // ⚡ Bolt 最適化: O(N log N) のソート処理を O(N) の Map ルックアップに置換
-    const bFilesMap = new Map<string, string | undefined>();
+        // ⚡ Bolt 最適化: O(N log N) のソート処理を O(N) の Map 集計に置換
+    // SetではなくMapを使用することで、多重集合（重複する要素を持つ配列）を正しく処理します。
+    const counts = new Map<string, number>();
     for (const f of bFiles) {
-        bFilesMap.set(f.path, f.status);
+        const key = f.path + "|" + f.status;
+        counts.set(key, (counts.get(key) || 0) + 1);
     }
 
     for (const f of aFiles) {
-        if (!bFilesMap.has(f.path) || bFilesMap.get(f.path) !== f.status) {
+        const key = f.path + "|" + f.status;
+        const count = counts.get(key);
+        if (!count) {
             return false;
         }
+        counts.set(key, count - 1);
     }
     return true;
 }

--- a/src/sessionArtifacts.ts
+++ b/src/sessionArtifacts.ts
@@ -501,11 +501,14 @@ function areChangeSetFilesEqual(a?: ChangeSetSummary, b?: ChangeSetSummary): boo
     }
 
     // Sort files by path to ensure order-independence
-    const sortedA = [...aFiles].sort((x, y) => x.path.localeCompare(y.path));
-    const sortedB = [...bFiles].sort((x, y) => x.path.localeCompare(y.path));
+    // ⚡ Bolt 最適化: O(N log N) のソート処理を O(N) の Map ルックアップに置換
+    const bFilesMap = new Map<string, string | undefined>();
+    for (const f of bFiles) {
+        bFilesMap.set(f.path, f.status);
+    }
 
-    for (let i = 0; i < sortedA.length; i += 1) {
-        if (sortedA[i].path !== sortedB[i].path || sortedA[i].status !== sortedB[i].status) {
+    for (const f of aFiles) {
+        if (!bFilesMap.has(f.path) || bFilesMap.get(f.path) !== f.status) {
             return false;
         }
     }

--- a/src/test/branchUtils.unit.test.ts
+++ b/src/test/branchUtils.unit.test.ts
@@ -337,7 +337,7 @@ suite('branchUtils Unit Tests', () => {
             };
 
             // This run matches cache data except remote order, so it hits areArraysEqual permutations true
-            const result1 = await getBranchesForSession(
+            await getBranchesForSession(
                 mockSource as any,
                 mockApiClient as any,
                 mockOutputChannel,

--- a/src/test/branchUtils.unit.test.ts
+++ b/src/test/branchUtils.unit.test.ts
@@ -256,7 +256,160 @@ suite('branchUtils Unit Tests', () => {
         });
     });
 
+
+    suite('areArraysEqual and areCacheContentsEqual Optimization', () => {
+        test('should correctly compare branch arrays and cache contents', async () => {
+            const mockSource = { id: 'test-source', name: 'test-source' };
+            const cachedData = {
+                branches: ['main', 'develop'],
+                defaultBranch: 'main',
+                remoteBranches: ['develop', 'main'],
+                currentBranch: 'main',
+                timestamp: Date.now() - 1000 // Force aging condition
+            };
+            (mockContext.globalState.get as any).returns(cachedData);
+
+            const mockApiClient = {
+                getSource: sinon.stub().resolves({
+                    githubRepo: {
+                        branches: [{ displayName: 'main' }, { displayName: 'develop' }],
+                        defaultBranch: { displayName: 'main' }
+                    }
+                })
+            };
+
+            const gitExtension = {
+                exports: {
+                    getAPI: sinon.stub().returns({
+                        repositories: [{
+                            state: { HEAD: { name: 'main' } }
+                        }]
+                    })
+                }
+            };
+            sandbox.stub(vscode.extensions, 'getExtension').returns(gitExtension as any);
+
+            // Fetch identical data to trigger areCacheContentsEqual
+            const result = await getBranchesForSession(
+                mockSource as any,
+                mockApiClient as any,
+                mockOutputChannel,
+                mockContext,
+                { forceRefresh: true, showProgress: false }
+            );
+
+            assert.strictEqual(result.currentBranch, 'main');
+
+            // Trigger cache mismatch by changing data
+            cachedData.branches = ['main'];
+            const result2 = await getBranchesForSession(
+                mockSource as any,
+                mockApiClient as any,
+                mockOutputChannel,
+                mockContext,
+                { forceRefresh: true, showProgress: false }
+            );
+            assert.strictEqual(result2.currentBranch, 'main');
+        });
+    });
+
     suite('getBranchesForSession', () => {
+
+        test('areArraysEqual covers full equivalence, subsets, and permutations', async () => {
+            const mockSource = { id: 'test-source', name: 'test-source' };
+            // First we prepare a cache
+            const cachedData = {
+                branches: ['main', 'develop', 'develop'], // Notice duplicate
+                defaultBranch: 'main',
+                remoteBranches: ['develop', 'main', 'develop'],
+                currentBranch: 'main',
+                timestamp: Date.now()
+            };
+            (mockContext.globalState.get as any).returns(cachedData);
+
+            const mockApiClient = {
+                getSource: sinon.stub().resolves({
+                    githubRepo: {
+                        branches: [{ displayName: 'develop' }, { displayName: 'main' }, { displayName: 'develop' }],
+                        defaultBranch: { displayName: 'main' }
+                    }
+                })
+            };
+
+            // This run matches cache data except remote order, so it hits areArraysEqual permutations true
+            const result1 = await getBranchesForSession(
+                mockSource as any,
+                mockApiClient as any,
+                mockOutputChannel,
+                mockContext,
+                { forceRefresh: false, showProgress: false } // we want areCacheContentsEqual
+            );
+
+            // Now force refresh but let API return same data, cache hit condition is triggered internally
+            await getBranchesForSession(
+                mockSource as any,
+                mockApiClient as any,
+                mockOutputChannel,
+                mockContext,
+                { forceRefresh: true, showProgress: false, silent: true }
+            );
+
+            // Now test failure cases
+
+            // Case 1: Length mismatch
+            cachedData.branches = ['main'];
+            await getBranchesForSession(
+                mockSource as any,
+                mockApiClient as any,
+                mockOutputChannel,
+                mockContext,
+                { forceRefresh: true, showProgress: false, silent: true }
+            );
+
+            // Case 2: Element missing
+            cachedData.branches = ['main', 'main', 'develop'];
+            await getBranchesForSession(
+                mockSource as any,
+                mockApiClient as any,
+                mockOutputChannel,
+                mockContext,
+                { forceRefresh: true, showProgress: false, silent: true }
+            );
+
+            // Case 3: Remote mismatch
+            cachedData.branches = ['develop', 'main', 'develop'];
+            cachedData.remoteBranches = ['main', 'develop', 'other'];
+            await getBranchesForSession(
+                mockSource as any,
+                mockApiClient as any,
+                mockOutputChannel,
+                mockContext,
+                { forceRefresh: true, showProgress: false, silent: true }
+            );
+
+            // Case 4: Default branch mismatch
+            cachedData.remoteBranches = ['develop', 'main', 'develop'];
+            cachedData.defaultBranch = 'other';
+            await getBranchesForSession(
+                mockSource as any,
+                mockApiClient as any,
+                mockOutputChannel,
+                mockContext,
+                { forceRefresh: true, showProgress: false, silent: true }
+            );
+
+            // Case 5: Current branch mismatch
+            cachedData.defaultBranch = 'main';
+            cachedData.currentBranch = 'other';
+            await getBranchesForSession(
+                mockSource as any,
+                mockApiClient as any,
+                mockOutputChannel,
+                mockContext,
+                { forceRefresh: true, showProgress: false, silent: true }
+            );
+        });
+
         test('should use cached branches when cache is valid', async () => {
             const mockSource: SourceType = {
                 id: 'test-source',

--- a/src/test/sessionArtifacts.unit.test.ts
+++ b/src/test/sessionArtifacts.unit.test.ts
@@ -564,7 +564,91 @@ index 123..abc 100644`;
     // updateSessionArtifactsCache のテスト
     // =========================================================================
 
+
+    suite('areChangeSetFilesEqual Optimization', () => {
+        test('should correctly compare multiset of files using Map lookup', () => {
+            const sessionId = 'session-multiset';
+            const activities1 = [
+                {
+                    createTime: '2024-01-01T00:00:00Z',
+                    artifacts: [
+                        {
+                            changeSet: {
+                                files: [
+                                    { path: 'file1.ts', status: 'modified' },
+                                    { path: 'file2.ts', status: 'added' }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ];
+
+            const activities2 = [
+                {
+                    createTime: '2024-01-02T00:00:00Z',
+                    artifacts: [
+                        {
+                            changeSet: {
+                                files: [
+                                    { path: 'file2.ts', status: 'added' },
+                                    { path: 'file1.ts', status: 'modified' }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ];
+
+            updateSessionArtifactsCache(sessionId, activities1);
+            const updated = updateSessionArtifactsCache(sessionId, activities2);
+            // Should be false because the files are technically the same (multiset match)
+            assert.strictEqual(updated, false);
+
+            // Now test inequality
+            const activities3 = [
+                {
+                    createTime: '2024-01-03T00:00:00Z',
+                    artifacts: [
+                        {
+                            changeSet: {
+                                files: [
+                                    { path: 'file1.ts', status: 'modified' },
+                                    { path: 'file2.ts', status: 'modified' } // Changed status
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ];
+            const updated2 = updateSessionArtifactsCache(sessionId, activities3);
+            assert.strictEqual(updated2, true);
+        });
+    });
+
     suite('updateSessionArtifactsCache', () => {
+
+        test('areChangeSetFilesEqual missing parameters and differing lengths', () => {
+            const sessionId = 'session-equality-edge-cases';
+
+            // Neither have changesets
+            const act1 = [{ createTime: '1', artifacts: [{}] }];
+            const act2 = [{ createTime: '2', artifacts: [{}] }];
+            updateSessionArtifactsCache(sessionId, act1);
+            const r1 = updateSessionArtifactsCache(sessionId, act2);
+            assert.strictEqual(r1, false); // No change
+
+            // Only one has changeset
+            const act3 = [{ createTime: '3', artifacts: [{ changeSet: { files: [{ path: 'a' }] } }] }];
+            const r2 = updateSessionArtifactsCache(sessionId, act3);
+            assert.strictEqual(r2, true); // Change detected
+
+            // Differing lengths
+            const act4 = [{ createTime: '4', artifacts: [{ changeSet: { files: [{ path: 'a' }, { path: 'b' }] } }] }];
+            const r3 = updateSessionArtifactsCache(sessionId, act4);
+            assert.strictEqual(r3, true); // Change detected
+        });
+
         test('キャッシュが空の場合、新しいエントリを追加し true を返すこと', () => {
             const sessionId = 'session-001';
             const activities = [


### PR DESCRIPTION
💡 **What:** 配列の順序に依存しない多重集合の同等性チェックにおいて、`Array.prototype.sort()` の呼び出しを削除し、代わりに `Map` を使用した O(N) の集計・ルックアップに置き換えました。対象は `src/branchUtils.ts` および `src/sessionArtifacts.ts` の2箇所です。

🎯 **Why:** 配列の要素数が大きくなるにつれて、不要なソート処理は O(N log N) のオーバーヘッドとメモリ再割り当てのコストを生み出します。順序が不要な要素同士の比較であれば、Mapを使用することで計算量を O(N) に抑え、パフォーマンスを向上させることができます。

📊 **Impact:** アーティファクトリストやブランチリストなどの配列を比較する際の計算量が O(N log N) から O(N) に削減され、無駄なGC（ガベージコレクション）の発生が抑制されます。

🔬 **Measurement:** `pnpm run test:unit` によるユニットテストの成功を確認済みです。アルゴリズムが `for` ループ1周分に短縮されており、実行速度の向上が期待できます。

---
*PR created automatically by Jules for task [4800083762672324804](https://jules.google.com/task/4800083762672324804) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

配列の多重集合等価チェックを O(N log N) のソートから O(N) の頻度マップに置き換えたパフォーマンス最適化 PR です。`src/branchUtils.ts` と `src/sessionArtifacts.ts` の2箇所が対象で、重複要素の取り扱いも正しくカウント減算方式で実装されています。

- `areArraysEqual`（branchUtils）: `Map<string, number>` を使った頻度マップで文字列配列の多重集合比較を O(N) に最適化。ロジックは正確で、重複エントリも適切に処理される。
- `areChangeSetFilesEqual`（sessionArtifacts）: `path + \"|\" + status` を複合キーとして頻度マップを構築。実装は機能的に正しいが、`|` をパスに含むファイルが存在すると理論的にキー衝突が起きる可能性がある。
- テストスイートが追加されているが、`branchUtils.ts` 側は `areArraysEqual` を直接ではなく `getBranchesForSession` 経由で間接的にテストする形になっている。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

両ファイルの頻度マップ実装は正しく、旧来のソートベース実装との動作互換性も保たれており、マージしても安全です。

頻度マップの長さチェック・カウント減算ロジックは正確で、重複要素・欠落要素・順序違いのいずれも正しく判定できます。sessionArtifacts の複合キーセパレータ `|` は理論的な衝突リスクがありますが、実用上のファイルパスと git ステータスの値域ではほぼ発生しません。

No files require special attention
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/branchUtils.ts | areArraysEqual を O(N log N) のソートから O(N) の頻度マップに置き換え。長さチェック → `a` からのカウント構築 → `b` のルックアップと減算という3段階のロジックは正しく、重複要素も適切に処理される。 |
| src/sessionArtifacts.ts | areChangeSetFilesEqual を頻度マップ方式に置き換え。複合キー (path + "|" + status) を使用し、カウントを減算することで重複エントリも正しく処理される。`|` を区切り文字に使用しているが、ファイルパスが `|` を含む場合に理論的なキー衝突の可能性あり。 |
| src/test/branchUtils.unit.test.ts | areArraysEqual のテストが追加されているが、private 関数を getBranchesForSession 経由で間接的にテストする形になっており、関数そのものの境界値テストがない。 |
| src/test/sessionArtifacts.unit.test.ts | areChangeSetFilesEqual の多重集合比較・辺値（undefined/長さ違い）を直接テストするスイートが追加されており、カバレッジは適切。 |
| .jules/bolt.md | sort → Map ルックアップ最適化と、オブジェクト配列の多重集合比較における頻度マップ方式の学習エントリが追記された。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["areArraysEqual / areChangeSetFilesEqual"] --> B{"length(a) == length(b)?"}
    B -- No --> R1["return false"]
    B -- Yes --> C["Build counts Map from a O(N)"]
    C --> D["Iterate over b O(N)"]
    D --> E{"count = map.get(key) is falsy?"}
    E -- Yes --> R2["return false"]
    E -- No --> F["counts.set(key, count - 1)"]
    F --> D
    D -- Done --> R3["return true"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/sessionArtifacts.ts:507-512
`path + "|" + status` という複合キーは、ファイルパスが `|` を含む場合（Linux では技術的に有効な文字）に衝突を引き起こす可能性があります。例えば `path="a|b", status="c"` と `path="a", status="b|c"` は同じキー `"a|b|c"` を生成し、誤った等価判定になります。`\0` のようにパスや Status に含まれない文字をセパレータにするか、JSON 文字列化を使用することでこの問題を回避できます。

```suggestion
        const key = f.path + "\0" + f.status;
        counts.set(key, (counts.get(key) || 0) + 1);
    }

    for (const f of aFiles) {
        const key = f.path + "\0" + f.status;
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["⚡ Bolt: 複数の同一パスが存在する場合に対応する Map 最適化の修正"](https://github.com/hiroki-org/jules-extension/commit/c4723305cb6d18a29a92936a160b66e2b1829fb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31796177)</sub>

<!-- /greptile_comment -->