### PR TITLE
remove enforce japanese

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,11 @@
 
 **Learning:** Linux CI環境での共有メモリ不足や、macOS(arm64等)でのGPU関連の初期化エラーにより、Electronアプリ(VSCode E2Eテスト)が起動直後にクラッシュし `Target page closed` エラーになることがある。
 **Action:** PlaywrightからVSCodeをlaunchする引数に `--disable-dev-shm-usage` と `--disable-software-rasterizer` を追加してクラッシュを回避する。
+
+## 2026-05-15 - [Performance] Eliminating spread operators and .filter() chains
+**Learning:** Using spread syntax `...()` inside an array literal followed by  creates multiple intermediate arrays and forces multiple O(N) iterations, leading to unnecessary memory allocations and CPU overhead during simple array processing.
+**Action:** Use a single-pass `for...of` loop combined with a `Set` to handle array concatenation, type checking, and deduplication simultaneously.
+
+## 2026-05-15 - [Performance] Eliminating spread operators and .filter() chains
+**Learning:** Using spread syntax `...` inside an array literal followed by `.filter()` creates multiple intermediate arrays and forces multiple O(N) iterations, leading to unnecessary memory allocations and CPU overhead during simple array processing.
+**Action:** Use a single-pass `for...of` loop combined with a `Set` to handle array concatenation, type checking, and deduplication simultaneously.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,9 +35,5 @@
 **Action:** PlaywrightからVSCodeをlaunchする引数に `--disable-dev-shm-usage` と `--disable-software-rasterizer` を追加してクラッシュを回避する。
 
 ## 2026-05-15 - [Performance] Eliminating spread operators and .filter() chains
-**Learning:** Using spread syntax `...()` inside an array literal followed by  creates multiple intermediate arrays and forces multiple O(N) iterations, leading to unnecessary memory allocations and CPU overhead during simple array processing.
-**Action:** Use a single-pass `for...of` loop combined with a `Set` to handle array concatenation, type checking, and deduplication simultaneously.
-
-## 2026-05-15 - [Performance] Eliminating spread operators and .filter() chains
 **Learning:** Using spread syntax `...` inside an array literal followed by `.filter()` creates multiple intermediate arrays and forces multiple O(N) iterations, leading to unnecessary memory allocations and CPU overhead during simple array processing.
 **Action:** Use a single-pass `for...of` loop combined with a `Set` to handle array concatenation, type checking, and deduplication simultaneously.

--- a/package.json
+++ b/package.json
@@ -66,12 +66,6 @@
           "description": "A custom prompt to automatically prepend to every message sent to Jules. This acts as a persistent instruction.",
           "markdownDescription": "Enter a custom prompt that will be automatically added to the beginning of every message you send to Jules. This is useful for providing persistent instructions or context.\n\n**Example:**\n`Always reply in Japanese.`"
         },
