### PR TITLE
⚡ Bolt: [performance improvement] Optimize Array.find calls in PR remote resolution

### DIFF
--- a/benchmark_remotes.js
+++ b/benchmark_remotes.js
@@ -1,0 +1,75 @@
+const { performance } = require('perf_hooks');
+
+const remotes = [];
+for (let i = 0; i < 10000; i++) {
+    remotes.push({ remote: `remote${i}`, fetchUrl: `https://github.com/owner/repo${i}.git` });
+}
+remotes.push({ remote: 'origin', fetchUrl: 'https://github.com/headOwner/headRepo.git' });
+
+const headCloneUrl = 'https://github.com/headOwner/headRepo.git';
+const headCloneUrlNoGit = headCloneUrl.replace(/\.git$/, '');
+
+function runBaseline() {
+    let targetRemote = remotes.find(r =>
+        r.fetchUrl === headCloneUrl ||
+        (r.fetchUrl && r.fetchUrl.replace(/\.git$/, '') === headCloneUrlNoGit)
+    );
+
+    if (!targetRemote) {
+        const originRemote = remotes.find(r => r.remote === 'origin');
+        if (originRemote?.fetchUrl?.includes(`headOwner/headRepo`)) {
+            targetRemote = originRemote;
+        }
+    }
+    return targetRemote;
+}
+
+function runOptimized() {
+    const remotesByUrl = new Map();
+    const remotesByName = new Map();
+
+    for (const r of remotes) {
+        if (r.fetchUrl) {
+            if (!remotesByUrl.has(r.fetchUrl)) {
+                remotesByUrl.set(r.fetchUrl, r);
+            }
+            const fetchUrlNoGit = r.fetchUrl.replace(/\.git$/, '');
+            if (!remotesByUrl.has(fetchUrlNoGit)) {
+                remotesByUrl.set(fetchUrlNoGit, r);
+            }
+        }
+        if (r.remote) {
+            if (!remotesByName.has(r.remote)) {
+                remotesByName.set(r.remote, r);
+            }
+        }
+    }
+
+    let targetRemote = remotesByUrl.get(headCloneUrl) || remotesByUrl.get(headCloneUrlNoGit);
+
+    if (!targetRemote) {
+        const originRemote = remotesByName.get('origin');
+        if (originRemote?.fetchUrl?.includes(`headOwner/headRepo`)) {
+            targetRemote = originRemote;
+        }
+    }
+    return targetRemote;
+}
+
+// Warmup
+for (let i = 0; i < 100; i++) {
+    runBaseline();
+    runOptimized();
+}
+
+let start = performance.now();
+for (let i = 0; i < 1000; i++) {
+    runBaseline();
+}
+console.log(`Baseline: ${performance.now() - start} ms`);
+
+start = performance.now();
+for (let i = 0; i < 1000; i++) {
+    runOptimized();
+}
+console.log(`Optimized: ${performance.now() - start} ms`);

--- a/benchmark_small.js
+++ b/benchmark_small.js
@@ -1,0 +1,73 @@
+const { performance } = require('perf_hooks');
+
+const remotes = [];
+for (let i = 0; i < 4; i++) {
+    remotes.push({ remote: `remote${i}`, fetchUrl: `https://github.com/owner/repo${i}.git` });
+}
+remotes.push({ remote: 'origin', fetchUrl: 'https://github.com/headOwner/headRepo.git' });
+
+const headCloneUrl = 'https://github.com/headOwner/headRepo.git';
+const headCloneUrlNoGit = headCloneUrl.replace(/\.git$/, '');
+
+function runBaseline() {
+    let targetRemote = remotes.find(r =>
+        r.fetchUrl === headCloneUrl ||
+        (r.fetchUrl && r.fetchUrl.replace(/\.git$/, '') === headCloneUrlNoGit)
+    );
+
+    if (!targetRemote) {
+        const originRemote = remotes.find(r => r.remote === 'origin');
+        if (originRemote?.fetchUrl?.includes(`headOwner/headRepo`)) {
+            targetRemote = originRemote;
+        }
+    }
+    return targetRemote;
+}
+
+function runOptimized() {
+    const remotesByUrl = new Map();
+    const remotesByName = new Map();
+
+    for (const r of remotes) {
+        if (!remotesByName.has(r.remote)) {
+            remotesByName.set(r.remote, r);
+        }
+        if (r.fetchUrl) {
+            if (!remotesByUrl.has(r.fetchUrl)) {
+                remotesByUrl.set(r.fetchUrl, r);
+            }
+            const fetchUrlNoGit = r.fetchUrl.endsWith('.git') ? r.fetchUrl.slice(0, -4) : r.fetchUrl;
+            if (!remotesByUrl.has(fetchUrlNoGit)) {
+                remotesByUrl.set(fetchUrlNoGit, r);
+            }
+        }
+    }
+
+    let targetRemote = remotesByUrl.get(headCloneUrl) || remotesByUrl.get(headCloneUrlNoGit);
+
+    if (!targetRemote) {
+        const originRemote = remotesByName.get('origin');
+        if (originRemote?.fetchUrl?.includes(`headOwner/headRepo`)) {
+            targetRemote = originRemote;
+        }
+    }
+    return targetRemote;
+}
+
+// Warmup
+for (let i = 0; i < 1000; i++) {
+    runBaseline();
+    runOptimized();
+}
+
+let start = performance.now();
+for (let i = 0; i < 100000; i++) {
+    runBaseline();
+}
+console.log(`Baseline: ${performance.now() - start} ms`);
+
+start = performance.now();
+for (let i = 0; i < 100000; i++) {
+    runOptimized();
+}
+console.log(`Optimized: ${performance.now() - start} ms`);

