### PR TITLE
🛡️ Sentinel: [MEDIUM] 強化されたDOMPurifyプロファイルによるmXSS防御の改善

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS), but using `USE_PROFILES` incorrectly strips default HTML tags.
 **Learning:** `USE_PROFILES` resets `ALLOWED_TAGS`. If you provide an invalid key or do not include standard profiles like `html`, DOMPurify removes safe HTML tags like `<p>` and `<a>`, causing UI breakage.
 **Prevention:** To disable specific attack vectors like MathML while preserving default safe tags, use `FORBID_TAGS: ['math', 'annotation', ...]` rather than altering profiles.
+## 2026-05-16 - [DOMPurify Profile Configuration for MathML]
+**Vulnerability:** Adding `USE_PROFILES: { math: false }` incorrectly stripped all standard HTML/SVG tags because missing profiles default to false.
+**Learning:** When using `USE_PROFILES` in DOMPurify to disable a specific attack vector (like MathML), you must explicitly enable the standard profiles (e.g., `html: true, svg: true`) to avoid breaking regular content rendering.
+**Prevention:** Use `USE_PROFILES: { html: true, svg: true, math: false }` to retain core formatting while closing niche profile vulnerabilities.

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -142,6 +142,7 @@ suite("chatAssets unit tests", () => {
     ]);
     assert.strictEqual(sanitizeConfig.RETURN_DOM, false);
     assert.strictEqual(sanitizeConfig.RETURN_DOM_FRAGMENT, false);
