### PR TITLE
⚡ Bolt: [test] E2Eテストを独立ジョブに分離し、macOSでの安定性を向上

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,11 +156,48 @@ jobs:
         shell: bash
         run: pnpm test
 
-      # The regular integration matrix already exercises the extension host across
-      # Linux, macOS, and Windows. Keep this second-VS-Code smoke narrow to the
-      # most stable lane so CI cost stays bounded and the UI selectors remain
-      # deterministic.
-      - name: Run E2E smoke test (macOS)
-        if: runner.os == 'macOS' && matrix.node-version == 20
+  e2e-smoke:
+    needs: [test-unit, build-check]
+    runs-on: ubuntu-latest
+    env:
+      JULES_E2E_VSCODE_VERSION: "1.113.0"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.28.0
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Cache VS Code Test Downloads (.vscode-test)
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.vscode-test
+            ~/.vscode
+            .vscode-test
+          key: Linux-vscode-test-${{ env.JULES_E2E_VSCODE_VERSION }}
+          restore-keys: |
+            Linux-vscode-test-
+
+      - name: Ensure display available
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Compile
+        run: pnpm run compile
+
+      # Run the E2E smoke test on Linux in this dedicated job
+      - name: Run E2E smoke test
         shell: bash
-        run: pnpm run test:e2e
+        run: xvfb-run -a pnpm run test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Tests
 on:
   workflow_call:
 
+env:
+  JULES_E2E_VSCODE_VERSION: "1.113.0"
+
 jobs:
   test-unit:
     runs-on: ubuntu-latest
@@ -102,8 +105,6 @@ jobs:
   integration:
     needs: [test-unit, build-check]
     runs-on: ${{ matrix.os }}
-    env:
-      JULES_E2E_VSCODE_VERSION: "1.113.0"
     strategy:
       fail-fast: false
       matrix:
@@ -159,8 +160,7 @@ jobs:
   e2e-smoke:
     needs: [test-unit, build-check]
     runs-on: ubuntu-latest
-    env:
-      JULES_E2E_VSCODE_VERSION: "1.113.0"
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -184,9 +184,9 @@ jobs:
             ~/.vscode-test
             ~/.vscode
             .vscode-test
-          key: Linux-vscode-test-${{ env.JULES_E2E_VSCODE_VERSION }}
+          key: ${{ runner.os }}-vscode-test-${{ env.JULES_E2E_VSCODE_VERSION }}
           restore-keys: |
-            Linux-vscode-test-
+            ${{ runner.os }}-vscode-test-
 
       - name: Ensure display available
         run: sudo apt-get update && sudo apt-get install -y xvfb

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,10 @@
 ## 2024-05-13 - Fast Path & Single-Pass Filtering for `JulesSessionsProvider.getChildren`
 **Learning:** Sequential `.filter()` calls, especially those dependent on settings (`hideClosedPRSessions`), can create multiple intermediate arrays and cause unnecessary O(N) iterations.
 **Action:** Implemented a 'Fast Path' to avoid allocations entirely when no filtering is needed (e.g., All Sources selected and hide closed PRs disabled). Consolidated remaining filter logic into a single loop, manually maintaining required counters (`sourceFilteredCount`, `terminatedFilteredCount`) to preserve telemetry/logging parity while optimizing speed and memory.
