### PR TITLE
🎨 Palette: sessionLabel の省略表示に対するツールチップと aria-label の追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-05-11 - Dynamic ARIA Labeling for Context-Aware Inputs
 **Learning:** When using context-aware placeholders (like dynamically changing the placeholder from "Select a session to start typing" to "Enter message (Ctrl/Cmd+Enter to send)"), it is crucial to synchronize these changes with ARIA attributes (`aria-label` and `title`) to ensure screen readers provide accurate, up-to-date context, preventing users from becoming disoriented by outdated or mismatched labels.
 **Action:** Next time an input element's visual cue (like a placeholder) is dynamically updated based on state, immediately map that updated string to the element's `aria-label` and `title` properties within the same DOM update cycle.
+## 2025-05-20 - sessionLabel Tooltips and ARIA-labels
+**Learning:** When applying CSS text truncation (e.g., `text-overflow: ellipsis`) to dynamically populated UI elements like the `sessionLabel`, the full text is hidden from the user. Even if screen readers can read the full text via textContent, sighted users cannot view the full label.
+**Action:** Next time an element is styled with `text-overflow: ellipsis`, ensure a `title` attribute matching the `textContent` is explicitly set so users can read the full content on hover. In addition, setting `aria-label` to match ensures consistency across both visual and auditory interfaces.

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -41,7 +41,11 @@ function createChatScriptHarness(
       setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
       addEventListener: () => {},
     },
-    sessionLabel: { textContent: "" },
+    sessionLabel: {
+      textContent: "",
+      title: "",
+      setAttribute: function(k: string, v: string) { (this as any)[k] = v; }
+    },
     composer: { addEventListener: (evt: string, cb: any) => { listeners.composer[evt] = cb; } },
   };
   const messageListeners: Array<(event: { data: any }) => void> = [];
@@ -636,7 +640,11 @@ suite("chatAssets unit tests", () => {
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
       },
-      sessionLabel: { textContent: "" },
+      sessionLabel: {
+        textContent: "",
+        title: "",
+        setAttribute: function(k: string, v: string) { (this as any)[k] = v; }
+      },
       composer: { addEventListener: () => {} },
     };
 
@@ -668,6 +676,8 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton.title, "Select a session to send a message");
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Select a session to send a message)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: None selected");
+    assert.strictEqual(elements.sessionLabel.title, "Session: None selected");
+    assert.strictEqual(elements.sessionLabel["aria-label"], "Session: None selected");
 
     // (2) sessionId present + empty input value
     elements.messageInput.value = "   "; // whitespace
@@ -677,6 +687,8 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton.title, "Type a message to send");
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Type a message to send)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
+    assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
+    assert.strictEqual(elements.sessionLabel["aria-label"], "Session: session-123");
 
     // (3) sessionId present + non-empty input value
     elements.messageInput.value = "Hello";

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -699,6 +699,7 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton["aria-disabled"], "false");
     assert.strictEqual(elements.sendButton.title, "Send message (Ctrl/Cmd+Enter)");
     assert.strictEqual(elements.sendButton["aria-label"], "Send message (Ctrl/Cmd+Enter)");
+    assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
     assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
     assert.strictEqual(elements.sessionLabel["aria-label"], "Session: session-123");
   });

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -699,6 +699,8 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton["aria-disabled"], "false");
     assert.strictEqual(elements.sendButton.title, "Send message (Ctrl/Cmd+Enter)");
     assert.strictEqual(elements.sendButton["aria-label"], "Send message (Ctrl/Cmd+Enter)");
