### PR TITLE
🛡️ Sentinel: [CRITICAL] xmpタグによるデフォルトXSSの修正のためsanitize-htmlを更新

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,3 +13,7 @@
 **Vulnerability:** Use of innerHTML in composer.ts to set loading spinner.
 **Learning:** Assigning strings containing HTML to innerHTML is inherently risky and can lead to XSS if user inputs are ever involved. Using document.createElement and appendChild is the safe and secure approach.
 **Prevention:** Avoid .innerHTML and use safer DOM APIs like textContent, document.createElement, and appendChild.
+## 2026-05-20 - Default XSS via xmp tag in sanitize-html
+**Vulnerability:** Found a sanitizer bypass in `sanitize-html` <= 2.17.3 where the default configuration allowed arbitrary HTML and scripts to execute when wrapped inside an `<xmp>` tag. The library did not treat `<xmp>` as a tag whose entire contents should be discarded by default.
+**Learning:** Default configurations of security libraries may harbor silent bypasses if obscure HTML tags (like `<xmp>`) are treated as text nodes during parsing but re-interpreted as active markup when rendered.
+**Prevention:** Regularly update dependencies (like `sanitize-html`), especially those performing security-critical tasks like sanitization. Additionally, explicitly configure sanitizers to discard contents of dangerous or obscure elements rather than relying solely on default settings.

--- a/package.json
+++ b/package.json
@@ -419,7 +419,7 @@
     "https-proxy-agent": "^7.0.6",
     "is-glob": "^4.0.3",
     "markdown-it": "^14.1.1",
-    "sanitize-html": "^2.17.3",
+    "sanitize-html": "^2.17.4",
     "shiki": "^4.0.2",
     "socks-proxy-agent": "^8.0.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^14.1.1
         version: 14.1.1
       sanitize-html:
-        specifier: ^2.17.3
-        version: 2.17.3
+        specifier: ^2.17.4
+        version: 2.17.4
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
@@ -822,6 +822,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1393,6 +1396,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -1747,8 +1753,8 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
-  sanitize-html@2.17.3:
-    resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
+  sanitize-html@2.17.4:
+    resolution: {integrity: sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -2852,6 +2858,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dayjs@1.11.20: {}
+
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -3515,6 +3523,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.20
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -3928,12 +3940,13 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
-  sanitize-html@2.17.3:
+  sanitize-html@2.17.4:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
       htmlparser2: 10.1.0
       is-plain-object: 5.0.0
+      launder: 1.7.1
       parse-srcset: 1.0.2
       postcss: 8.5.14
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: sanitize-html <= 2.17.3 のデフォルト設定では、<xmp>タグ内のコンテンツを破棄しません。<xmp>はプレーンテキスト要素として扱われるため、中に潜ませた悪意のあるスクリプトがサニタイズをバイパスし、サニタイズされたHTMLがブラウザでレンダリングされた際に実行されてしまいます。
🎯 Impact: サニタイズされたHTMLを直接レンダリングするコンポーネントにおける蓄積型クロスサイトスクリプティング (Stored XSS)
🔧 Fix: sanitize-html を ^2.17.4 にアップグレードし、デフォルト設定で許可されていない <xmp> 要素のコンテンツが正しく破棄されるようにしました。
✅ Verification: pnpm test:unit、pnpm test、pnpm run lint、pnpm run check-typesを実行して確認しました。

---
*PR created automatically by Jules for task [18169016150381101599](https://jules.google.com/task/18169016150381101599) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`sanitize-html` を `^2.17.3` から `^2.17.4` にアップグレードし、`<xmp>` タグ内コンテンツがサニタイズをバイパスしてXSSを引き起こす脆弱性 (CVE-2026-44990) を修正します。あわせて、当該脆弱性の詳細を `sentinel.md` にセキュリティ学習記録として追記しています。

- `package.json` および `pnpm-lock.yaml` の `sanitize-html` バージョンを 2.17.4 に更新。`<xmp>` タグのコンテンツが正しく破棄されるようになります。
- `sanitize-html@2.17.4` の新しいトランジティブ依存として `launder@1.7.1` と `dayjs@1.11.20` が追加されています（ともに apostrophecms 管理の既存パッケージ）。
- `.jules/sentinel.md` に今回の脆弱性・教訓・予防策が明確に文書化されました。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは既知のXSS脆弱性を修正するための依存バージョン更新のみで、アプリケーションコードへの変更はなく、マージは安全です。

`sanitize-html` のパッチバンプという最小限の変更で、`<xmp>` タグ経由のXSSを適切に塞いでいます。新たに追加されるトランジティブ依存（`launder`・`dayjs`）は同組織のパッケージであり、ロックファイルのハッシュも正しく記録されています。アプリケーションの既存コードは一切変更されていないため、リグレッションリスクは極めて低いです。

特に注意が必要なファイルはありません。`pnpm-lock.yaml` の新しいトランジティブ依存エントリを念のため確認することを推奨します。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | `sanitize-html` の依存バージョンを `^2.17.3` から `^2.17.4` に更新し、`<xmp>` タグ経由のXSS脆弱性 (CVE-2026-44990) を修正 |
| pnpm-lock.yaml | `sanitize-html@2.17.4` へのロックファイル更新。新たなトランジティブ依存として `launder@1.7.1` と `dayjs@1.11.20` が追加された |
| .jules/sentinel.md | `<xmp>` タグのXSS脆弱性に関するセキュリティ学習記録を追加。脆弱性・教訓・予防策が適切に文書化されている |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser as ブラウザ
    participant App as アプリ
    participant SH as sanitize-html

    Note over Browser,SH: 修正前 (v2.17.3)
    Browser->>App: "悪意あるHTML: xmpタグ内スクリプト"
    App->>SH: "sanitize(html)"
    SH-->>App: "xmpコンテンツをそのまま返す (バイパス)"
    App->>Browser: "サニタイズ済みHTMLをレンダリング"
    Browser->>Browser: "XSS実行 (スクリプトが動作)"

    Note over Browser,SH: 修正後 (v2.17.4)
    Browser->>App: "悪意あるHTML: xmpタグ内スクリプト"
    App->>SH: "sanitize(html)"
    SH-->>App: "xmpコンテンツを破棄して空文字を返す"
    App->>Browser: "安全なHTMLをレンダリング"
    Browser->>Browser: "スクリプト未実行 (安全)"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
pnpm-lock.yaml:3523-3527
**新しいトランジティブ依存の追加を確認してください**

`sanitize-html@2.17.4` により、`launder@1.7.1`（データ型サニタイズ用）と `dayjs@1.11.20`（日付操作ライブラリ）という2つの新しいパッケージがトランジティブ依存として追加されています。`launder` は `sanitize-html` と同じ apostrophecms 組織が管理するパッケージですが、HTMLサニタイズライブラリが日付処理ライブラリ（`dayjs`）を必要とするのは珍しい組み合わせです。サプライチェーンの観点から、これらのパッケージが意図どおりのものであることを確認することを推奨します。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[CRITICAL\] xmpタグによるデフォルトXS..."](https://github.com/hiroki-org/jules-extension/commit/0e843d8c76aaba49e537ae17a2cd553d98e4ada2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32927464)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->