+## 2026-05-15 - [test] E2EテストをLinuxと仮想ディスプレイ上で実行するように変更
+**Learning:** CI環境においてElectron/PlaywrightのUIベースE2Eテストは仮想ディスプレイ(xvfb)がないと初期化エラーになる。
+**Action:** CIでVSCode/Electron E2Eテストを動かすときはmacOSではなく、Linux環境にxvfbを導入し `xvfb-run -a <command>` を使う。
+
+## 2026-05-15 - [test] E2EテストのVSCode起動安定化
+**Learning:** macOS(arm64等)でElectronアプリ(VSCode E2Eテスト)を起動する際、共有メモリ不足やGPU関連の初期化エラーで即クラッシュし `Target page closed` エラーになることがある。
+**Action:** PlaywrightからVSCodeをlaunchする引数に `--disable-dev-shm-usage` と `--disable-software-rasterizer` を追加してクラッシュを回避する。

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,16 +13,23 @@
 ## 2024-05-12 - Handling Multiset arrays composed of Objects
 **Learning:** A simple tally map works well to compare arrays composed of strings or numbers, but you need to be careful when the array contains objects. Simply matching lengths and hashing the stringified keys or specific properties (e.g. `path + status`) correctly allows a Frequency Map representation of a Multiset of Objects without the memory allocation and O(N log N) overhead of sorts.
 **Action:** Always verify if arrays you are comparing allow duplicate items. Use `.length` validation, then build a Frequency map and decrement values when comparing.
+
 ## 2026-05-13 - Array.find() optimizations
+
 **Learning:** Replacing multiple O(N) Array.find() calls sequentially with an O(1) Map lookup ensures worst-case performance bounds and scales better for larger collections. However, for very small collections (like Git remotes) that are only looked up once or twice, the Map allocation and hashing overhead usually outweighs the O(1) lookup benefit, causing performance degradation.
 **Action:** Always prefer Maps when resolving objects across multiple fields iteratively **only** if the collection is large or if there are many subsequent lookups on the same structure. For small, infrequent lookups, stick to `Array.find()` or simple `for` loops.
+
 ## 2024-05-13 - Fast Path & Single-Pass Filtering for `JulesSessionsProvider.getChildren`
+
 **Learning:** Sequential `.filter()` calls, especially those dependent on settings (`hideClosedPRSessions`), can create multiple intermediate arrays and cause unnecessary O(N) iterations.
 **Action:** Implemented a 'Fast Path' to avoid allocations entirely when no filtering is needed (e.g., All Sources selected and hide closed PRs disabled). Consolidated remaining filter logic into a single loop, manually maintaining required counters (`sourceFilteredCount`, `terminatedFilteredCount`) to preserve telemetry/logging parity while optimizing speed and memory.
+
 ## 2026-05-15 - [test] E2EテストをLinuxと仮想ディスプレイ上で実行するように変更
+
 **Learning:** CI環境においてElectron/PlaywrightのUIベースE2Eテストは仮想ディスプレイ(xvfb)がないと初期化エラーになる。
 **Action:** CIでVSCode/Electron E2Eテストを動かすときはmacOSではなく、Linux環境にxvfbを導入し `xvfb-run -a <command>` を使う。
 
 ## 2026-05-15 - [test] E2EテストのVSCode起動安定化
-**Learning:** macOS(arm64等)でElectronアプリ(VSCode E2Eテスト)を起動する際、共有メモリ不足やGPU関連の初期化エラーで即クラッシュし `Target page closed` エラーになることがある。
+
+**Learning:** Linux CI環境での共有メモリ不足や、macOS(arm64等)でのGPU関連の初期化エラーにより、Electronアプリ(VSCode E2Eテスト)が起動直後にクラッシュし `Target page closed` エラーになることがある。
 **Action:** PlaywrightからVSCodeをlaunchする引数に `--disable-dev-shm-usage` と `--disable-software-rasterizer` を追加してクラッシュを回避する。

--- a/src/test/createSession.e2e.ts
+++ b/src/test/createSession.e2e.ts
@@ -56,6 +56,8 @@ async function launchExtensionHost(): Promise<LaunchResult> {
         "--disable-gpu",
         "--disable-workspace-trust",
         "--no-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-software-rasterizer",
         "--skip-release-notes",
         "--skip-welcome",
       ],


