### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix innerHTML usage in composer

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -268,7 +268,10 @@ export function getComposerHtml(
       }
 
       submitButton.disabled = true;
-      submitButton.innerHTML = 'Sending... <span class="spinner"></span>';
+      submitButton.textContent = 'Sending... ';
+      const spinner = document.createElement('span');
+      spinner.className = 'spinner';
+      submitButton.appendChild(spinner);
       submitButton.setAttribute('aria-busy', 'true');
       submitButton.title = 'Sending message...';
       submitButton.setAttribute('aria-label', 'Sending message...');

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -592,7 +592,10 @@ suite("Composer Test Suite", () => {
         "nonce-123"
       );
       // Check for loading state logic
-      assert.ok(html.includes("submitButton.innerHTML = 'Sending... <span class=\"spinner\"></span>';"));
+      assert.ok(html.includes("submitButton.textContent = 'Sending... ';"));
+      assert.ok(html.includes("const spinner = document.createElement('span');"));
+      assert.ok(html.includes("spinner.className = 'spinner';"));
+      assert.ok(html.includes("submitButton.appendChild(spinner);"));
       assert.ok(html.includes("submitButton.setAttribute('aria-busy', 'true');"));
       assert.ok(html.includes("submitButton.title = 'Sending message...';"));
       assert.ok(html.includes("submitButton.setAttribute('aria-label', 'Sending message...');"));


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `src/composer.ts` 内で `submitButton.innerHTML` への直接代入が行われており、文字列の動的連結が含まれた場合に DOM Based XSS のリスクが生じやすい設計になっていました（現在はハードコードされた文字列のため直接的なエクスプロイトは不可ですが、防御的設計の観点から改善が必要です）。
🎯 Impact: 将来的なコード改修で動的なユーザー入力が混入した場合に、XSS攻撃の経路となる可能性を排除します。
🔧 Fix: `innerHTML` の使用を完全に廃止し、`textContent` プロパティへのテキスト設定と `document.createElement('span')` を用いた要素追加の安全なDOM操作に置換しました。テストも合わせて修正しました。
✅ Verification: `pnpm run test:unit`, `xvfb-run -a pnpm test`, `pnpm run lint`, `pnpm run check-types` を実行し、全て正常にパスすることを確認しました。

---
*PR created automatically by Jules for task [10380404143380001404](https://jules.google.com/task/10380404143380001404) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `src/composer.ts` 内の `submitButton.innerHTML` への直接代入を廃止し、`textContent` と `document.createElement` を用いた安全なDOM操作に置き換えるセキュリティ改善です。現状はハードコードされた文字列のみが使用されているため直接的なXSSリスクはありませんが、将来的な動的コンテンツ混入に備えた防御的な修正として適切です。

- **`src/composer.ts`**: `submitButton.innerHTML = 'Sending... <span class="spinner"></span>'` を `textContent` によるテキスト設定 + `createElement` / `appendChild` による要素追加に置換。機能的に同等な結果を、XSSリスクのない方法で実現しています。
- **`src/test/composer.unit.test.ts`**: 旧 `innerHTML` の文字列チェックを新しいDOM操作コードのチェックに対応させてテストを更新。既存のHTMLテンプレート文字列マッチング方式を踏襲しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はスコープが小さく、機能的に等価な置き換えであり、安全にマージできます。

変更は submitButton.innerHTML の単一箇所を textContent + createElement + appendChild に置き換えるだけで、ロジックの変化はありません。ボタンの初期状態・送信後状態ともに同じ表示結果が得られ、テストも適切に更新されています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | innerHTML をtextContent + createElement に置換。機能的に等価で、XSS防御観点から正しい修正。 |
| src/test/composer.unit.test.ts | テストを新しいDOM操作パターンの文字列チェックに更新。既存テスト方針に沿っており、変更内容を正しく反映。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: composer.tsのinnerHTMLを安全なD..."](https://github.com/hiroki-org/jules-extension/commit/45411907bdf455e1e9febc327fdcffdede14a97b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32449249)</sub>

<!-- /greptile_comment -->