### PR TITLE
🎨 Palette: チャット入力欄の動的な ARIA ラベルおよびツールチップの同期

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-11 - ARIA属性とコンテンツ変更の同期
 **Learning:** コピーボタンのようなインタラクティブ要素の動的なテキスト変更（例：「Copy」から「Copied」への変更）を行う際、対応するARIA属性（`aria-label`、`title`）も同時に更新し、スクリーンリーダーが新しい状態をアナウンスできるようにすることが非常に重要です。また、セッションインジケーターやタイピング状態などの動的なテキスト領域に`aria-live="polite"`と`aria-atomic="true"`を追加することで、スクリーンリーダーが更新されたテキスト全体を正しく読み上げるようになります。
 **Action:** 次回、ボタンやインジケーターに一時的なテキスト変更を実装する際は、テキストと共に`aria-label`と`title`を同期して更新し、`aria-live`領域には必ず`aria-atomic="true"`を設定すること。
+
+## 2025-05-11 - Dynamic ARIA Labeling for Context-Aware Inputs
+**Learning:** When using context-aware placeholders (like dynamically changing the placeholder from "Select a session to start typing" to "Enter message (Ctrl/Cmd+Enter to send)"), it is crucial to synchronize these changes with ARIA attributes (`aria-label` and `title`) to ensure screen readers provide accurate, up-to-date context, preventing users from becoming disoriented by outdated or mismatched labels.
+**Action:** Next time an input element's visual cue (like a placeholder) is dynamically updated based on state, immediately map that updated string to the element's `aria-label` and `title` properties within the same DOM update cycle.

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -397,6 +397,7 @@ suite("chatAssets unit tests", () => {
         value: "",
         disabled: false,
         placeholder: "",
+        title: "",
         style: { height: "" },
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
@@ -432,6 +433,8 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.messageInput.disabled, true);
     assert.strictEqual(elements.messageInput["aria-disabled"], "true");
     assert.ok(elements.messageInput.placeholder.startsWith("Select a session"));
+    assert.strictEqual(elements.messageInput["aria-label"], elements.messageInput.placeholder);
+    assert.strictEqual(elements.messageInput.title, elements.messageInput.placeholder);
     assert.strictEqual(elements.sendButton.disabled, true);
     assert.strictEqual(elements.sendButton["aria-disabled"], "true");
     assert.strictEqual(elements.sendButton.title, "Select a session to send a message");
@@ -450,6 +453,8 @@ suite("chatAssets unit tests", () => {
     // (3) sessionId present + non-empty input value
     elements.messageInput.value = "Hello";
     messageListener({ data: { type: "chatState", payload: { sessionId: "session-123", messages: [], isTyping: false } } });
+    assert.strictEqual(elements.messageInput["aria-label"], elements.messageInput.placeholder);
+    assert.strictEqual(elements.messageInput.title, elements.messageInput.placeholder);
     assert.strictEqual(elements.sendButton.disabled, false);
     assert.strictEqual(elements.sendButton["aria-disabled"], "false");
     assert.strictEqual(elements.sendButton.title, "Send message (Ctrl/Cmd+Enter)");

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -130,6 +130,8 @@ export const CHAT_JS = `(function() {
     messageInput.placeholder = hasSession
       ? "Enter message (Ctrl/Cmd+Enter to send)"
       : "Select a session to start typing";
+    messageInput.setAttribute("aria-label", messageInput.placeholder);
+    messageInput.title = messageInput.placeholder;
 
     if (!hasSession) {
       sendButton.title = "Select a session to send a message";


### PR DESCRIPTION
💡 What: `messageInput` の `placeholder` が動的に変更される際に、それと同期して `aria-label` および `title` 属性も更新されるようにしました。
🎯 Why: セッションの選択状態に応じてプレースホルダーが変化しますが、スクリーンリーダーやホバー時のツールチップでも最新のコンテキスト（状態）を正しくユーザーに伝えるためです。
📸 Before/After: 視覚的な変化はありません。
♿ Accessibility: 入力欄のコンテキストがスクリーンリーダーユーザーにも正確に伝わるようになります。

---
*PR created automatically by Jules for task [5500832670211104060](https://jules.google.com/task/5500832670211104060) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

セッション状態に応じて動的に変化する `messageInput` のプレースホルダーと同期して、`aria-label` および `title` 属性も更新されるよう `updateUI()` に2行追加されました。これによりスクリーンリーダーやホバーツールチップが常に最新のコンテキストをユーザーに伝えられます。

- `src/webview/chatAssets.ts`: `messageInput.placeholder` 設定直後に `setAttribute("aria-label", ...)` と `title =` の2行を追加し、ARIA属性とツールチップを即座に同期。
- `src/test/chatAssets.unit.test.ts`: モックオブジェクトに `title` プロパティを追加し、ケース(1)・(3) に同期アサートを追加。ただしケース(2)（セッション有り＋空入力）のアサートが未追加。
- `.Jules/palette.md`: 動的 ARIA ラベリングの学習メモをドキュメントに記録。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

実装は正確で副作用なし。既存の `updateUI()` フローに2行追加するだけの最小限な変更でマージ可能。

変更は `updateUI()` 内の属性同期のみで、ロジックのバグや回帰リスクはない。テストのケース(2)にアサートが不足しているが、実装コードの正確性には影響しない。

特に問題のあるファイルはなし。`src/test/chatAssets.unit.test.ts` のケース(2) に追加アサートがあるとテストカバレッジが完全になる。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | `updateUI()` 内でプレースホルダー設定直後に `aria-label` と `title` を同期するよう2行追加。ロジックは正確でシンプル。 |
| src/test/chatAssets.unit.test.ts | モック `messageInput` に `title` プロパティを追加し、ケース(1)・(3) に ARIA 同期アサートを追加。ただしケース(2)（sessionId有り＋空入力）での対応アサートが未追加。 |
| .Jules/palette.md | 動的 ARIA ラベリングに関する学習メモを英語で追加。変更自体はドキュメントのみ。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W as Window (message event)
    participant UI as updateUI()
    participant MI as messageInput
    participant SB as sendButton

    W->>UI: chatState payload (sessionId, messages, isTyping)
    UI->>MI: "disabled = !hasSession"
    UI->>MI: setAttribute("aria-disabled", ...)
    UI->>MI: "placeholder = hasSession ? "Enter message..." : "Select a session...""
    UI->>MI: setAttribute("aria-label", placeholder)
    UI->>MI: "title = placeholder"
    alt "hasSession && hasText"
        UI->>SB: "disabled = false"
        UI->>SB: "title = "Send message (Ctrl/Cmd+Enter)""
        UI->>SB: setAttribute("aria-label", "Send message (Ctrl/Cmd+Enter)")
    else "hasSession && !hasText"
        UI->>SB: "disabled = true"
        UI->>SB: "title = "Type a message to send""
        UI->>SB: setAttribute("aria-label", "Send (Type a message to send)")
    else !hasSession
        UI->>SB: "disabled = true"
        UI->>SB: "title = "Select a session to send a message""
        UI->>SB: setAttribute("aria-label", "Send (Select a session to send a message)")
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/test/chatAssets.unit.test.ts`, line 449-451 ([link](https://github.com/hiroki-org/jules-extension/blob/9540bb6f5c7dcc20da7ce7d84fd8704c171cf7f7/src/test/chatAssets.unit.test.ts#L449-L451)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> ケース(2)（sessionId有り＋空入力）でも `aria-label` と `title` の同期アサートが抜けています。`hasSession=true` への遷移が最初に起きるのはこのケースなので、ここで検証するのが最も適切です。ケース(1)とケース(3)では確認済みなのに、この中間状態だけカバーされていません。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 449-451

   Comment:
   ケース(2)（sessionId有り＋空入力）でも `aria-label` と `title` の同期アサートが抜けています。`hasSession=true` への遷移が最初に起きるのはこのケースなので、ここで検証するのが最も適切です。ケース(1)とケース(3)では確認済みなのに、この中間状態だけカバーされていません。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/test/chatAssets.unit.test.ts:444-451
**ケース(2) で `aria-label` / `title` のアサートが欠落しています**

セッション有り＋空入力状態（`hasSession=true` への最初の遷移）でも `messageInput` の `aria-label` と `title` が placeholder と同期していることを確認すべきです。ケース(1) と(3) では検証済みなのに、この中間状態だけ抜けています。`updateUI()` はこのパスでも必ず実行されるため、プレースホルダーが `"Enter message (Ctrl/Cmd+Enter to send)"` に切り替わるタイミングの検証が完全になりません。


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Update message input aria-label and titl..."](https://github.com/hiroki-org/jules-extension/commit/9540bb6f5c7dcc20da7ce7d84fd8704c171cf7f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32169789)</sub>

<!-- /greptile_comment -->