### PR DESCRIPTION
💡 What:
1. CIにおいて、E2Eスモークテストを 'integration' ジョブから分離し、専用の 'e2e-smoke' ジョブ（Linux環境・xvfb使用）として独立させました。
2. 'src/test/createSession.e2e.ts' のVS Code起動オプションに '--disable-dev-shm-usage' と '--disable-software-rasterizer' を追加しました。
🎯 Why:
1. E2Eテストは専用の仮想ディスプレイ環境など特有の要件を持つため、通常の統合テストと分離することでCI構成の見通しを良くし、依存関係や問題の切り分けを容易にするため。
2. macOS環境（特にarm64）などで、Electronが起動時にクラッシュし 'Target page, context or browser has been closed' エラーになる問題を緩和し、共有メモリ領域不足やラスタライザ初期化失敗を防ぐため。
📊 Impact: CIでのE2Eテストが安定して別ジョブとして動作し、ローカルmacOS環境でもテスト起動時のクラッシュが減少します。
🔬 Measurement: 変更内容、およびLinux仮想ディスプレイ(xvfb)環境下でのローカル実行成功で確認しました。

---
*PR created automatically by Jules for task [6986772859068374181](https://jules.google.com/task/6986772859068374181) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CI上のE2EスモークテストをLinux専用の独立ジョブ（`e2e-smoke`）に分離し、VS Code起動オプションに安定化フラグを追加することで、macOS/arm64環境でのクラッシュを緩和する変更です。`JULES_E2E_VSCODE_VERSION`はトップレベルの`env`へ昇格し、全ジョブで一元管理されるようになっています。

- `e2e-smoke`ジョブを新設：`ubuntu-latest` + `xvfb-run`で実行、`timeout-minutes: 20`、`${{ runner.os }}`ベースのキャッシュキーを使用。
- `integration`ジョブからE2Eステップを完全削除し、役割を明確に分離。
- `createSession.e2e.ts`の`electron.launch`引数に`--disable-dev-shm-usage`と`--disable-software-rasterizer`を追加し、共有メモリ不足・GPU初期化失敗によるクラッシュを防止。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はCIワークフローのリファクタリングとElectron起動フラグの追加のみで、プロダクションコードへの影響はなく安全にマージできます。

ジョブ分離はCI構造の整理であり既存ロジックを壊しません。追加フラグ（`--disable-dev-shm-usage`・`--disable-software-rasterizer`）はLinux CI環境でのElectron起動安定化に広く使われている標準的な組み合わせです。以前のレビューで指摘されていたタイムアウトとキャッシュキーの問題はいずれも解決済みです。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/test.yml | E2EスモークテストをLinux専用の独立ジョブ(`e2e-smoke`)に分離。`JULES_E2E_VSCODE_VERSION`をトップレベルの`env`に昇格、`timeout-minutes: 20`とキャッシュキー(`${{ runner.os }}`)も適切に設定済み。 |
| src/test/createSession.e2e.ts | Electron起動オプションに`--disable-dev-shm-usage`と`--disable-software-rasterizer`を追加し、CI環境での共有メモリ不足やGPU初期化失敗によるクラッシュを防止。 |
| .jules/bolt.md | 今回の変更で得られたE2E安定化に関する学習事項2件を追記。フォーマット（エントリ間の空行）も整理。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push / workflow_call] --> B[test-unit]
    A --> C[build-check]
    B --> D[integration\nubuntu / macos / windows\nNode 20 & 22]
    C --> D
    B --> E[e2e-smoke\nubuntu-latest\nNode 20 + xvfb-run]
    C --> E
    D --> D1[pnpm test\n統合テスト]
    E --> E1[xvfb-run -a pnpm run test:e2e\nPlaywright + VS Code UI]
```

<sub>Reviews (2): Last reviewed commit: ["fix: harden e2e smoke workflow"](https://github.com/hiroki-org/jules-extension/commit/2d1799b880b494a3e6e522288bb75dc84f601b46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32265968)</sub>

<!-- /greptile_comment -->