### PR TITLE
🛡️ Sentinel: [MEDIUM] 強化された XSS 防御のための DOMPurify MathML プロファイルの無効化

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,7 +6,7 @@
 ## 2024-05-13 - [DOMPurify MathML Profile Disable]
 **Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS).
 **Learning:** DOMPurify's default configuration enables MathML. If math rendering is not required by the application (as in simple chat webviews), this unnecessary capability introduces risk, as MathML has historically been a vector for sanitizer bypasses.
-**Prevention:** Always explicitly disable unused DOMPurify profiles. Use USE_PROFILES: { mathML: false } or specify only the required profiles (e.g., { html: true }) as a defense-in-depth measure.
+**Prevention:** Always explicitly disable unused DOMPurify profiles. Use `USE_PROFILES: { math: false }` or specify only the required profiles (e.g., `{ html: true }`) as a defense-in-depth measure.
 
 ## 2024-05-13 - [DOMPurify MathML Tags Disable]
 **Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS), but using `USE_PROFILES` incorrectly strips default HTML tags.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,11 +3,6 @@
 **Learning:** External processes should always have a timeout to prevent DoS.
 **Prevention:** Always add a timeout option when using childProcess.execFile or similar functions.
 
-## 2024-05-13 - [DOMPurify MathML Profile Disable]
-**Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS).
-**Learning:** DOMPurify's default configuration enables MathML. If math rendering is not required by the application (as in simple chat webviews), this unnecessary capability introduces risk, as MathML has historically been a vector for sanitizer bypasses.
-**Prevention:** Always explicitly disable unused DOMPurify profiles. Use `USE_PROFILES: { math: false }` or specify only the required profiles (e.g., `{ html: true }`) as a defense-in-depth measure.
-
 ## 2024-05-13 - [DOMPurify MathML Tags Disable]
 **Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS), but using `USE_PROFILES` incorrectly strips default HTML tags.
 **Learning:** `USE_PROFILES` resets `ALLOWED_TAGS`. If you provide an invalid key or do not include standard profiles like `html`, DOMPurify removes safe HTML tags like `<p>` and `<a>`, causing UI breakage.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,7 +6,7 @@
 ## 2024-05-13 - [DOMPurify MathML Profile Disable]
 **Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS).
 **Learning:** DOMPurify's default configuration enables MathML. If math rendering is not required by the application (as in simple chat webviews), this unnecessary capability introduces risk, as MathML has historically been a vector for sanitizer bypasses.
-**Prevention:** Always explicitly disable unused DOMPurify profiles. Use `USE_PROFILES: { math: false }` or specify only the required profiles (e.g., `{ html: true }`) as a defense-in-depth measure.
+**Prevention:** Always explicitly disable unused DOMPurify profiles. Use USE_PROFILES: { mathML: false } or specify only the required profiles (e.g., { html: true }) as a defense-in-depth measure.
 
 ## 2024-05-13 - [DOMPurify MathML Tags Disable]
 **Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS), but using `USE_PROFILES` incorrectly strips default HTML tags.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** childProcess.execFile does not have a timeout, which can cause the extension host to hang indefinitely if the git process stalls.
 **Learning:** External processes should always have a timeout to prevent DoS.
 **Prevention:** Always add a timeout option when using childProcess.execFile or similar functions.
+
+## 2024-05-13 - [DOMPurify MathML Profile Disable]
+**Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS).
+**Learning:** DOMPurify's default configuration enables MathML. If math rendering is not required by the application (as in simple chat webviews), this unnecessary capability introduces risk, as MathML has historically been a vector for sanitizer bypasses.
+**Prevention:** Always explicitly disable unused DOMPurify profiles. Use `USE_PROFILES: { math: false }` or specify only the required profiles (e.g., `{ html: true }`) as a defense-in-depth measure.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS).
 **Learning:** DOMPurify's default configuration enables MathML. If math rendering is not required by the application (as in simple chat webviews), this unnecessary capability introduces risk, as MathML has historically been a vector for sanitizer bypasses.
 **Prevention:** Always explicitly disable unused DOMPurify profiles. Use `USE_PROFILES: { math: false }` or specify only the required profiles (e.g., `{ html: true }`) as a defense-in-depth measure.
+
+## 2024-05-13 - [DOMPurify MathML Tags Disable]
+**Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS), but using `USE_PROFILES` incorrectly strips default HTML tags.
+**Learning:** `USE_PROFILES` resets `ALLOWED_TAGS`. If you provide an invalid key or do not include standard profiles like `html`, DOMPurify removes safe HTML tags like `<p>` and `<a>`, causing UI breakage.
+**Prevention:** To disable specific attack vectors like MathML while preserving default safe tags, use `FORBID_TAGS: ['math', 'annotation', ...]` rather than altering profiles.

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -142,6 +142,7 @@ suite("chatAssets unit tests", () => {
     ]);
     assert.strictEqual(sanitizeConfig.RETURN_DOM, false);
     assert.strictEqual(sanitizeConfig.RETURN_DOM_FRAGMENT, false);