+    assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
+    assert.strictEqual(elements.sessionLabel["aria-label"], "Session: session-123");
   });
 
   test("CHAT_JS should preserve fractional border widths when auto-resizing", () => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -267,6 +267,8 @@ export const CHAT_JS = `(function() {
     }
 
     sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
+    sessionLabel.title = sessionLabel.textContent;
+    sessionLabel.setAttribute("aria-label", sessionLabel.textContent);
   }
 
   function formatTime(timestamp) {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -79,6 +79,8 @@ export const CHAT_JS = `(function() {
   const DOMPURIFY_ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto|tel|callto|sms|cid|xmpp|vscode-webview-resource):|(?![a-z][a-z0-9+.-]*:))/i;
   const SANITIZATION_FAILURE_HTML = '<span class="message-unavailable" role="status" aria-label="Message unavailable">Message unavailable</span>';
   const SANITIZED_HTML_CACHE_LIMIT = 500;
+  const SESSION_LABEL_PREFIX = "Session: ";
+  const SESSION_LABEL_NONE_SELECTED = SESSION_LABEL_PREFIX + "None selected";
   const sanitizedHtmlCache = new Map();
 
   function createSanitizeConfig(overrides) {
@@ -266,7 +268,7 @@ export const CHAT_JS = `(function() {
       sendButton.setAttribute("aria-label", "Send message (Ctrl/Cmd+Enter)");
     }
 
-    sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
+    sessionLabel.textContent = hasSession ? SESSION_LABEL_PREFIX + state.sessionId : SESSION_LABEL_NONE_SELECTED;
     sessionLabel.title = sessionLabel.textContent;
     sessionLabel.setAttribute("aria-label", sessionLabel.textContent);
   }


### PR DESCRIPTION
💡 What:
チャットビューの Webview において、`sessionLabel` (`#sessionLabel`) 要素の `title` 属性と `aria-label` 属性をそのテキスト内容（`textContent`）と同期させる処理を追加しました。

🎯 Why:
`sessionLabel` 要素は CSS で `text-overflow: ellipsis` が設定されており、セッション ID が長い場合に表示が省略されてしまいます。これにより視覚的に全容を確認できないという問題がありましたが、`title` 属性を追加することで、ユーザーがマウスをホバーした際に完全なセッション情報をツールチップとして確認できるようになります。

📸 Before/After:
*   **Before:** 長いセッション名が省略され、ホバーしても完全な名前を確認できませんでした。また、`aria-label` が動的に更新されていませんでした。
*   **After:** 長いセッション名が省略された場合でも、マウスホバーで完全なセッション名が表示されます。

♿ Accessibility:
`aria-label` 属性を同時に更新することで、支援技術（スクリーンリーダー）に対して、視覚的なテキストと同一の明確なコンテキストを提供するようにしました。これにより、UIのテキスト変更がアクセシビリティツリーにも正確に反映されます。

---
*PR created automatically by Jules for task [7096397279745858411](https://jules.google.com/task/7096397279745858411) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CSS の `text-overflow: ellipsis` による省略表示に対応するため、`sessionLabel` 要素の `title` 属性と `aria-label` 属性を `textContent` と同期させる処理を追加しています。定数 `SESSION_LABEL_PREFIX` / `SESSION_LABEL_NONE_SELECTED` の導入により文字列の重複も解消されています。

- `chatAssets.ts`: `updateUI` 関数内で `sessionLabel.title` と `aria-label` を `textContent` と同時に設定するよう変更。定数を導入して文字列の一元管理も実現。
- `chatAssets.unit.test.ts`: テストハーネスに `title` と `setAttribute` を追加し、3 つの状態ケース (セッションなし・入力なし・入力あり) すべてで `sessionLabel` の属性を検証するアサーションを追加。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は最小限で副作用なし。マージ可能です。

変更対象は updateUI 内の sessionLabel 属性設定の 3 行のみ。既存のパターン（sendButton や messageInput での同様の属性同期）と完全に一致しており、3 つのテストケースすべてで新属性が検証されています。

特になし。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | sessionLabel の title・aria-label を textContent と同期する 3 行を追加。定数抽出も含め変更は最小限かつ正確。 |
| src/test/chatAssets.unit.test.ts | テストハーネスに title・setAttribute を追加し、3 状態ケースすべてに sessionLabel の属性検証を追加。以前の P2 指摘も解消済み。 |
| .Jules/palette.md | 今回の学習内容（text-overflow 要素への title・aria-label 付与）をログとして記録。コードへの影響なし。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[updateUI 呼び出し] --> B{hasSession?}
    B -- No --> C["sessionLabel.textContent = SESSION_LABEL_NONE_SELECTED"]
    B -- Yes --> D["sessionLabel.textContent = SESSION_LABEL_PREFIX + state.sessionId"]
    C --> E["sessionLabel.title = sessionLabel.textContent"]
    D --> E
    E --> F["sessionLabel.setAttribute('aria-label', sessionLabel.textContent)"]
    F --> G[DOM 更新完了]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/test/chatAssets.unit.test.ts`, line 700-702 ([link](https://github.com/hiroki-org/jules-extension/blob/7e12836e6bf157c94e3aeefda73f13e791fbcb6f/src/test/chatAssets.unit.test.ts#L700-L702)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> テストケース (3) では `sessionLabel.title` と `sessionLabel["aria-label"]` のアサーションが追加されていません。ケース (1)(2) と同様に検証することで、全状態で属性が正しく同期されることを確認できます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 700-702

   Comment:
   テストケース (3) では `sessionLabel.title` と `sessionLabel["aria-label"]` のアサーションが追加されていません。ケース (1)(2) と同様に検証することで、全状態で属性が正しく同期されることを確認できます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["test(webview): cover active session labe..."](https://github.com/hiroki-org/jules-extension/commit/75a09bc42ba9209eca361f24689eec7548ab5454) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33042423)</sub>

<!-- /greptile_comment -->