### PR TITLE
🎨 Palette: empty-stateの動的更新をスクリーンリーダーにアナウンスするよう改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-11 - Dynamic ARIA Labeling for Context-Aware Inputs
 **Learning:** When using context-aware placeholders (like dynamically changing the placeholder from "Select a session to start typing" to "Enter message (Ctrl/Cmd+Enter to send)"), it is crucial to synchronize these changes with ARIA attributes (`aria-label` and `title`) to ensure screen readers provide accurate, up-to-date context, preventing users from becoming disoriented by outdated or mismatched labels.
 **Action:** Next time an input element's visual cue (like a placeholder) is dynamically updated based on state, immediately map that updated string to the element's `aria-label` and `title` properties within the same DOM update cycle.
+
+## 2025-05-19 - ARIA Status Announcements for Empty States
+**Learning:** When dynamic UI areas transition to or from an empty state (e.g., from "Welcome" to "Ready to assist" when selecting a session), screen reader users are often left unaware of the change unless the update is explicitly announced. Relying on default semantic markup isn't enough because the outer container doesn't announce content insertions implicitly.
+**Action:** Next time an `empty-state` or similar "no data" placeholder is dynamically rendered or swapped, ensure it is wrapped in an element with `role="status"`, `aria-live="polite"`, and `aria-atomic="true"` to guarantee the change is reliably announced.

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -510,7 +510,7 @@ export function getChatWebviewHtml(
     nonce +
     '">' +
     CHAT_CSS +
-    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
+    '</style></head><body><div id="emptyStateStatus" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
     nonce +
     '" src="' +
     domPurifyScriptUri +

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -8,6 +8,7 @@ function createChatScriptHarness(
   let chatInnerHTML = "";
   let chatInnerHTMLSetCount = 0;
   const chatAttributes: Record<string, string> = {};
+  const emptyStateStatusAttributes: Record<string, string> = {};
   const listeners: Record<string, Record<string, any>> = {
     chat: {},
     messageInput: {},
@@ -35,6 +36,13 @@ function createChatScriptHarness(
         };
       },
       querySelectorAll: () => [],
+    },
+    emptyStateStatus: {
+      textContent: "",
+      setAttribute: (name: string, value: string) => {
+        emptyStateStatusAttributes[name] = value;
+      },
+      getAttribute: (name: string) => emptyStateStatusAttributes[name] ?? null,
     },
     typing: { classList: { toggle: () => {} } },
     messageInput: {
@@ -512,6 +520,7 @@ suite("chatAssets unit tests", () => {
     assert.ok(!CHAT_CSS.includes("height: 100%; opacity: 0; animation: fade-in"));
     assert.ok(CHAT_CSS.includes("@media (prefers-reduced-motion: reduce)"));
     assert.ok(CHAT_CSS.includes(".empty-state { animation: none; opacity: 1; }"));
+    assert.ok(CHAT_CSS.includes(".sr-only"));
   });
 
   test("CHAT_JS should render welcome empty state when no session is selected", () => {
@@ -524,9 +533,15 @@ suite("chatAssets unit tests", () => {
 
     const emptyState = harness.elements.chat.querySelector(".empty-state");
     assert.ok(emptyState);
-    assert.strictEqual(harness.elements.chat.getAttribute("role"), "status");
-    assert.strictEqual(harness.elements.chat.getAttribute("aria-live"), "polite");
-    assert.strictEqual(harness.elements.chat.getAttribute("aria-atomic"), "true");
+    assert.strictEqual(harness.elements.chat.getAttribute("role"), null);
+    assert.strictEqual(harness.elements.chat.getAttribute("aria-live"), null);
+    assert.strictEqual(harness.elements.emptyStateStatus.getAttribute("role"), "status");
+    assert.strictEqual(harness.elements.emptyStateStatus.getAttribute("aria-live"), "polite");
+    assert.strictEqual(harness.elements.emptyStateStatus.getAttribute("aria-atomic"), "true");
+    assert.strictEqual(
+      harness.elements.emptyStateStatus.textContent,
+      "Welcome to Jules. Select a session or create a new one to begin.",
+    );
     assert.ok(emptyState.textContent.includes("Welcome to Jules"));
     assert.ok(emptyState.textContent.includes("Select a session or create a new one"));
   });
@@ -541,11 +556,35 @@ suite("chatAssets unit tests", () => {
 
     const emptyState = harness.elements.chat.querySelector(".empty-state");
     assert.ok(emptyState);
-    assert.strictEqual(harness.elements.chat.getAttribute("role"), "status");
-    assert.strictEqual(harness.elements.chat.getAttribute("aria-live"), "polite");
-    assert.strictEqual(harness.elements.chat.getAttribute("aria-atomic"), "true");
+    assert.strictEqual(harness.elements.chat.getAttribute("role"), null);
+    assert.strictEqual(harness.elements.chat.getAttribute("aria-live"), null);
+    assert.strictEqual(harness.elements.emptyStateStatus.getAttribute("role"), "status");
+    assert.strictEqual(harness.elements.emptyStateStatus.getAttribute("aria-live"), "polite");
+    assert.strictEqual(harness.elements.emptyStateStatus.getAttribute("aria-atomic"), "true");
+    assert.strictEqual(
+      harness.elements.emptyStateStatus.textContent,
+      "Ready to assist. Type a message to start interacting with Jules.",
+    );
     assert.ok(emptyState.textContent.includes("Ready to assist"));
     assert.ok(emptyState.textContent.includes("Type a message to start interacting"));
+  });
+
+  test("CHAT_JS should keep regular message rendering out of the empty state live region", () => {
+    const harness = createChatScriptHarness({ sanitize: (html) => html });
+
+    harness.postWindowMessage({
+      type: "chatState",
+      payload: {
+        sessionId: "session-1",
+        messages: [{ role: "assistant", html: "<p>Hello</p>" }],
+        isTyping: false,
+      },
+    });
+
+    assert.strictEqual(harness.elements.chat.getAttribute("role"), null);
+    assert.strictEqual(harness.elements.chat.getAttribute("aria-live"), null);
+    assert.strictEqual(harness.elements.emptyStateStatus.textContent, "");
+    assert.ok(harness.elements.chat.innerHTML.includes("<p>Hello</p>"));
   });
 
   test("CHAT_JS should not reinsert the same empty state repeatedly", () => {

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -7,6 +7,7 @@ function createChatScriptHarness(
 ) {
   let chatInnerHTML = "";
   let chatInnerHTMLSetCount = 0;
+  const chatAttributes: Record<string, string> = {};
   const listeners: Record<string, Record<string, any>> = {
     chat: {},
     messageInput: {},
@@ -22,7 +23,20 @@ function createChatScriptHarness(
       get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
       scrollTop: 0,
       scrollHeight: 0,
+      setAttribute: (name: string, value: string) => { chatAttributes[name] = value; },
+      getAttribute: (name: string) => chatAttributes[name] ?? null,
       addEventListener: (evt: string, cb: any) => { listeners.chat[evt] = cb; },
+      querySelector: (selector: string) => {
+        if (selector !== ".empty-state" || !chatInnerHTML.includes('class="empty-state"')) {
+          return null;
+        }
+        return {
+          textContent: chatInnerHTML
+            .replace(/<[^>]*>/g, "")
+            .replace(/\s+/g, " ")
+            .trim(),
+        };
+      },
       querySelectorAll: () => [],
     },
     typing: { classList: { toggle: () => {} } },
@@ -511,9 +525,13 @@ suite("chatAssets unit tests", () => {
       payload: { sessionId: null, messages: [], isTyping: false },
     });
 
-    assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state" role="status" aria-live="polite" aria-atomic="true"'));
-    assert.ok(harness.elements.chat.innerHTML.includes("Welcome to Jules"));
-    assert.ok(harness.elements.chat.innerHTML.includes("Select a session or create a new one"));
+    const emptyState = harness.elements.chat.querySelector(".empty-state");
+    assert.ok(emptyState);
+    assert.strictEqual(harness.elements.chat.getAttribute("role"), "status");
+    assert.strictEqual(harness.elements.chat.getAttribute("aria-live"), "polite");
+    assert.strictEqual(harness.elements.chat.getAttribute("aria-atomic"), "true");
+    assert.ok(emptyState.textContent.includes("Welcome to Jules"));
+    assert.ok(emptyState.textContent.includes("Select a session or create a new one"));
   });
 
   test("CHAT_JS should render ready empty state when a session has no messages", () => {
@@ -524,9 +542,13 @@ suite("chatAssets unit tests", () => {
       payload: { sessionId: "session-1", messages: [], isTyping: false },
     });
 
-    assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state" role="status" aria-live="polite" aria-atomic="true"'));
-    assert.ok(harness.elements.chat.innerHTML.includes("Ready to assist"));
-    assert.ok(harness.elements.chat.innerHTML.includes("Type a message to start interacting"));
+    const emptyState = harness.elements.chat.querySelector(".empty-state");
+    assert.ok(emptyState);
+    assert.strictEqual(harness.elements.chat.getAttribute("role"), "status");
+    assert.strictEqual(harness.elements.chat.getAttribute("aria-live"), "polite");
+    assert.strictEqual(harness.elements.chat.getAttribute("aria-atomic"), "true");
+    assert.ok(emptyState.textContent.includes("Ready to assist"));
+    assert.ok(emptyState.textContent.includes("Type a message to start interacting"));
   });
 
   test("CHAT_JS should not reinsert the same empty state repeatedly", () => {
@@ -619,7 +641,15 @@ suite("chatAssets unit tests", () => {
 
   test("CHAT_JS updateUI should properly configure disabled states and ARIA attributes", () => {
     const elements: any = {
-      chat: { innerHTML: "", scrollTop: 0, scrollHeight: 0, addEventListener: () => {}, querySelectorAll: () => [] },
+      chat: {
+        innerHTML: "",
+        scrollTop: 0,
+        scrollHeight: 0,
+        addEventListener: () => {},
+        setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
+        getAttribute: function(k: string) { return (this as any)[k] ?? null; },
+        querySelectorAll: () => [],
+      },
       typing: { classList: { toggle: () => {} } },
       messageInput: {
         value: "",

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -8,7 +8,11 @@ function createChatScriptHarness(
   let chatInnerHTML = "";
   let chatInnerHTMLSetCount = 0;
   const chatAttributes: Record<string, string> = {};
-  const emptyStateStatusAttributes: Record<string, string> = {};
+  const emptyStateStatusAttributes: Record<string, string> = {
+    role: "status",
+    "aria-live": "polite",
+    "aria-atomic": "true",
+  };
   const listeners: Record<string, Record<string, any>> = {
     chat: {},
     messageInput: {},
@@ -32,7 +36,7 @@ function createChatScriptHarness(
           return null;
         }
         return {
-          textContent: chatInnerHTML,
+          textContent: chatInnerHTML.replace(/<[^>]+>/g, ""),
         };
       },
       querySelectorAll: () => [],

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -511,7 +511,7 @@ suite("chatAssets unit tests", () => {
       payload: { sessionId: null, messages: [], isTyping: false },
     });
 
-    assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state" role="status" aria-live="polite" aria-atomic="true"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Welcome to Jules"));
     assert.ok(harness.elements.chat.innerHTML.includes("Select a session or create a new one"));
   });
@@ -524,7 +524,7 @@ suite("chatAssets unit tests", () => {
       payload: { sessionId: "session-1", messages: [], isTyping: false },
     });
 
-    assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state" role="status" aria-live="polite" aria-atomic="true"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Ready to assist"));
     assert.ok(harness.elements.chat.innerHTML.includes("Type a message to start interacting"));
   });

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -31,10 +31,7 @@ function createChatScriptHarness(
           return null;
         }
         return {
-          textContent: chatInnerHTML
-            .replace(/<[^>]*>/g, "")
-            .replace(/\s+/g, " ")
-            .trim(),
+          textContent: chatInnerHTML,
         };
       },
       querySelectorAll: () => [],

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,6 +1,27 @@
 import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
+function approximateTextContent(html: string): string {
+  let text = "";
+  let insideTag = false;
+
+  for (const char of html) {
+    if (char === "<") {
+      insideTag = true;
+      continue;
+    }
+    if (char === ">") {
+      insideTag = false;
+      continue;
+    }
+    if (!insideTag) {
+      text += char;
+    }
+  }
+
+  return text;
+}
+
 function createChatScriptHarness(
   domPurify?: { sanitize: (html: string, config: any) => any },
   computedStyle = { borderTopWidth: "1px", borderBottomWidth: "1px" },
@@ -36,7 +57,7 @@ function createChatScriptHarness(
           return null;
         }
         return {
-          textContent: chatInnerHTML.replace(/<[^>]+>/g, ""),
+          textContent: approximateTextContent(chatInnerHTML),
         };
       },
       querySelectorAll: () => [],

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -84,6 +84,8 @@ suite("Chat View Unit Test Suite", () => {
       extensionUri,
     );
     assert.ok(html.includes('id="typing"'));
+    assert.ok(html.includes('id="emptyStateStatus"'));
+    assert.ok(html.includes('class="sr-only"'));
     assert.ok(html.includes('type:"sendMessage"') || html.includes('type: "sendMessage"'));
     assert.ok(html.includes("requestInitialState"));
     assert.ok(html.includes("copy-code-button"));

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -2,6 +2,7 @@ export const CHAT_CSS = `
 * { box-sizing: border-box; }
 body { margin: 0; padding: 10px; color: var(--vscode-editor-foreground); background: var(--vscode-editor-background); font-family: var(--vscode-font-family); height: 100vh; display: flex; flex-direction: column; gap: 10px; }
 #chat { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 10px; padding-right: 2px; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; border: 0; }
 .message { display: flex; flex-direction: column; max-width: 92%; animation: slide-in .18s ease-out; gap: 4px; }
 .message.user { margin-left: auto; align-items: flex-end; }
 .message.assistant { margin-right: auto; align-items: flex-start; }
@@ -65,15 +66,18 @@ export const CHAT_JS = `(function() {
     : { postMessage: (m) => console.warn("VSCode API unavailable", m) };
 
   const chatContainer = document.getElementById("chat");
+  const emptyStateStatus = document.getElementById("emptyStateStatus");
   const typingIndicator = document.getElementById("typing");
   const messageInput = document.getElementById("messageInput");
   const sendButton = document.getElementById("sendButton");
   const sessionLabel = document.getElementById("sessionLabel");
   const DETAILS_BUSY_TIMEOUT_MS = 15000;
 
-  chatContainer.setAttribute("role", "status");
-  chatContainer.setAttribute("aria-live", "polite");
-  chatContainer.setAttribute("aria-atomic", "true");
+  if (emptyStateStatus) {
+    emptyStateStatus.setAttribute("role", "status");
+    emptyStateStatus.setAttribute("aria-live", "polite");
+    emptyStateStatus.setAttribute("aria-atomic", "true");
+  }
 
   let state = { sessionId: null, messages: [], isTyping: false };
   let detailsCache = {}; // "activityId|detailType|index" -> html
@@ -285,14 +289,23 @@ export const CHAT_JS = `(function() {
       const emptyStateContent = state.sessionId
         ? '<h3>Ready to assist</h3><p>Type a message to start interacting with Jules.</p>'
         : '<h3>Welcome to Jules</h3><p>Select a session or create a new one to begin.</p>';
+      const emptyStateAnnouncement = state.sessionId
+        ? "Ready to assist. Type a message to start interacting with Jules."
+        : "Welcome to Jules. Select a session or create a new one to begin.";
       const emptyStateKey = state.sessionId ? "ready" : "welcome";
       const emptyStateHtml = \`<div class="empty-state">\${emptyStateContent}</div>\`;
       if (renderedEmptyStateKey !== emptyStateKey) {
         chatContainer.innerHTML = emptyStateHtml;
+        if (emptyStateStatus) {
+          emptyStateStatus.textContent = emptyStateAnnouncement;
+        }
         renderedEmptyStateKey = emptyStateKey;
       }
     } else {
       renderedEmptyStateKey = null;
+      if (emptyStateStatus) {
+        emptyStateStatus.textContent = "";
+      }
       chatContainer.innerHTML = state.messages.map(m => {
         const sanitizedHtml = sanitizeHtml(m.html);
         const roleClass = m.role === "user" ? "user" : "assistant";

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -71,10 +71,15 @@ export const CHAT_JS = `(function() {
   const sessionLabel = document.getElementById("sessionLabel");
   const DETAILS_BUSY_TIMEOUT_MS = 15000;
 
+  chatContainer.setAttribute("role", "status");
+  chatContainer.setAttribute("aria-live", "polite");
+  chatContainer.setAttribute("aria-atomic", "true");
+
   let state = { sessionId: null, messages: [], isTyping: false };
   let detailsCache = {}; // "activityId|detailType|index" -> html
   let expandedDetails = new Set(); // set of "activityId|detailType|index"
   let detailsBusyTimeouts = {}; // "activityId|detailType|index" -> timeout id
+  let renderedEmptyStateKey = null;
 
   const DOMPURIFY_ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto|tel|callto|sms|cid|xmpp|vscode-webview-resource):|(?![a-z][a-z0-9+.-]*:))/i;
   const SANITIZATION_FAILURE_HTML = '<span class="message-unavailable" role="status" aria-label="Message unavailable">Message unavailable</span>';
@@ -280,11 +285,14 @@ export const CHAT_JS = `(function() {
       const emptyStateContent = state.sessionId
         ? '<h3>Ready to assist</h3><p>Type a message to start interacting with Jules.</p>'
         : '<h3>Welcome to Jules</h3><p>Select a session or create a new one to begin.</p>';
-      const emptyStateHtml = \`<div class="empty-state" role="status" aria-live="polite" aria-atomic="true">\${emptyStateContent}</div>\`;
-      if (chatContainer.innerHTML !== emptyStateHtml) {
+      const emptyStateKey = state.sessionId ? "ready" : "welcome";
+      const emptyStateHtml = \`<div class="empty-state">\${emptyStateContent}</div>\`;
+      if (renderedEmptyStateKey !== emptyStateKey) {
         chatContainer.innerHTML = emptyStateHtml;
+        renderedEmptyStateKey = emptyStateKey;
       }
     } else {
+      renderedEmptyStateKey = null;
       chatContainer.innerHTML = state.messages.map(m => {
         const sanitizedHtml = sanitizeHtml(m.html);
         const roleClass = m.role === "user" ? "user" : "assistant";

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -73,12 +73,6 @@ export const CHAT_JS = `(function() {
   const sessionLabel = document.getElementById("sessionLabel");
   const DETAILS_BUSY_TIMEOUT_MS = 15000;
 
-  if (emptyStateStatus) {
-    emptyStateStatus.setAttribute("role", "status");
-    emptyStateStatus.setAttribute("aria-live", "polite");
-    emptyStateStatus.setAttribute("aria-atomic", "true");
-  }
-
   let state = { sessionId: null, messages: [], isTyping: false };
   let detailsCache = {}; // "activityId|detailType|index" -> html
   let expandedDetails = new Set(); // set of "activityId|detailType|index"

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -280,7 +280,7 @@ export const CHAT_JS = `(function() {
       const emptyStateContent = state.sessionId
         ? '<h3>Ready to assist</h3><p>Type a message to start interacting with Jules.</p>'
         : '<h3>Welcome to Jules</h3><p>Select a session or create a new one to begin.</p>';
-      const emptyStateHtml = \`<div class="empty-state">\${emptyStateContent}</div>\`;
+      const emptyStateHtml = \`<div class="empty-state" role="status" aria-live="polite" aria-atomic="true">\${emptyStateContent}</div>\`;
       if (chatContainer.innerHTML !== emptyStateHtml) {
         chatContainer.innerHTML = emptyStateHtml;
       }


### PR DESCRIPTION
💡 **What:** 
チャットビュー（`src/webview/chatAssets.ts`）で動的に表示される `empty-state`（セッション未選択時やメッセージがない時のプレースホルダー表示）の要素に対し、`role="status"`, `aria-live="polite"`, `aria-atomic="true"` の属性を追加しました。

🎯 **Why:** 
セッションを選択した際など、UIのメイン領域が「Welcome to Jules」から「Ready to assist」といった空状態メッセージに動的に切り替わりますが、これらの更新はスクリーンリーダーに自動でアナウンスされません。これをステータス領域としてマークすることで、ユーザーがUIのコンテキスト変化（メッセージの入力を待機している状態など）を即座に把握できるようになります。

📸 **Before/After:**
*(Visual changes remain the same, only accessibility markup was modified)*

♿ **Accessibility:** 
動的な空状態（Empty State）の変更が `aria-live` 領域を通じてスクリーンリーダーに正確かつ自動的に通知されるようになりました。これにより、視覚に障害のあるユーザーがセッションの切り替えに伴うUIの準備状況を正確に把握できるようになります。

---
*PR created automatically by Jules for task [3406622419345445831](https://jules.google.com/task/3406622419345445831) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

空状態（empty-state）の動的切り替えをスクリーンリーダーに通知するため、常時 DOM に存在する専用ステータス要素 `#emptyStateStatus` を追加しました。これにより、以前フラグが立てられた「動的挿入 `aria-live` 領域は信頼性が低い」「`#chat` に `aria-atomic` を付けると全メッセージが再読み上げされる」の両問題を解消しています。

- `#emptyStateStatus`（`role="status" aria-live="polite" aria-atomic="true"`）を初期 HTML に静的追加し、空状態切り替え時に `textContent` のみを更新することで確実なアナウンスを実現
- `#chat` コンテナへの `aria-live` 付与を廃止し、メッセージリスト全体の不要な再読み上げを防止
- `renderedEmptyStateKey` キャッシュにより同一状態での重複アナウンスを抑制し、テストも同パターンを網羅するよう更新
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はアクセシビリティのマークアップのみに限定されており、既存のメッセージ描画ロジックやセッション管理には影響しないため、安全にマージ可能です。

`#emptyStateStatus` は静的に DOM へ追加されるため aria-live 領域の信頼性問題を解消しており、`#chat` への aria-live 付与廃止によってメッセージ全件の再読み上げも回避されています。`renderedEmptyStateKey` による重複防止ロジックも正しく機能しており、テストが主要シナリオを網羅しています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | 永続的なステータス要素 `#emptyStateStatus` への更新ロジックを追加。`renderedEmptyStateKey` で重複アナウンスを防止し、`#chat` への aria-live 属性付与を廃止。実装は ARIA のベストプラクティスに準拠している。 |
| src/chatView.ts | `#emptyStateStatus` div を初期 HTML テンプレートに静的追加。`role="status"`, `aria-live="polite"`, `aria-atomic="true"`, `class="sr-only"` が正しく設定されている。 |
| src/test/chatAssets.unit.test.ts | `emptyStateStatus` モックを追加し、空状態の ARIA 属性・テキスト内容・メッセージ表示時のクリアを検証するテストケースを追加。新規テスト「keep regular message rendering out of the empty state live region」も追加済み。 |
| src/test/chatView.unit.test.ts | `id="emptyStateStatus"` と `class="sr-only"` が生成 HTML に含まれることを確認するアサーションを追加。 |
| .Jules/palette.md | 空状態用の永続ステータス要素パターンに関する学習記録を追加。実装内容と一致している。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W as Webview HTML
    participant C as chatAssets.js (CHAT_JS)
    participant ESS as #emptyStateStatus (aria-live)
    participant CH as #chat

    Note over W: ページ初期化時に #emptyStateStatus が静的に DOM へ追加済み

    W->>C: "chatState {sessionId: null, messages: []}"
    C->>C: renderMessages() — empty state branch
    C->>CH: "innerHTML = empty-state Welcome"
    C->>ESS: "textContent = "Welcome to Jules...""
    Note over ESS: スクリーンリーダーがアナウンス

    W->>C: "chatState {sessionId: "s1", messages: []}"
    C->>C: renderMessages() — empty state branch (key changed)
    C->>CH: "innerHTML = empty-state Ready"
    C->>ESS: "textContent = "Ready to assist...""
    Note over ESS: スクリーンリーダーがアナウンス

    W->>C: "chatState {sessionId: "s1", messages: [{...}]}"
    C->>C: renderMessages() — messages branch
    C->>ESS: "textContent = "" (クリア)"
    C->>CH: "innerHTML = message HTML"
    Note over ESS: 空テキストのため読み上げなし
```

<sub>Reviews (12): Last reviewed commit: ["merge main into empty state aria PR"](https://github.com/hiroki-org/jules-extension/commit/a15ffcfd586acd25689c9e6f63cf4456ed0f696c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32922182)</sub>

<!-- /greptile_comment -->