+    assert.deepStrictEqual(sanitizeConfig.USE_PROFILES, { math: false });
   });
 
   test("CHAT_JS should fail closed when DOMPurify is unavailable", () => {

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -142,7 +142,7 @@ suite("chatAssets unit tests", () => {
     ]);
     assert.strictEqual(sanitizeConfig.RETURN_DOM, false);
     assert.strictEqual(sanitizeConfig.RETURN_DOM_FRAGMENT, false);
-    assert.deepStrictEqual(sanitizeConfig.USE_PROFILES, { math: false });
+    assert.deepStrictEqual(sanitizeConfig.FORBID_TAGS, ["math", "annotation", "annotation-xml", "maction", "mi", "mn", "mo", "ms", "mtext", "semantics"]);
   });
 
   test("CHAT_JS should fail closed when DOMPurify is unavailable", () => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -102,6 +102,7 @@ export const CHAT_JS = `(function() {
           ADD_ATTR: ["data-activity-id", "data-detail-type", "data-index"],
           RETURN_DOM: false,
           RETURN_DOM_FRAGMENT: false,
+          USE_PROFILES: { math: false },
         }),
       );
     } catch (error) {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -102,7 +102,7 @@ export const CHAT_JS = `(function() {
           ADD_ATTR: ["data-activity-id", "data-detail-type", "data-index"],
           RETURN_DOM: false,
           RETURN_DOM_FRAGMENT: false,
-          USE_PROFILES: { math: false },
+          FORBID_TAGS: ["math", "annotation", "annotation-xml", "maction", "mi", "mn", "mo", "ms", "mtext", "semantics"],
         }),
       );
     } catch (error) {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: DOMPurify のデフォルト設定では MathML の解析が有効になっており、チャットの webview のように数式レンダリングが不要な場合でも有効なままであるため、不要なアタックサーフェスが広がっていました。
🎯 Impact: MathML 経由でのクロスサイトスクリプティング (XSS) バイパスのリスクを最小限に抑えます。
🔧 Fix: \`src/webview/chatAssets.ts\` の \`DOMPurify.sanitize\` の設定に \`USE_PROFILES: { math: false }\` を追加し、多層防御として不要なパーサー機能を無効化しました。
✅ Verification: ユニットテスト (\`src/test/chatAssets.unit.test.ts\`) にて、この設定が正しく適用されていることを確認しました。テストスイート (\`pnpm run test:unit\`, \`xvfb-run -a pnpm test\`) はすべてパスしています。

---
*PR created automatically by Jules for task [653078177487314454](https://jules.google.com/task/653078177487314454) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

前回のレビューで指摘された `USE_PROFILES: { math: false }` の誤用（通常の HTML タグが消える問題）が修正され、`FORBID_TAGS` を用いた正しい MathML ブロックに変更されました。PR タイトルや説明文には古い実装内容（`USE_PROFILES`）が残っていますが、実際のコードは正しい方法で実装されています。

- `chatAssets.ts`: `DOMPurify.sanitize` の設定に `FORBID_TAGS: [\"math\", \"annotation\", ...]` を追加し、MathML 関連タグを明示的に禁止。既存の `ALLOWED_TAGS` には影響せず、通常の HTML タグはそのまま保持される。
- `sentinel.md`: `USE_PROFILES` の落とし穴と `FORBID_TAGS` が正しいアプローチであることを記録した学習エントリを追記。
- `chatAssets.unit.test.ts`: `FORBID_TAGS` が設定オブジェクトに正しく含まれていることをアサートするテストを追加。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

前回指摘された USE_PROFILES の誤用が正しく修正されており、通常の HTML タグへの影響もなく、安全にマージできます。

FORBID_TAGS による MathML ブロックは DOMPurify の推奨アプローチであり、既存の ALLOWED_TAGS リセットの問題も解消されています。sentinel.md の学習エントリも一貫した内容で記録されています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | 前回指摘された USE_PROFILES の誤用が修正され、FORBID_TAGS による正しい MathML ブロックに変更された。既存の ALLOWED_TAGS には影響なし。 |
| src/test/chatAssets.unit.test.ts | FORBID_TAGS の配列が設定オブジェクトに含まれていることを検証するアサーションを追加。モックを使用した構成確認テスト。 |
| .jules/sentinel.md | USE_PROFILES の問題点と FORBID_TAGS を推奨する正しい学習エントリを追記。前回指摘の矛盾するエントリは存在しない。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WebView as Webview (チャット)
    participant sanitizeHtml as sanitizeHtml()
    participant Cache as sanitizedHtmlCache
    participant DOMPurify as DOMPurify.sanitize()

    WebView->>sanitizeHtml: HTML 文字列を渡す
    sanitizeHtml->>Cache: キャッシュ確認
    alt キャッシュヒット
        Cache-->>sanitizeHtml: キャッシュ済みの結果を返す
    else キャッシュミス
        sanitizeHtml->>DOMPurify: "sanitize(html, { FORBID_TAGS: [math, ...] })"
        Note over DOMPurify: math, annotation, annotation-xml,maction, mi, mn, mo, ms, mtext, semantics を除去
        DOMPurify-->>sanitizeHtml: サニタイズ済み HTML を返す
        sanitizeHtml->>Cache: 結果をキャッシュ
    end
    sanitizeHtml-->>WebView: サニタイズ済み HTML を返す
```

<sub>Reviews (3): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] 強化された XSS 防御のための ..."](https://github.com/hiroki-org/jules-extension/commit/1776bb09ac2789618db4874f2d4d27aff774f33a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31876346)</sub>

<!-- /greptile_comment -->