-        "jules-extension.enforceJapanese": {
-          "type": "boolean",
-          "default": true,
-          "description": "Automatically append an instruction to enforce Japanese language for all GitHub interactions (PRs, comments).",
-          "markdownDescription": "If enabled, Jules will automatically use Japanese for all GitHub interactions like Pull Request titles, descriptions, and commit messages."
-        },
         "jules-extension.hideClosedPRSessions": {
           "type": "boolean",
           "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2598,22 +2598,35 @@ export function resolveSelectedSessionItems(
   primary?: SessionTreeItem,
   selected?: readonly unknown[],
 ): SessionTreeItem[] {
+  const result: SessionTreeItem[] = [];
+  const seen = new Set<string>();
+
+  // ⚡ Bolt Optimization:
+  // We avoid chained ...(spreads) and .filter() calls to eliminate unnecessary
+  // intermediate array allocations and redundant iterations.
+  // Instead, we populate the final `result` array directly via a single pass,
+  // managing type filtering and deduplication in one loop.
+
   // Keep the right-clicked item first so future bulk actions have a stable
   // primary target while still deduplicating it from the selection.
-  const items = [
-    ...(primary instanceof SessionTreeItem ? [primary] : []),
-    ...(selected ?? []).filter((item): item is SessionTreeItem => item instanceof SessionTreeItem),
-  ];
+  if (primary instanceof SessionTreeItem) {
+    result.push(primary);
+    seen.add(primary.session.name);
+  }
 
-  const seen = new Set<string>();
-  return items.filter((item) => {
-    const id = item.session.name;
-    if (seen.has(id)) {
-      return false;
+  if (selected) {
+    for (const item of selected) {
+      if (item instanceof SessionTreeItem) {
+        const id = item.session.name;
+        if (!seen.has(id)) {
+          result.push(item);
+          seen.add(id);
+        }
+      }
     }
-    seen.add(id);
-    return true;
-  });
+  }
+
+  return result;
 }
 
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2601,12 +2601,6 @@ export function resolveSelectedSessionItems(
   const result: SessionTreeItem[] = [];
   const seen = new Set<string>();
 
-  // ⚡ Bolt Optimization:
-  // We avoid chained ...(spreads) and .filter() calls to eliminate unnecessary
-  // intermediate array allocations and redundant iterations.
-  // Instead, we populate the final `result` array directly via a single pass,
-  // managing type filtering and deduplication in one loop.
-
   // Keep the right-clicked item first so future bulk actions have a stable
   // primary target while still deduplicating it from the selection.
   if (primary instanceof SessionTreeItem) {

--- a/src/promptUtils.ts
+++ b/src/promptUtils.ts
@@ -8,19 +8,10 @@ import * as vscode from "vscode";
 export function buildFinalPrompt(userPrompt: string): string {
   const config = vscode.workspace.getConfiguration("jules-extension");
   const customPrompt = config.get<string>("customPrompt", "");
-  const enforceJapanese = config.get<boolean>("enforceJapanese", true);
 
   const basePrompt = customPrompt ? `${customPrompt}
 
 ${userPrompt}` : userPrompt;
 
-  if (!enforceJapanese) {
-    return basePrompt;
-  }
-
-  const japaneseInstruction = "Please use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).";
-
-  return `${basePrompt}
-
-${japaneseInstruction}`;
+  return basePrompt;
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -394,9 +394,6 @@ suite("Extension Test Suite", () => {
           if (key === "customPrompt") {
             return "My custom prompt";
           }
-          if (key === "enforceJapanese") {
-            return true;
-          }
           return undefined;
         }),
       };
@@ -404,7 +401,7 @@ suite("Extension Test Suite", () => {
 
       const userPrompt = "User message";
       const finalPrompt = buildFinalPrompt(userPrompt);
-      assert.strictEqual(finalPrompt, "My custom prompt\n\nUser message\n\nPlease use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).");
+      assert.strictEqual(finalPrompt, "My custom prompt\n\nUser message");
     });
 
     test("should return only user prompt if custom prompt is empty", () => {
@@ -412,47 +409,6 @@ suite("Extension Test Suite", () => {
         get: sinon.stub().callsFake((key: string) => {
           if (key === "customPrompt") {
             return "";
-          }
-          if (key === "enforceJapanese") {
-            return true;
-          }
-          return undefined;
-        }),
-      };
-      getConfigurationStub.withArgs("jules-extension").returns(workspaceConfig as any);
-
-      const userPrompt = "User message";
-      const finalPrompt = buildFinalPrompt(userPrompt);
-      assert.strictEqual(finalPrompt, "User message\n\nPlease use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).");
-    });
-
-    test("should return only user prompt if custom prompt is not set", () => {
-      const workspaceConfig = {
-        get: sinon.stub().callsFake((key: string) => {
-          if (key === "customPrompt") {
-            return undefined;
-          }
-          if (key === "enforceJapanese") {
-            return true;
-          }
-          return undefined;
-        }),
-      };
-      getConfigurationStub.withArgs("jules-extension").returns(workspaceConfig as any);
-
-      const userPrompt = "User message";
-      const finalPrompt = buildFinalPrompt(userPrompt);
-      assert.strictEqual(finalPrompt, "User message\n\nPlease use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).");
-    });
-
-    test("should not append Japanese instruction when enforceJapanese is false", () => {
-      const workspaceConfig = {
-        get: sinon.stub().callsFake((key: string) => {
-          if (key === "customPrompt") {
-            return "";
-          }
-          if (key === "enforceJapanese") {
-            return false;
           }
           return undefined;
         }),
@@ -464,14 +420,11 @@ suite("Extension Test Suite", () => {
       assert.strictEqual(finalPrompt, "User message");
     });
 
-    test("should not append Japanese instruction when enforceJapanese is false even with custom prompt", () => {
+    test("should return only user prompt if custom prompt is not set", () => {
       const workspaceConfig = {
         get: sinon.stub().callsFake((key: string) => {
           if (key === "customPrompt") {
-            return "Custom instructions";
-          }
-          if (key === "enforceJapanese") {
-            return false;
+            return undefined;
           }
           return undefined;
         }),
@@ -480,7 +433,7 @@ suite("Extension Test Suite", () => {
 
       const userPrompt = "User message";
       const finalPrompt = buildFinalPrompt(userPrompt);
-      assert.strictEqual(finalPrompt, "Custom instructions\n\nUser message");
+      assert.strictEqual(finalPrompt, "User message");
     });
   });
 

--- a/src/test/extensionHelpers.unit.test.ts
+++ b/src/test/extensionHelpers.unit.test.ts
@@ -1509,8 +1509,10 @@ suite("Extension helper unit tests", () => {
       assert.strictEqual(result[1], item2);
     });
 
-    test("should deduplicate items if primary is also in selected array", () => {
-      const result = resolveSelectedSessionItems(item1, [item2, item1]);
+    test("should deduplicate items if primary is also in selected array, and by session.name", () => {
+      const duplicateItem1 = new SessionTreeItem(mockSession1 as any);
+      const duplicateItem2 = new SessionTreeItem(mockSession2 as any);
+      const result = resolveSelectedSessionItems(item1, [item2, item1, duplicateItem1, duplicateItem2]);
       assert.strictEqual(result.length, 2);
       assert.strictEqual(result[0], item1);
       assert.strictEqual(result[1], item2);
@@ -1518,6 +1520,19 @@ suite("Extension helper unit tests", () => {
 
     test("should filter out unknown/non-SessionTreeItem objects from selected array", () => {
       const result = resolveSelectedSessionItems(item1, [item2, { name: "not-an-item" } as any, "string"]);
+      assert.strictEqual(result.length, 2);
+      assert.strictEqual(result[0], item1);
+      assert.strictEqual(result[1], item2);
+    });
+
+    test("should comprehensively resolve selected session items (primary precedence, deduplication, and type filtering)", () => {
+      const duplicateItem1 = new SessionTreeItem(mockSession1 as any);
+      const result = resolveSelectedSessionItems(item1, [
+        item2,
+        duplicateItem1,
+        { name: "invalid" } as any,
+        "string"
+      ]);
       assert.strictEqual(result.length, 2);
       assert.strictEqual(result[0], item1);
       assert.strictEqual(result[1], item2);

--- a/src/test/promptUtils.unit.test.ts
+++ b/src/test/promptUtils.unit.test.ts
@@ -3,9 +3,6 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 import { buildFinalPrompt } from "../promptUtils";
 
-const JAPANESE_INSTRUCTION =
-  "Please use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).";
-
 suite("promptUtils", () => {
   let getConfigurationStub: sinon.SinonStub;
 
@@ -17,74 +14,39 @@ suite("promptUtils", () => {
     getConfigurationStub.restore();
   });
 
-  function makeConfig(opts: { customPrompt?: string; enforceJapanese?: boolean }) {
+  function makeConfig(opts: { customPrompt?: string }) {
     return {
       get: sinon.stub().callsFake((key: string, def: unknown) => {
         if (key === "customPrompt") {
           return opts.customPrompt ?? def;
-        }
-        if (key === "enforceJapanese") {
-          return opts.enforceJapanese ?? def;
         }
         return def;
       }),
     };
   }
 
-  test("enforceJapanese=true appends Japanese instruction", () => {
+  test("base prompt is returned when customPrompt is empty", () => {
     getConfigurationStub
       .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: "", enforceJapanese: true }));
-
-    const result = buildFinalPrompt("Do something");
-    assert.strictEqual(result, `Do something\n\n${JAPANESE_INSTRUCTION}`);
-  });
-
-  test("enforceJapanese=false returns base prompt without Japanese instruction", () => {
-    getConfigurationStub
-      .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: "", enforceJapanese: false }));
+      .returns(makeConfig({ customPrompt: "" }));
 
     const result = buildFinalPrompt("Do something");
     assert.strictEqual(result, "Do something");
-    assert.ok(!result.includes(JAPANESE_INSTRUCTION));
   });
 
-  test("custom prompt is prepended when enforceJapanese=true", () => {
+  test("custom prompt is prepended when provided", () => {
     getConfigurationStub
       .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: "Always be concise.", enforceJapanese: true }));
-
-    const result = buildFinalPrompt("Explain this");
-    assert.strictEqual(
-      result,
-      `Always be concise.\n\nExplain this\n\n${JAPANESE_INSTRUCTION}`,
-    );
-  });
-
-  test("custom prompt is prepended when enforceJapanese=false", () => {
-    getConfigurationStub
-      .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: "Always be concise.", enforceJapanese: false }));
+      .returns(makeConfig({ customPrompt: "Always be concise." }));
 
     const result = buildFinalPrompt("Explain this");
     assert.strictEqual(result, "Always be concise.\n\nExplain this");
-    assert.ok(!result.includes(JAPANESE_INSTRUCTION));
-  });
-
-  test("empty custom prompt is ignored", () => {
-    getConfigurationStub
-      .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: "", enforceJapanese: false }));
-
-    const result = buildFinalPrompt("Simple prompt");
-    assert.strictEqual(result, "Simple prompt");
   });
 
   test("undefined custom prompt is treated as empty", () => {
     getConfigurationStub
       .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: undefined, enforceJapanese: false }));
+      .returns(makeConfig({ customPrompt: undefined }));
 
     const result = buildFinalPrompt("Simple prompt");
     assert.strictEqual(result, "Simple prompt");

--- a/src/test/sessionUtils.unit.test.ts
+++ b/src/test/sessionUtils.unit.test.ts
@@ -97,7 +97,7 @@ suite("sessionUtils Test Suite", () => {
         assert.strictEqual(url, "https://jules.googleapis.com/v1alpha/sessions/123:sendMessage");
         
         const payload = JSON.parse(options.body);
-        assert.strictEqual(payload.prompt, "test message\n\nPlease use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).");
+        assert.strictEqual(payload.prompt, "test message");
     });
 
     test("sendMessage throws error when API fails", async () => {


### PR DESCRIPTION
- **⚡ Bolt: Combine multiple session filters into a single pass and implement fast path**
- **⚡ Bolt: Combine multiple session filters into a single pass with fast path and tests**
- **fix(review): use logChannel instead of console.log**
- **⚡ Bolt: Combine multiple session filters into a single pass with fast path and tests**
- **⚡ Bolt: Combine multiple session filters into a single pass with tests**
- **fix(style): add blank line after heading (MD022) and curly braces for if statements**
- **⚡ Bolt: Finalize session filter optimization with tests and style fixes**
- **test: cover session filter edge cases**
- **test: stabilize session filter coverage**
- **fix: guard session filter fast path**
- **test: type cached session states**
- **fix: apply CodeRabbit auto-fixes**
- **⚡ Bolt: `resolveSelectedSessionItems` のパフォーマンス改善**
- **fix(review): address review comments for PR #587**
- **feat: remove redundant enforceJapanese setting**

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `enforceJapanese` 設定を完全に廃止し、あわせて `resolveSelectedSessionItems` を単一パスのループへリファクタリングするパフォーマンス改善を含んでいます。

- `package.json` から `jules-extension.enforceJapanese` の定義を削除し、`src/promptUtils.ts` の実装・テストもすべて整理。Japanese指示文字列は `customPrompt` 設定で代替可能。
- `resolveSelectedSessionItems` をスプレッド演算子＋複数 `.filter()` から `for...of` ＋ `Set` の単一パスに変換し、中間配列の生成を排除。ロジックは以前と等価。
- テスト群は削除したコードパスを的確に除去し、セッション重複排除テストを `session.name` ベースの検証を含む形に強化。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はすべて安全にマージできます。既存の機能を削除するシンプルなクリーンアップとパフォーマンス改善のみです。

`enforceJapanese` の廃止は `package.json`・実装・テストにわたって一貫しており、関連コードの残留はありません。`resolveSelectedSessionItems` のリファクタリングは元のロジックと等価で、テストがその正確さを確認しています。懸念点は見当たりません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/promptUtils.ts | `enforceJapanese` 設定の読み取りとJapanese指示の追記ロジックを完全に削除。`buildFinalPrompt` がシンプルに整理された。 |
| src/extension.ts | `resolveSelectedSessionItems` をスプレッド演算子＋複数回の `.filter()` から単一パスの `for...of` ループ＋`Set` に変換。ロジックは等価で中間配列が不要になった。 |
| package.json | `jules-extension.enforceJapanese` 設定の定義を削除。コードとの整合性あり。 |
| src/test/extensionHelpers.unit.test.ts | 重複排除テストを `session.name` ベースの重複チェックを含む形に強化し、包括的なシナリオカバレッジテストを追加。 |
| src/test/promptUtils.unit.test.ts | `enforceJapanese` 関連のテストケース（4件）を削除し、残った3つのケースで `buildFinalPrompt` の全分岐を網羅。 |
| src/test/extension.test.ts | `enforceJapanese` のスタブと期待値をすべて除去。アサーションが新しい `buildFinalPrompt` の動作と一致している。 |
| src/test/sessionUtils.unit.test.ts | ペイロードの `prompt` 期待値からJapanese指示文字列を削除。 |
| .jules/bolt.md | スプレッド演算子と `.filter()` チェーンの排除に関する学習メモを追加。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: remove redundant enforceJapanese s..."](https://github.com/hiroki-org/jules-extension/commit/fdadee4f934ffc5462890a3125dc4af3b4f2711b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32446471)</sub>

<!-- /greptile_comment -->