--- a/benchmark_small_no_map.js
+++ b/benchmark_small_no_map.js
@@ -1,0 +1,74 @@
+const { performance } = require('perf_hooks');
+
+const remotes = [];
+for (let i = 0; i < 4; i++) {
+    remotes.push({ remote: `remote${i}`, fetchUrl: `https://github.com/owner/repo${i}.git` });
+}
+remotes.push({ remote: 'origin', fetchUrl: 'https://github.com/headOwner/headRepo.git' });
+
+const headCloneUrl = 'https://github.com/headOwner/headRepo.git';
+const headCloneUrlNoGit = headCloneUrl.replace(/\.git$/, '');
+
+function runBaseline() {
+    let targetRemote = remotes.find(r =>
+        r.fetchUrl === headCloneUrl ||
+        (r.fetchUrl && r.fetchUrl.replace(/\.git$/, '') === headCloneUrlNoGit)
+    );
+
+    if (!targetRemote) {
+        const originRemote = remotes.find(r => r.remote === 'origin');
+        if (originRemote?.fetchUrl?.includes(`headOwner/headRepo`)) {
+            targetRemote = originRemote;
+        }
+    }
+    return targetRemote;
+}
+
+function runOptimized() {
+    let targetRemote = undefined;
+    let originRemote = undefined;
+
+    for (const r of remotes) {
+        if (!targetRemote) {
+            if (r.fetchUrl === headCloneUrl) {
+                targetRemote = r;
+            } else if (r.fetchUrl) {
+                const rFetchUrlNoGit = r.fetchUrl.endsWith('.git') ? r.fetchUrl.slice(0, -4) : r.fetchUrl;
+                if (rFetchUrlNoGit === headCloneUrlNoGit) {
+                    targetRemote = r;
+                }
+            }
+        }
+
+        if (!originRemote && r.remote === 'origin') {
+            originRemote = r;
+        }
+
+        // Both found, early exit
+        if (targetRemote && originRemote) break;
+    }
+
+    if (!targetRemote && originRemote?.fetchUrl?.includes(`headOwner/headRepo`)) {
+        targetRemote = originRemote;
+    }
+
+    return targetRemote;
+}
+
+// Warmup
+for (let i = 0; i < 1000; i++) {
+    runBaseline();
+    runOptimized();
+}
+
+let start = performance.now();
+for (let i = 0; i < 100000; i++) {
+    runBaseline();
+}
+console.log(`Baseline: ${performance.now() - start} ms`);
+
+start = performance.now();
+for (let i = 0; i < 100000; i++) {
+    runOptimized();
+}
+console.log(`Optimized: ${performance.now() - start} ms`);

--- a/commit_diff.js
+++ b/commit_diff.js
@@ -1,0 +1,9 @@
+const { execSync } = require('child_process');
+
+try {
+    execSync('git add src/test/sessionContextMenu.checkout.unit.test.ts');
+    execSync('git commit --amend --no-edit');
+    console.log("Successfully amended commit with test updates.");
+} catch(e) {
+    console.error(e.stdout ? e.stdout.toString() : e);
+}

--- a/fix_lines.js
+++ b/fix_lines.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+
+// We have 2 lines that we missed coverage for, lines 568 and 569 in src/sessionContextMenu.ts.
+// Line 568: const rFetchUrlNoGit = r.fetchUrl.endsWith('.git') ? r.fetchUrl.slice(0, -4) : r.fetchUrl;
+// We actually hit both branches. Wait, looking at the codecov patch report it says 80%.
+// The only things modified in this PR were lines around 560-580.
+// We added tests. Let's run pnpm run test:unit again and see if the patch coverage hits.
+// Actually, looking at `BRDA:568,115,0,0` and `BRDA:569,116,0,0` these are branch missed in lcov.
+// What are the exact conditions?
+// 568: `r.fetchUrl.endsWith('.git') ? r.fetchUrl.slice(0, -4) : r.fetchUrl;`
+// We need a test where `r.fetchUrl` does NOT end with `.git` and `rFetchUrlNoGit === headCloneUrlNoGit`.
+// We already added one where `r.fetchUrl` DOES NOT end with `.git`.
+// In `checkoutToBranchForSession covers fallback to headCloneUrl`:
+// `r.fetchUrl = 'https://github.com/fork-owner/fork-repo'`
+// `headCloneUrl = 'https://github.com/fork-owner/fork-repo'`
+
+// Let's create a test where `r.fetchUrl` ends with `.git` but `headCloneUrl` does NOT end with `.git`,
+// or where `r.fetchUrl` does not end with `.git` but `headCloneUrl` does.

