### PR TITLE
fix: remove redundant enforceJapanese setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,12 +66,6 @@
           "description": "A custom prompt to automatically prepend to every message sent to Jules. This acts as a persistent instruction.",
           "markdownDescription": "Enter a custom prompt that will be automatically added to the beginning of every message you send to Jules. This is useful for providing persistent instructions or context.\n\n**Example:**\n`Always reply in Japanese.`"
         },
-        "jules-extension.enforceJapanese": {
-          "type": "boolean",
-          "default": true,
-          "description": "Automatically append an instruction to enforce Japanese language for all GitHub interactions (PRs, comments).",
-          "markdownDescription": "If enabled, Jules will automatically use Japanese for all GitHub interactions like Pull Request titles, descriptions, and commit messages."
-        },
         "jules-extension.hideClosedPRSessions": {
           "type": "boolean",
           "default": true,

--- a/src/promptUtils.ts
+++ b/src/promptUtils.ts
@@ -8,19 +8,10 @@ import * as vscode from "vscode";
 export function buildFinalPrompt(userPrompt: string): string {
   const config = vscode.workspace.getConfiguration("jules-extension");
   const customPrompt = config.get<string>("customPrompt", "");
-  const enforceJapanese = config.get<boolean>("enforceJapanese", true);
 
   const basePrompt = customPrompt ? `${customPrompt}
 
 ${userPrompt}` : userPrompt;
 
-  if (!enforceJapanese) {
-    return basePrompt;
-  }
-
-  const japaneseInstruction = "Please use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).";
-
-  return `${basePrompt}
-
-${japaneseInstruction}`;
+  return basePrompt;
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -394,9 +394,6 @@ suite("Extension Test Suite", () => {
           if (key === "customPrompt") {
             return "My custom prompt";
           }
-          if (key === "enforceJapanese") {
-            return true;
-          }
           return undefined;
         }),
       };
@@ -404,7 +401,7 @@ suite("Extension Test Suite", () => {
 
       const userPrompt = "User message";
       const finalPrompt = buildFinalPrompt(userPrompt);
-      assert.strictEqual(finalPrompt, "My custom prompt\n\nUser message\n\nPlease use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).");
+      assert.strictEqual(finalPrompt, "My custom prompt\n\nUser message");
     });
 
     test("should return only user prompt if custom prompt is empty", () => {
@@ -412,47 +409,6 @@ suite("Extension Test Suite", () => {
         get: sinon.stub().callsFake((key: string) => {
           if (key === "customPrompt") {
             return "";
-          }
-          if (key === "enforceJapanese") {
-            return true;
-          }
-          return undefined;
-        }),
-      };
-      getConfigurationStub.withArgs("jules-extension").returns(workspaceConfig as any);
-
-      const userPrompt = "User message";
-      const finalPrompt = buildFinalPrompt(userPrompt);
-      assert.strictEqual(finalPrompt, "User message\n\nPlease use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).");
-    });
-
-    test("should return only user prompt if custom prompt is not set", () => {
-      const workspaceConfig = {
-        get: sinon.stub().callsFake((key: string) => {
-          if (key === "customPrompt") {
-            return undefined;
-          }
-          if (key === "enforceJapanese") {
-            return true;
-          }
-          return undefined;
-        }),
-      };
-      getConfigurationStub.withArgs("jules-extension").returns(workspaceConfig as any);
-
-      const userPrompt = "User message";
-      const finalPrompt = buildFinalPrompt(userPrompt);
-      assert.strictEqual(finalPrompt, "User message\n\nPlease use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).");
-    });
-
-    test("should not append Japanese instruction when enforceJapanese is false", () => {
-      const workspaceConfig = {
-        get: sinon.stub().callsFake((key: string) => {
-          if (key === "customPrompt") {
-            return "";
-          }
-          if (key === "enforceJapanese") {
-            return false;
           }
           return undefined;
         }),
@@ -464,14 +420,11 @@ suite("Extension Test Suite", () => {
       assert.strictEqual(finalPrompt, "User message");
     });
 
-    test("should not append Japanese instruction when enforceJapanese is false even with custom prompt", () => {
+    test("should return only user prompt if custom prompt is not set", () => {
       const workspaceConfig = {
         get: sinon.stub().callsFake((key: string) => {
           if (key === "customPrompt") {
-            return "Custom instructions";
-          }
-          if (key === "enforceJapanese") {
-            return false;
+            return undefined;
           }
           return undefined;
         }),
@@ -480,7 +433,7 @@ suite("Extension Test Suite", () => {
 
       const userPrompt = "User message";
       const finalPrompt = buildFinalPrompt(userPrompt);
-      assert.strictEqual(finalPrompt, "Custom instructions\n\nUser message");
+      assert.strictEqual(finalPrompt, "User message");
     });
   });
 

--- a/src/test/promptUtils.unit.test.ts
+++ b/src/test/promptUtils.unit.test.ts
@@ -3,9 +3,6 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 import { buildFinalPrompt } from "../promptUtils";
 
-const JAPANESE_INSTRUCTION =
-  "Please use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).";
-
 suite("promptUtils", () => {
   let getConfigurationStub: sinon.SinonStub;
 
@@ -17,74 +14,39 @@ suite("promptUtils", () => {
     getConfigurationStub.restore();
   });
 
-  function makeConfig(opts: { customPrompt?: string; enforceJapanese?: boolean }) {
+  function makeConfig(opts: { customPrompt?: string }) {
     return {
       get: sinon.stub().callsFake((key: string, def: unknown) => {
         if (key === "customPrompt") {
           return opts.customPrompt ?? def;
-        }
-        if (key === "enforceJapanese") {
-          return opts.enforceJapanese ?? def;
         }
         return def;
       }),
     };
   }
 
-  test("enforceJapanese=true appends Japanese instruction", () => {
+  test("base prompt is returned when customPrompt is empty", () => {
     getConfigurationStub
       .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: "", enforceJapanese: true }));
-
-    const result = buildFinalPrompt("Do something");
-    assert.strictEqual(result, `Do something\n\n${JAPANESE_INSTRUCTION}`);
-  });
-
-  test("enforceJapanese=false returns base prompt without Japanese instruction", () => {
-    getConfigurationStub
-      .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: "", enforceJapanese: false }));
+      .returns(makeConfig({ customPrompt: "" }));
 
     const result = buildFinalPrompt("Do something");
     assert.strictEqual(result, "Do something");
-    assert.ok(!result.includes(JAPANESE_INSTRUCTION));
   });
 
-  test("custom prompt is prepended when enforceJapanese=true", () => {
+  test("custom prompt is prepended when provided", () => {
     getConfigurationStub
       .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: "Always be concise.", enforceJapanese: true }));
-
-    const result = buildFinalPrompt("Explain this");
-    assert.strictEqual(
-      result,
-      `Always be concise.\n\nExplain this\n\n${JAPANESE_INSTRUCTION}`,
-    );
-  });
-
-  test("custom prompt is prepended when enforceJapanese=false", () => {
-    getConfigurationStub
-      .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: "Always be concise.", enforceJapanese: false }));
+      .returns(makeConfig({ customPrompt: "Always be concise." }));
 
     const result = buildFinalPrompt("Explain this");
     assert.strictEqual(result, "Always be concise.\n\nExplain this");
-    assert.ok(!result.includes(JAPANESE_INSTRUCTION));
-  });
-
-  test("empty custom prompt is ignored", () => {
-    getConfigurationStub
-      .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: "", enforceJapanese: false }));
-
-    const result = buildFinalPrompt("Simple prompt");
-    assert.strictEqual(result, "Simple prompt");
   });
 
   test("undefined custom prompt is treated as empty", () => {
     getConfigurationStub
       .withArgs("jules-extension")
-      .returns(makeConfig({ customPrompt: undefined, enforceJapanese: false }));
+      .returns(makeConfig({ customPrompt: undefined }));
 
     const result = buildFinalPrompt("Simple prompt");
     assert.strictEqual(result, "Simple prompt");

--- a/src/test/sessionUtils.unit.test.ts
+++ b/src/test/sessionUtils.unit.test.ts
@@ -97,7 +97,7 @@ suite("sessionUtils Test Suite", () => {
         assert.strictEqual(url, "https://jules.googleapis.com/v1alpha/sessions/123:sendMessage");
         
         const payload = JSON.parse(options.body);
-        assert.strictEqual(payload.prompt, "test message\n\nPlease use Japanese for all GitHub interactions (PR titles, descriptions, commit messages, and review replies).");
+        assert.strictEqual(payload.prompt, "test message");
     });
 
     test("sendMessage throws error when API fails", async () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `jules-extension.enforceJapanese` 設定（デフォルト `true`）を完全に削除し、`buildFinalPrompt` がカスタムプロンプトとユーザー入力を結合するだけのシンプルな実装になりました。

- **`src/promptUtils.ts`**: `enforceJapanese` の読み取りおよび日本語指示文の付与ロジックを削除。関数は `customPrompt` の先頭付与のみを行う。
- **`package.json`**: `contributes.configuration` から `enforceJapanese` の定義を削除。
- **テストファイル3件**: `enforceJapanese` に関連するスタブ・アサーション・テストケースをすべて削除し、新しい期待値に整合させた。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

コードの変更自体はシンプルで一貫性があり、テストも適切に更新されているため、マージ自体に技術的な問題はありません。

削除した `enforceJapanese` のデフォルト値が `true` だったため、既存ユーザーはアップデート後に日本語指示が消えるという動作変更を受けます。リリースノートや README で移行案内があるとより安全です。コードロジック自体は正確で、5ファイルすべてが整合的に更新されています。

`package.json` の設定削除が既存ユーザーの動作に影響するため、リリース前に変更ログの記載を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | `jules-extension.enforceJapanese` 設定を package.json の contributes.configuration から削除。デフォルト true だった動作が廃止される。 |
| src/promptUtils.ts | `enforceJapanese` の読み取りと日本語指示の追加ロジックを削除。関数はカスタムプロンプトの先頭付与のみを行うシンプルな実装になった。 |
| src/test/extension.test.ts | `enforceJapanese` 関連のテストケース（5件）を削除し、残りのアサーションを新しい期待値に更新。整合性あり。 |
| src/test/promptUtils.unit.test.ts | `JAPANESE_INSTRUCTION` 定数と `enforceJapanese` 関連テストを削除。`makeConfig` のシグネチャも更新済み。 |
| src/test/sessionUtils.unit.test.ts | sendMessage のペイロード検証テストで期待値を日本語指示なしに更新。変更内容に対応している。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
package.json:66
**既存ユーザーへのサイレントな動作変更**

`enforceJapanese` の デフォルト値は `true` だったため、既存ユーザーは自動的に日本語指示が付与されていました。この設定を削除すると、`settings.json` に `"jules-extension.enforceJapanese": true` と明示設定しているユーザーも含め、日本語指示が無通告で消えます。移行手順（例: `customPrompt` に同等の文言を設定するよう README やリリースノートで案内）がないと、ユーザーが意図しない言語でJulesが動作し始める恐れがあります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: remove redundant enforceJapanese s..."](https://github.com/hiroki-org/jules-extension/commit/070c7f46052414464a218630b9b3d4f7e3445246) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32446636)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->