### PR TITLE
fix: mitigate XSS in sanitize-html by adding xmp to nonTextTags

### DIFF
--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -111,27 +111,43 @@ export async function initMarkdownRenderer(): Promise<void> {
   return markdownRendererInit;
 }
 
+/**
+ * Default options for sanitize-html to prevent XSS.
+ * Includes additional obsolete/dangerous tags like xmp, listing, and plaintext in nonTextTags.
+ */
+const DEFAULT_SANITIZER_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+    "img",
+    "details",
+    "summary",
+    "button",
+  ]),
+  allowedAttributes: {
+    ...sanitizeHtml.defaults.allowedAttributes,
+    "*": ["class", "id", "data-*", "aria-*"],
+    button: ["type", "title"],
+  },
+  nonTextTags: [
+    "script",
+    "style",
+    "textarea",
+    "option",
+    "xmp",
+    "listing",
+    "plaintext",
+  ],
+};
+
+/**
+ * Renders markdown content to HTML and sanitizes it.
+ * @param markdown - The markdown string to render.
+ * @returns The sanitized HTML string.
+ */
 export function renderChatMarkdown(markdown: string): string {
   if (!markdownRenderer) {
     return escapeHtml(markdown);
   }
-  return sanitizeHtml(markdownRenderer.render(markdown), {
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-      "img", "details", "summary", "button"
-    ]),
-    allowedAttributes: {
-      ...sanitizeHtml.defaults.allowedAttributes,
-      "*": ["class", "id", "data-*", "aria-*"],
-      button: ["type", "title"],
-    },
-    nonTextTags: [
-      "script",
-      "style",
-      "textarea",
-      "option",
-      "xmp"
-    ],
-  });
+  return sanitizeHtml(markdownRenderer.render(markdown), DEFAULT_SANITIZER_OPTIONS);
 }
 
 const GENERATING_SESSION_STATES: ReadonlySet<string> = new Set([
@@ -292,23 +308,7 @@ export function buildChatMessagesFromActivities(
           escapeHtml(combinedText) +
           "</em></div>" +
           detailsHtml,
-        {
-          allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-            "img", "details", "summary", "button"
-          ]),
-          allowedAttributes: {
-            ...sanitizeHtml.defaults.allowedAttributes,
-            "*": ["class", "id", "data-*", "aria-*"],
-            button: ["type", "title"],
-          },
-          nonTextTags: [
-            "script",
-            "style",
-            "textarea",
-            "option",
-            "xmp"
-          ],
-        }
+        DEFAULT_SANITIZER_OPTIONS
       ),
     });
   });

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -124,6 +124,13 @@ export function renderChatMarkdown(markdown: string): string {
       "*": ["class", "id", "data-*", "aria-*"],
       button: ["type", "title"],
     },
+    nonTextTags: [
+      "script",
+      "style",
+      "textarea",
+      "option",
+      "xmp"
+    ],
   });
 }
 
@@ -294,6 +301,13 @@ export function buildChatMessagesFromActivities(
             "*": ["class", "id", "data-*", "aria-*"],
             button: ["type", "title"],
           },
+          nonTextTags: [
+            "script",
+            "style",
+            "textarea",
+            "option",
+            "xmp"
+          ],
         }
       ),
     });


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

sanitize-htmlのオプションを`DEFAULT_SANITIZER_OPTIONS`定数として抽出することで重複を排除し、CVE-2026-44990への対策として`xmp`・`listing`・`plaintext`を`nonTextTags`に追加しています。前回のレビューで指摘された廃止済み生テキスト要素(`listing`・`plaintext`)も含めた対応が完了しています。

- `DEFAULT_SANITIZER_OPTIONS`を`renderChatMarkdown`と`buildChatMessagesFromActivities`の両呼び出し箇所で共有することでDRY原則を実現
- `nonTextTags`はsanitize-htmlのデフォルト値(`script`・`style`・`textarea`・`option`)を全て維持した上で新タグを追加しており、既存の挙動を壊さない正しい実装になっている
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は局所的で意図が明確。既存の挙動を壊すリスクはなく、安全にマージできる。

sanitize-htmlのデフォルトnonTextTags（script/style/textarea/option）を全て維持しながら新タグを追加しており、設定の取り違えによるリグレッションはない。共有定数への抽出は2箇所の呼び出しに正しく適用されており、挙動の不整合も生じない。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | sanitize-htmlオプションをDEFAULT_SANITIZER_OPTIONS定数に集約し、nonTextTagsにxmp/listing/plaintextを追加してCVE-2026-44990を緩和。デフォルト値(script/style/textarea/option)は全て保持されており、重複コードも解消されている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[マークダウン / HTML文字列の入力] --> B{markdownRendererが存在するか?}
    B -- No --> C[escapeHtml でエスケープして返す]
    B -- Yes --> D[markdownRenderer.render でHTML生成]
    D --> E[sanitizeHtml with DEFAULT_SANITIZER_OPTIONS]
    F[直接HTMLの組み立て buildChatMessagesFromActivities] --> E
    E --> G{nonTextTagsに合致するか?}
    G -- Yes --> H[タグごとコンテンツを完全に破棄]
    G -- No --> I[allowedTagsによるフィルタリング + allowedAttributesによる属性フィルタ]
    H --> J[サニタイズ済みHTML出力]
    I --> J
```

<sub>Reviews (2): Last reviewed commit: ["fix: address review comments for XSS mit..."](https://github.com/hiroki-org/jules-extension/commit/35d549279fac2e1abb9e64fbdd18d97d43a8be68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32448379)</sub>

<!-- /greptile_comment -->