--- a/fix_lint.js
+++ b/fix_lint.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+let content = fs.readFileSync('src/sessionContextMenu.ts', 'utf8');
+
+const search = `            // 両方見つかれば早期終了
+            if (targetRemote && originRemote) break;`;
+
+const replace = `            // 両方見つかれば早期終了
+            if (targetRemote && originRemote) {
+                break;
+            }`;
+
+content = content.replace(search, replace);
+fs.writeFileSync('src/sessionContextMenu.ts', content);
+console.log("Lint issue fixed.");

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,57 @@
+<<<<<<< SEARCH
+        // リポジトリのリモート一覧を取得
+        const remotes: { remote: string; fetchUrl: string }[] = repository.state?.remotes || [];
+
+        const headCloneUrlNoGit = headCloneUrl.replace(/\.git$/, '');
+
+        // headCloneUrlに一致するリモートを探す
+        let targetRemote = remotes.find(r =>
+            r.fetchUrl === headCloneUrl ||
+            (r.fetchUrl && r.fetchUrl.replace(/\.git$/, '') === headCloneUrlNoGit)
+        );
+
+        // フォークからのPRで、対応するリモートがない場合
+        if (!targetRemote) {
+            // origin/upstreamを確認
+            const originRemote = remotes.find(r => r.remote === 'origin');
+
+            // originがheadCloneUrlと同じなら、originを使う
+            if (originRemote?.fetchUrl?.includes(`${headOwner}/${headRepo}`)) {
+                targetRemote = originRemote;
+            } else {
+=======
+        // リポジトリのリモート一覧を取得
+        const remotes: { remote: string; fetchUrl: string }[] = repository.state?.remotes || [];
+
+        const headCloneUrlNoGit = headCloneUrl.endsWith('.git') ? headCloneUrl.slice(0, -4) : headCloneUrl;
+
+        let targetRemote: { remote: string; fetchUrl: string } | undefined;
+        let originRemote: { remote: string; fetchUrl: string } | undefined;
+
+        for (const r of remotes) {
+            if (!targetRemote) {
+                if (r.fetchUrl === headCloneUrl) {
+                    targetRemote = r;
+                } else if (r.fetchUrl) {
+                    const rFetchUrlNoGit = r.fetchUrl.endsWith('.git') ? r.fetchUrl.slice(0, -4) : r.fetchUrl;
+                    if (rFetchUrlNoGit === headCloneUrlNoGit) {
+                        targetRemote = r;
+                    }
+                }
+            }
+
+            if (!originRemote && r.remote === 'origin') {
+                originRemote = r;
+            }
+
+            // 両方見つかれば早期終了
+            if (targetRemote && originRemote) break;
+        }
+
+        // フォークからのPRで、対応するリモートがない場合
+        if (!targetRemote) {
+            // originがheadCloneUrlと同じなら、originを使う
+            if (originRemote?.fetchUrl?.includes(`${headOwner}/${headRepo}`)) {
+                targetRemote = originRemote;
+            } else {
+>>>>>>> REPLACE

--- a/src/sessionContextMenu.ts
+++ b/src/sessionContextMenu.ts
@@ -555,19 +555,35 @@ async function fetchAndCheckoutFromPRInfo(
         // リポジトリのリモート一覧を取得
         const remotes: { remote: string; fetchUrl: string }[] = repository.state?.remotes || [];
 
-        const headCloneUrlNoGit = headCloneUrl.replace(/\.git$/, '');
+        const headCloneUrlNoGit = headCloneUrl.endsWith('.git') ? headCloneUrl.slice(0, -4) : headCloneUrl;
 
-        // headCloneUrlに一致するリモートを探す
-        let targetRemote = remotes.find(r =>
-            r.fetchUrl === headCloneUrl ||
-            (r.fetchUrl && r.fetchUrl.replace(/\.git$/, '') === headCloneUrlNoGit)
-        );
+        let targetRemote: { remote: string; fetchUrl: string } | undefined;
+        let originRemote: { remote: string; fetchUrl: string } | undefined;
+
+        for (const r of remotes) {
+            if (!targetRemote) {
+                if (r.fetchUrl === headCloneUrl) {
+                    targetRemote = r;
+                } else if (r.fetchUrl) {
+                    const rFetchUrlNoGit = r.fetchUrl.endsWith('.git') ? r.fetchUrl.slice(0, -4) : r.fetchUrl;
+                    if (rFetchUrlNoGit === headCloneUrlNoGit) {
+                        targetRemote = r;
+                    }
+                }
+            }
+
+            if (!originRemote && r.remote === 'origin') {
+                originRemote = r;
+            }
+
+            // 両方見つかれば早期終了
+            if (targetRemote && originRemote) {
+                break;
+            }
+        }
 
         // フォークからのPRで、対応するリモートがない場合
         if (!targetRemote) {
-            // origin/upstreamを確認
-            const originRemote = remotes.find(r => r.remote === 'origin');
-
             // originがheadCloneUrlと同じなら、originを使う
             if (originRemote?.fetchUrl?.includes(`${headOwner}/${headRepo}`)) {
                 targetRemote = originRemote;

--- a/test_coverage_update.js
+++ b/test_coverage_update.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+let content = fs.readFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', 'utf8');
+
+const search = `    it('checkoutToBranchForSession covers fetchAndCheckoutFromPRInfo success when headCloneUrl matches exactly without replace', async () => {`;
+
+const replace = `    it('checkoutToBranchForSession covers fetchAndCheckoutFromPRInfo success when headCloneUrl matches exactly without replace', async () => {
+        // Set up mock repositories and fetch info to trigger the condition
+        mockBranchInfo = {
+            headBranch: 'feature/pr-123',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo.git' // Exact match via .git replace
+        };
+
+        const mockRepo = {
+            state: {
+                remotes: [
+                    { remote: 'origin', fetchUrl: 'https://github.com/owner/repo.git' },
+                    // Make the fetchUrl slightly different to hit the else if branch
+                    // and use .endsWith('.git')
+                    { remote: 'fork-remote', fetchUrl: 'https://github.com/fork-owner/fork-repo' }
+                ]
+            },
+            fetch: sandbox.stub().resolves(),
+            checkout: sandbox.stub().resolves()
+        };
+
+        mockGitAPI.repositories = [mockRepo];
+
+        const result = await checkoutToBranchForSession(mockSession);
+
+        assert.strictEqual(result, true);
+        assert.ok(mockRepo.fetch.calledWith('fork-remote'), 'Should use fork-remote found via regex replace match');
+        assert.ok(mockRepo.checkout.calledWith('feature/pr-123'));
+    });
+
+    it('checkoutToBranchForSession covers fetchAndCheckoutFromPRInfo success when headCloneUrl matches exactly without replace in else block', async () => {`;
+
+content = content.replace(search, replace);
+fs.writeFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', content);
+console.log("Updated tests to hit coverage branch.");

--- a/test_coverage_update_2.js
+++ b/test_coverage_update_2.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+let content = fs.readFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', 'utf8');
+
+const search = `    it('checkoutToBranchForSession covers fetchAndCheckoutFromPRInfo success when headCloneUrl matches exactly without replace in else block', async () => {`;
+
+const replace = `    it('checkoutToBranchForSession covers fetchAndCheckoutFromPRInfo success when headCloneUrl matches exactly without replace in else block', async () => {
+        // Set up mock repositories and fetch info to trigger the condition
+        mockBranchInfo = {
+            headBranch: 'feature/pr-123',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo' // No .git extension
+        };
+
+        const mockRepo = {
+            state: {
+                remotes: [
+                    { remote: 'origin', fetchUrl: 'https://github.com/owner/repo.git' },
+                    { remote: 'fork-remote', fetchUrl: 'https://github.com/fork-owner/fork-repo.git' } // Has .git extension
+                ]
+            },
+            fetch: sandbox.stub().resolves(),
+            checkout: sandbox.stub().resolves()
+        };
+
+        mockGitAPI.repositories = [mockRepo];
+
+        const result = await checkoutToBranchForSession(mockSession);
+
+        assert.strictEqual(result, true);
+        assert.ok(mockRepo.fetch.calledWith('fork-remote'), 'Should use fork-remote found via endsWith match');
+        assert.ok(mockRepo.checkout.calledWith('feature/pr-123'));
+    });
+
+    it('dummy', async () => {`;
+
+content = content.replace(search, replace);
+fs.writeFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', content);
+console.log("Updated tests to hit coverage branch.");

--- a/test_coverage_update_3.js
+++ b/test_coverage_update_3.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+let content = fs.readFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', 'utf8');
+
+const search = `    it('dummy', async () => {`;
+
+const replace = `    it('checkoutToBranchForSession covers fetchAndCheckoutFromPRInfo when rFetchUrlNoGit does not match', async () => {
+        // Set up mock repositories and fetch info to trigger the condition
+        mockBranchInfo = {
+            headBranch: 'feature/pr-123',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo.git'
+        };
+
+        const mockRepo = {
+            state: {
+                remotes: [
+                    { remote: 'origin', fetchUrl: 'https://github.com/owner/repo.git' },
+                    { remote: 'fork-remote', fetchUrl: 'https://github.com/other/other.git' } // Different URL
+                ]
+            },
+            fetch: sandbox.stub().rejects(new Error('Should not reach here')),
+            checkout: sandbox.stub().rejects(new Error('Should not reach here')),
+            addRemote: sandbox.stub().rejects(new Error('Stop')) // early abort
+        };
+
+        mockGitAPI.repositories = [mockRepo];
+
+        // Should return false due to addRemote rejecting
+        const result = await checkoutToBranchForSession(mockSession);
+        assert.strictEqual(result, false);
+    });
+
+    it('checkoutToBranchForSession covers fallback to headCloneUrl', async () => {
+        mockBranchInfo = {
+            headBranch: 'feature/pr-123',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo'
+        };
+
+        const mockRepo = {
+            state: {
+                remotes: [
+                    { remote: 'origin', fetchUrl: 'https://github.com/owner/repo.git' },
+                    { remote: 'fork-remote', fetchUrl: 'https://github.com/fork-owner/fork-repo' }
+                ]
+            },
+            fetch: sandbox.stub().resolves(),
+            checkout: sandbox.stub().resolves()
+        };
+
+        mockGitAPI.repositories = [mockRepo];
+
+        const result = await checkoutToBranchForSession(mockSession);
+        assert.strictEqual(result, true);
+    });`;
+
+content = content.replace(search, replace);
+fs.writeFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', content);
+console.log("Updated tests to hit coverage branch.");

--- a/test_coverage_update_4.js
+++ b/test_coverage_update_4.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+let content = fs.readFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', 'utf8');
+
+const search = `    it('checkoutToBranchForSession covers fallback to headCloneUrl', async () => {`;
+
+const replace = `    it('checkoutToBranchForSession covers early exit when both targetRemote and originRemote are found', async () => {
+        // Set up mock repositories and fetch info to trigger the condition
+        mockBranchInfo = {
+            headBranch: 'feature/pr-123',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo.git'
+        };
+
+        const mockRepo = {
+            state: {
+                remotes: [
+                    { remote: 'origin', fetchUrl: 'https://github.com/owner/repo.git' },
+                    { remote: 'fork-remote', fetchUrl: 'https://github.com/fork-owner/fork-repo.git' },
+                    { remote: 'extra', fetchUrl: 'https://github.com/extra/extra.git' } // Should not be processed if early exit works
+                ]
+            },
+            fetch: sandbox.stub().resolves(),
+            checkout: sandbox.stub().resolves()
+        };
+
+        mockGitAPI.repositories = [mockRepo];
+
+        const result = await checkoutToBranchForSession(mockSession);
+
+        assert.strictEqual(result, true);
+        assert.ok(mockRepo.fetch.calledWith('fork-remote'), 'Should use fork-remote');
+        assert.ok(mockRepo.checkout.calledWith('feature/pr-123'));
+    });
+
+    it('checkoutToBranchForSession covers fallback to headCloneUrl', async () => {`;
+
+content = content.replace(search, replace);
+fs.writeFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', content);
+console.log("Updated tests to hit coverage branch.");

--- a/test_coverage_update_5.js
+++ b/test_coverage_update_5.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+let content = fs.readFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', 'utf8');
+
+const search = `    it('checkoutToBranchForSession covers fallback to headCloneUrl', async () => {`;
+
+const replace = `    it('checkoutToBranchForSession covers fallback to headCloneUrl', async () => {
+        mockBranchInfo = {
+            headBranch: 'feature/pr-123',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo'
+        };
+
+        const mockRepo = {
+            state: {
+                remotes: [
+                    { remote: 'origin', fetchUrl: 'https://github.com/owner/repo.git' },
+                    { remote: 'fork-remote', fetchUrl: 'https://github.com/fork-owner/fork-repo.git' } // Ends with .git
+                ]
+            },
+            fetch: sandbox.stub().resolves(),
+            checkout: sandbox.stub().resolves()
+        };
+
+        mockGitAPI.repositories = [mockRepo];
+
+        const result = await checkoutToBranchForSession(mockSession);
+        assert.strictEqual(result, true);
+    });
+
+    it('checkoutToBranchForSession covers fallback to headCloneUrl when fetchUrl does not end with .git', async () => {`;
+
+content = content.replace(search, replace);
+fs.writeFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', content);
+console.log("Updated tests to hit coverage branch.");

--- a/test_coverage_update_6.js
+++ b/test_coverage_update_6.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+let content = fs.readFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', 'utf8');
+
+const search = `    it('checkoutToBranchForSession covers fallback to headCloneUrl', async () => {`;
+
+const replace = `    it('checkoutToBranchForSession covers fallback to headCloneUrl when fetchUrl does not end with .git and URL does not match', async () => {
+        mockBranchInfo = {
+            headBranch: 'feature/pr-123',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo.git'
+        };
+
+        const mockRepo = {
+            state: {
+                remotes: [
+                    { remote: 'origin', fetchUrl: 'https://github.com/owner/repo.git' },
+                    { remote: 'fork-remote', fetchUrl: 'https://github.com/other-owner/other-repo' } // No .git and different URL
+                ]
+            },
+            fetch: sandbox.stub().rejects(new Error('Stop')),
+            checkout: sandbox.stub().rejects(new Error('Stop')),
+            addRemote: sandbox.stub().rejects(new Error('Stop'))
+        };
+
+        mockGitAPI.repositories = [mockRepo];
+
+        const result = await checkoutToBranchForSession(mockSession);
+        assert.strictEqual(result, false);
+    });
+
+    it('checkoutToBranchForSession covers fallback to headCloneUrl', async () => {`;
+
+content = content.replace(search, replace);
+fs.writeFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', content);
+console.log("Updated tests to hit coverage branch.");

--- a/test_coverage_update_7.js
+++ b/test_coverage_update_7.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+let content = fs.readFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', 'utf8');
+
+const search = `    it('checkoutToBranchForSession covers fallback to headCloneUrl', async () => {`;
+
+const replace = `    it('checkoutToBranchForSession covers fallback to headCloneUrl when fetchUrl does not match and does not end with .git', async () => {
+        mockBranchInfo = {
+            headBranch: 'feature/pr-123',
+            headOwner: 'fork-owner',
+            headRepo: 'fork-repo',
+            headCloneUrl: 'https://github.com/fork-owner/fork-repo.git'
+        };
+
+        const mockRepo = {
+            state: {
+                remotes: [
+                    { remote: 'origin', fetchUrl: 'https://github.com/owner/repo.git' },
+                    { remote: 'fork-remote', fetchUrl: 'https://github.com/other-owner/other-repo.git' } // Ends with .git but different URL
+                ]
+            },
+            fetch: sandbox.stub().rejects(new Error('Stop')),
+            checkout: sandbox.stub().rejects(new Error('Stop')),
+            addRemote: sandbox.stub().rejects(new Error('Stop'))
+        };
+
+        mockGitAPI.repositories = [mockRepo];
+
+        const result = await checkoutToBranchForSession(mockSession);
+        assert.strictEqual(result, false);
+    });
+
+    it('checkoutToBranchForSession covers fallback to headCloneUrl', async () => {`;
+
+content = content.replace(search, replace);
+fs.writeFileSync('src/test/sessionContextMenu.checkout.unit.test.ts', content);
+console.log("Updated tests to hit coverage branch.");

--- a/test_equality.js
+++ b/test_equality.js
@@ -1,0 +1,87 @@
+const assert = require('assert');
+
+function runBaseline(remotes, headCloneUrl, headCloneUrlNoGit) {
+    let targetRemote = remotes.find(r =>
+        r.fetchUrl === headCloneUrl ||
+        (r.fetchUrl && r.fetchUrl.replace(/\.git$/, '') === headCloneUrlNoGit)
+    );
+
+    if (!targetRemote) {
+        const originRemote = remotes.find(r => r.remote === 'origin');
+        if (originRemote?.fetchUrl?.includes(`headOwner/headRepo`)) {
+            targetRemote = originRemote;
+        }
+    }
+    return targetRemote;
+}
+
+function runOptimized(remotes, headCloneUrl, headCloneUrlNoGit) {
+    let targetRemote = undefined;
+    let originRemote = undefined;
+
+    for (const r of remotes) {
+        if (!targetRemote) {
+            if (r.fetchUrl === headCloneUrl) {
+                targetRemote = r;
+            } else if (r.fetchUrl) {
+                const rFetchUrlNoGit = r.fetchUrl.endsWith('.git') ? r.fetchUrl.slice(0, -4) : r.fetchUrl;
+                if (rFetchUrlNoGit === headCloneUrlNoGit) {
+                    targetRemote = r;
+                }
+            }
+        }
+
+        if (!originRemote && r.remote === 'origin') {
+            originRemote = r;
+        }
+
+        // Both found, early exit
+        if (targetRemote && originRemote) break;
+    }
+
+    if (!targetRemote && originRemote?.fetchUrl?.includes(`headOwner/headRepo`)) {
+        targetRemote = originRemote;
+    }
+
+    return targetRemote;
+}
+
+const testCases = [
+    {
+        name: "Exact match headCloneUrl",
+        remotes: [{ remote: 'r1', fetchUrl: 'https://foo' }, { remote: 'r2', fetchUrl: 'https://headOwner/headRepo.git' }],
+        headCloneUrl: 'https://headOwner/headRepo.git',
+        headCloneUrlNoGit: 'https://headOwner/headRepo'
+    },
+    {
+        name: "NoGit match",
+        remotes: [{ remote: 'r1', fetchUrl: 'https://foo' }, { remote: 'r2', fetchUrl: 'https://headOwner/headRepo' }],
+        headCloneUrl: 'https://headOwner/headRepo.git',
+        headCloneUrlNoGit: 'https://headOwner/headRepo'
+    },
+    {
+        name: "Origin match",
+        remotes: [{ remote: 'r1', fetchUrl: 'https://foo' }, { remote: 'origin', fetchUrl: 'https://github.com/headOwner/headRepo.git' }],
+        headCloneUrl: 'https://some-fork/repo.git',
+        headCloneUrlNoGit: 'https://some-fork/repo'
+    },
+    {
+        name: "No match",
+        remotes: [{ remote: 'r1', fetchUrl: 'https://foo' }, { remote: 'r2', fetchUrl: 'https://bar' }],
+        headCloneUrl: 'https://some-fork/repo.git',
+        headCloneUrlNoGit: 'https://some-fork/repo'
+    }
+];
+
+testCases.forEach(tc => {
+    const resBase = runBaseline(tc.remotes, tc.headCloneUrl, tc.headCloneUrlNoGit);
+    const resOpt = runOptimized(tc.remotes, tc.headCloneUrl, tc.headCloneUrlNoGit);
+    try {
+        assert.deepStrictEqual(resBase, resOpt);
+        console.log(`PASS: ${tc.name}`);
+    } catch(e) {
+        console.log(`FAIL: ${tc.name}`);
+        console.log(`Baseline:`, resBase);
+        console.log(`Optimized:`, resOpt);
+    }
+});

--- a/update_remotes.js
+++ b/update_remotes.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+
+let content = fs.readFileSync('src/sessionContextMenu.ts', 'utf8');
+
+const search = `        const remotes: { remote: string; fetchUrl: string }[] = repository.state?.remotes || [];
+
+        const headCloneUrlNoGit = headCloneUrl.replace(/\\.git$/, '');
+
+        // headCloneUrlに一致するリモートを探す
+        let targetRemote = remotes.find(r =>
+            r.fetchUrl === headCloneUrl ||
+            (r.fetchUrl && r.fetchUrl.replace(/\\.git$/, '') === headCloneUrlNoGit)
+        );
+
+        // フォークからのPRで、対応するリモートがない場合
+        if (!targetRemote) {
+            // origin/upstreamを確認
+            const originRemote = remotes.find(r => r.remote === 'origin');
+
+            // originがheadCloneUrlと同じなら、originを使う
+            if (originRemote?.fetchUrl?.includes(\`\${headOwner}/\${headRepo}\`)) {
+                targetRemote = originRemote;
+            } else {`;
+
+const replace = `        const remotes: { remote: string; fetchUrl: string }[] = repository.state?.remotes || [];
+
+        const headCloneUrlNoGit = headCloneUrl.endsWith('.git') ? headCloneUrl.slice(0, -4) : headCloneUrl;
+
+        let targetRemote: { remote: string; fetchUrl: string } | undefined;
+        let originRemote: { remote: string; fetchUrl: string } | undefined;
+
+        for (const r of remotes) {
+            if (!targetRemote) {
+                if (r.fetchUrl === headCloneUrl) {
+                    targetRemote = r;
+                } else if (r.fetchUrl) {
+                    const rFetchUrlNoGit = r.fetchUrl.endsWith('.git') ? r.fetchUrl.slice(0, -4) : r.fetchUrl;
+                    if (rFetchUrlNoGit === headCloneUrlNoGit) {
+                        targetRemote = r;
+                    }
+                }
+            }
+
+            if (!originRemote && r.remote === 'origin') {
+                originRemote = r;
+            }
+
+            // 両方見つかれば早期終了
+            if (targetRemote && originRemote) break;
+        }
+
+        // フォークからのPRで、対応するリモートがない場合
+        if (!targetRemote) {
+            // originがheadCloneUrlと同じなら、originを使う
+            if (originRemote?.fetchUrl?.includes(\`\${headOwner}/\${headRepo}\`)) {
+                targetRemote = originRemote;
+            } else {`;
+
+if (content.includes(search)) {
+    content = content.replace(search, replace);
+    fs.writeFileSync('src/sessionContextMenu.ts', content);
+    console.log("Successfully patched src/sessionContextMenu.ts");
+} else {
+    console.log("Failed to find the string to replace.");
+}


### PR DESCRIPTION
💡 **What:** 
`src/sessionContextMenu.ts` の `fetchAndCheckoutFromPRInfo` メソッドにおいて、リポジトリのリモートリスト（`remotes`）を検索する際、2回連続で行われていた `Array.find()` の呼び出しを、1つの `for...of` ループで走査するように最適化しました。また、`.replace(/\.git$/, '')` による正規表現のオーバーヘッドを、`.endsWith('.git') ? ... : ...` の単純な文字列操作で回避するようにしました。

🎯 **Why:** 
元のコードでは、対象リモートを見つけるために `Array.find()` が複数回実行されており、配列を何度も走査していました。これを単一のループと条件分岐にまとめることで、メモリ割り当てやCPUサイクルなどのオーバーヘッドを削減し、リモートの解決処理のパフォーマンスを向上させるためです。

📊 **Measured Improvement:** 
ローカルのベンチマークにおいて、改善前と改善後を比較したところ、以下の結果が得られました。

* Baseline (Array.find x 2, regex replace): 45.36 ms (100,000 iterations)
* Optimized (Single pass `for...of`, endsWith/slice): 23.66 ms (100,000 iterations)

実行時間が約47%削減され、より効率的な検索処理が実現できました。

---
*PR created automatically by Jules for task [16234582667814959571](https://jules.google.com/task/16234582667814959571) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `fetchAndCheckoutFromPRInfo` 内でリモートを検索する際に使われていた2回の `Array.find()` を単一の `for...of` ループに統合し、`.replace(/\\.git$/, '')` を `endsWith('.git') ? slice(0, -4) : ...` に置き換えるパフォーマンス改善です。ロジック自体は概ね等価ですが、開発作業中に作られた7つのスクラッチファイルが本来含めるべきでないのにリポジトリに追加されています。

- `src/sessionContextMenu.ts`: 2回の `Array.find()` を単一ループに統合し動作等価性は確認済み。
- **スクラッチファイル7件**: `benchmark_*.js`・`fix_lint.js`・`patch.diff`・`test_equality.js`・`update_remotes.js` はすべて開発過程の一時ファイルであり、このPRから除外する必要があります。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

本体のロジック変更は動作等価だが、7つの開発用スクラッチファイルがリポジトリに混入しており、マージ前に除去が必要。

src/sessionContextMenu.ts のロジック変更自体は test_equality.js で等価性が確認されており問題ないものの、fix_lint.js や update_remotes.js のようにソースファイルを直接書き換えるスクリプトを含む7ファイルがそのままコミットされている。

benchmark_remotes.js、benchmark_small.js、benchmark_small_no_map.js、fix_lint.js、patch.diff、test_equality.js、update_remotes.js の7ファイルを削除する必要があります。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/sessionContextMenu.ts | 2回の Array.find() を単一 for...of ループに置き換え。ロジックは概ね同等だが、targetRemote 発見後も originRemote を探し続ける軽微な非効率あり。 |
| fix_lint.js | src/sessionContextMenu.ts をスクリプトから直接書き換える開発用ファイル。リポジトリに含めるべきでない。 |
| patch.diff | AIツール固有のSEARCH/REPLACE形式を含む非標準パッチファイル。開発作業の残骸。 |
| benchmark_remotes.js | 開発中に使用したベンチマーク用スクラッチファイル。リポジトリに含めるべきでない。 |
| test_equality.js | 等価性を検証するスクラッチテストファイル。リポジトリに含めるべきでない。 |
| update_remotes.js | src/sessionContextMenu.ts を直接パッチする開発用スクリプト。リポジトリに含めるべきでない。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
benchmark_remotes.js:1
**開発用スクラッチファイルがリポジトリに混入**

`benchmark_remotes.js`、`benchmark_small.js`、`benchmark_small_no_map.js`、`fix_lint.js`、`patch.diff`、`test_equality.js`、`update_remotes.js` の7ファイルは、実装作業中に使用した一時的な開発用ファイルであり、本リポジトリのソース管理対象として不適切です。特に `fix_lint.js` と `update_remotes.js` は `src/sessionContextMenu.ts` をスクリプトから直接書き換えるファイルであり、`patch.diff` はAIツール固有のSEARCH/REPLACE形式であって標準的なgitパッチではありません。これらはすべて本PRから除外すべきです。

### Issue 2 of 2
src/sessionContextMenu.ts:563-583
**`targetRemote` 発見後も `originRemote` 探索を継続する軽微な非効率**

元のコードでは `targetRemote` が見つかった場合、2回目の `find()` (= `originRemote` の探索) はまったく実行されませんでした。新しいコードでは `targetRemote` が見つかっても、`originRemote` がまだ未発見であれば末尾まで配列を走査し続けます（`break` は両方揃った場合のみ）。`originRemote` は `!targetRemote` のブロックでしか使われないため、この追加走査は常に無駄になります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: optimize remotes finding with si..."](https://github.com/hiroki-org/jules-extension/commit/0f63e2782e0c7c45a8984c2d07ee76abb3b48ce0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32546958)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->