+    assert.deepStrictEqual(sanitizeConfig.USE_PROFILES, { html: true, svg: true, math: false });
     assert.deepStrictEqual(sanitizeConfig.FORBID_TAGS, ["math", "annotation", "annotation-xml", "maction", "mi", "mn", "mo", "ms", "mtext", "semantics"]);
   });
 

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -102,6 +102,7 @@ export const CHAT_JS = `(function() {
           ADD_ATTR: ["data-activity-id", "data-detail-type", "data-index"],
           RETURN_DOM: false,
           RETURN_DOM_FRAGMENT: false,
+          USE_PROFILES: { html: true, svg: true, math: false },
           FORBID_TAGS: ["math", "annotation", "annotation-xml", "maction", "mi", "mn", "mo", "ms", "mtext", "semantics"],
         }),
       );


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: DOMPurify のデフォルト設定では MathML のパースが有効になっており、これが mXSS（Mutation XSS）攻撃のベクターとして利用される可能性がありました。また、単に `{ math: false }` を設定すると、安全な HTML や SVG タグまで削除されてしまうという問題がありました。
🎯 Impact: 特殊なペイロードを介した XSS 攻撃のリスクを最小限に抑えます。
🔧 Fix: `src/webview/chatAssets.ts` 内の `DOMPurify.sanitize` 設定において、`USE_PROFILES: { html: true, svg: true, math: false }` を明示的に指定しました。これにより、標準の HTML および SVG のレンダリングを完全に維持しながら、MathML のみを無効化しました。
✅ Verification: `src/test/chatAssets.unit.test.ts` を更新し、設定が正しく適用されていることを確認しました。また、`pnpm run test:unit`, `xvfb-run -a pnpm test`, `pnpm run lint`, `pnpm run check-types` を実行し、すべてのチェックを通過しました。

---
*PR created automatically by Jules for task [18112510874195186263](https://jules.google.com/task/18112510874195186263) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

DOMPurify の `sanitize` 設定に `USE_PROFILES: { html: true, svg: true, math: false }` を追加し、MathML パースを無効化することで mXSS 攻撃ベクターを縮小しようとした変更です。対応するテストと sentinel.md のドキュメントも更新されています。

- **`math` キー名が誤り**: DOMPurify の `USE_PROFILES` が認識するキーは `html`、`svg`、`svgFilters`、`mathMl`（camelCase）の4種類のみ。`math: false` は黙って無視されるため、MathML の除外は `FORBID_TAGS` のみが実質的に担っています。
- **sentinel.md に矛盾する指針**: 既存エントリ（2024-05-13）は「`USE_PROFILES` ではなく `FORBID_TAGS` を使うこと」と明記している一方、新しいエントリは `USE_PROFILES` の利用を推奨しており、将来の開発者にとって混乱の原因となります。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

MathML 除外は FORBID_TAGS によって引き続き機能しているため実際のセキュリティ効果は維持されているが、誤ったキー名が実装とドキュメントの両方に記録されており、修正なしにマージすると誤情報が蓄積する。

コードの実動作上のセキュリティは FORBID_TAGS が担保しているが、`math: false` という誤ったキー名が chatAssets.ts と sentinel.md の両方に埋め込まれる。sentinel.md の新旧エントリが矛盾する内容となっており、将来の修正者が誤った参考実装を踏襲するリスクが残る。

`.jules/sentinel.md` — 矛盾する2つのエントリと誤ったキー名の修正が必要。`src/webview/chatAssets.ts` — `math` を `mathMl` に修正が必要。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | DOMPurify に USE_PROFILES を追加。ただし `math: false` は無効なキー名で silently ignored になる。セキュリティ上の効果は FORBID_TAGS が担保しているが、コードの意図と実装が乖離している。 |
| .jules/sentinel.md | 新しいエントリが既存エントリと矛盾する上、誤ったキー名 `math: false`（正しくは `mathMl: false`）を正しい実装例として記録しており、将来の開発者を誤誘導するリスクがある。 |
| src/test/chatAssets.unit.test.ts | USE_PROFILES の設定値が期待値と一致するかのアサーションを追加。構成オブジェクトの検証のみで、実際のサニタイズ動作は未テスト。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/webview/chatAssets.ts`, line 99-107 ([link](https://github.com/hiroki-org/jules-extension/blob/abec884cb60fe28d1733783e4709dc8c35e06651/src/webview/chatAssets.ts#L99-L107)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **USE_PROFILES と ADD_TAGS の組み合わせについて**

   DOMPurify の公式 README には「`USE_PROFILES` は `ALLOWED_TAGS` 設定を上書きするため、これらを同時に使わないこと」と明記されています。`ADD_TAGS` は `ALLOWED_TAGS` の拡張として機能するため現在は正しく動作していますが、この組み合わせは公式に非推奨とされているパターンであり、DOMPurify のバージョンアップ時に挙動が変わるリスクがあります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 99-107

   Comment:
   **USE_PROFILES と ADD_TAGS の組み合わせについて**

   DOMPurify の公式 README には「`USE_PROFILES` は `ALLOWED_TAGS` 設定を上書きするため、これらを同時に使わないこと」と明記されています。`ADD_TAGS` は `ALLOWED_TAGS` の拡張として機能するため現在は正しく動作していますが、この組み合わせは公式に非推奨とされているパターンであり、DOMPurify のバージョンアップ時に挙動が変わるリスクがあります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/webview/chatAssets.ts:105
DOMPurify の `USE_PROFILES` で認識されるキーは `html`、`svg`、`svgFilters`、`mathMl`（camelCase）の4種類のみです。`math` というキーは存在せず、DOMPurify は黙って無視します。現在は `FORBID_TAGS` が MathML タグを除外しているため実害はありませんが、`math: false` は意図通りに動作していない no-op であり、コードと `sentinel.md` の両方に誤った情報が記録されます。

```suggestion
          USE_PROFILES: { html: true, svg: true, mathMl: false },
```

### Issue 2 of 3
.jules/sentinel.md:10-13
sentinel.md の新しいエントリは既存エントリ（6〜9行目）と直接矛盾しています。既存エントリは「`USE_PROFILES` ではなく `FORBID_TAGS` を使うこと」と明記していますが、新しいエントリは `USE_PROFILES` の使用を推奨しています。さらに、新しいエントリが記録する `math: false` というキー名は DOMPurify では無効なキーです（正しくは `mathMl: false`）。このまま残すと、将来の開発者が誤った修正方法を学習してしまいます。

```suggestion
## 2026-05-16 - [DOMPurify Profile Configuration for MathML]
**Vulnerability:** Adding `USE_PROFILES: { math: false }` incorrectly stripped all standard HTML/SVG tags because missing profiles default to false.
**Learning:** When using `USE_PROFILES` in DOMPurify to disable a specific attack vector (like MathML), you must explicitly enable the standard profiles (e.g., `html: true, svg: true`) to avoid breaking regular content rendering. Note: the valid DOMPurify profile key for MathML is `mathMl` (camelCase), not `math`. Omitting `mathMl` from USE_PROFILES achieves the same exclusion effect.
**Prevention:** Prefer `FORBID_TAGS: ['math', 'annotation', ...]` over `USE_PROFILES` to avoid overriding ALLOWED_TAGS. If `USE_PROFILES` is used alongside `FORBID_TAGS`, use `USE_PROFILES: { html: true, svg: true, mathMl: false }` and note that the DOMPurify README warns against combining USE_PROFILES with ALLOWED_TAGS manipulation.
```

### Issue 3 of 3
src/webview/chatAssets.ts:99-107
**USE_PROFILES と ADD_TAGS の組み合わせについて**

DOMPurify の公式 README には「`USE_PROFILES` は `ALLOWED_TAGS` 設定を上書きするため、これらを同時に使わないこと」と明記されています。`ADD_TAGS` は `ALLOWED_TAGS` の拡張として機能するため現在は正しく動作していますが、この組み合わせは公式に非推奨とされているパターンであり、DOMPurify のバージョンアップ時に挙動が変わるリスクがあります。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] 強化されたDOMPurifyプロフ..."](https://github.com/hiroki-org/jules-extension/commit/abec884cb60fe28d1733783e4709dc8c35e06651) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32448174)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->