### PR TITLE
🎨 Palette: セッションラベルへのARIAラベルおよびツールチップ(title)の追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-11 - Dynamic ARIA Labeling for Context-Aware Inputs
 **Learning:** When using context-aware placeholders (like dynamically changing the placeholder from "Select a session to start typing" to "Enter message (Ctrl/Cmd+Enter to send)"), it is crucial to synchronize these changes with ARIA attributes (`aria-label` and `title`) to ensure screen readers provide accurate, up-to-date context, preventing users from becoming disoriented by outdated or mismatched labels.
 **Action:** Next time an input element's visual cue (like a placeholder) is dynamically updated based on state, immediately map that updated string to the element's `aria-label` and `title` properties within the same DOM update cycle.
+
+## 2025-05-21 - ARIA属性と省略されるテキスト（Truncated text）の同期
+**Learning:** `text-overflow: ellipsis` によって視覚的に切り捨てられる可能性のあるテキスト要素（例: Session Label）に対しては、`textContent` を変更する際に同時に `title` と `aria-label` を更新することで、アクセシビリティ（スクリーンリーダー対応）とユーザビリティ（ホバーによる全文表示）を同時に向上させることができる。
+**Action:** 動的なテキストを表示し、CSSで切り捨てを行っている箇所では、必ず `title` 属性もテキストコンテンツと同期させ、アクセシビリティのために `aria-label` も明示的に更新する。

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -41,7 +41,11 @@ function createChatScriptHarness(
       setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
       addEventListener: () => {},
     },
-    sessionLabel: { textContent: "" },
+    sessionLabel: {
+      textContent: "",
+      title: "",
+      setAttribute: function(k: string, v: string) { (this as any)[k] = v; }
+    },
     composer: { addEventListener: (evt: string, cb: any) => { listeners.composer[evt] = cb; } },
   };
   const messageListeners: Array<(event: { data: any }) => void> = [];
@@ -636,7 +640,11 @@ suite("chatAssets unit tests", () => {
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
       },
-      sessionLabel: { textContent: "" },
+      sessionLabel: {
+        textContent: "",
+        title: "",
+        setAttribute: function(k: string, v: string) { (this as any)[k] = v; }
+      },
       composer: { addEventListener: () => {} },
     };
 

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -267,6 +267,8 @@ export const CHAT_JS = `(function() {
     }
 
     sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
+    sessionLabel.title = sessionLabel.textContent;
+    sessionLabel.setAttribute("aria-label", sessionLabel.textContent);
   }
 
   function formatTime(timestamp) {


### PR DESCRIPTION
💡 What:
チャットWebview上のセッションラベル（`#sessionLabel`）に対して、`textContent`の更新時に`title`属性と`aria-label`属性を同期させる処理を追加しました。また、これに伴うユニットテスト用モックの更新も行いました。

🎯 Why:
1. セッション名が長くなり `text-overflow: ellipsis` で省略表示された場合に、ユーザーがホバーして全文を確認できるようにするため。
2. スクリーンリーダーが動的な変更を検知・読み上げる際に、視覚的なテキスト内容とアクセシビリティ向けのラベル内容を完全に一致させるため。

📸 Before/After:
* Before: テキストが省略された場合、全文を確認する方法がなく、スクリーンリーダー向けの明示的なラベルが不足していた。
* After: 省略されたテキストにマウスを乗せると全文がツールチップ表示され、スクリーンリーダーも変更された全文を正確に読み上げる。

♿ Accessibility:
`aria-label` を動的に更新し、`aria-live="polite"`（要素自体に定義済）と連動することで、コンテキストの変更がより正確にユーザーへ伝わるようになりました。

---
*PR created automatically by Jules for task [3942413795922490753](https://jules.google.com/task/3942413795922490753) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

セッションラベル（`#sessionLabel`）の `textContent` 更新時に `title` 属性と `aria-label` 属性を同期させる処理を追加し、テキスト省略時のツールチップ表示とスクリーンリーダー対応を改善する変更です。既存の `messageInput` に対する同様のパターンと一貫しており、実装自体は問題ありません。

- `src/webview/chatAssets.ts`: `sessionLabel.textContent` の更新直後に `title` と `aria-label` を同じ値で設定する2行を追加。
- `src/test/chatAssets.unit.test.ts`: `sessionLabel` モックに `title` フィールドと `setAttribute` メソッドを追加してランタイムエラーを防止しているが、新しく設定される値を検証するアサーションは未追加。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

本体の変更は小さく安全。テストのモック更新は正しいが、新機能の動作を保証するアサーションが不足している。

実装コード自体は既存パターンに沿った2行の追加で問題なし。テストはモックを更新しているが、title と aria-label の実際の値を検証するアサーションが追加されていないため、将来のリグレッションを検出できない状態になっている。

src/test/chatAssets.unit.test.ts — sessionLabel の title / aria-label を検証するアサーションの追加を検討してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | sessionLabel の textContent 更新時に title と aria-label を同期する2行を追加。既存の messageInput パターンと一貫しており、ロジック上の問題なし。 |
| src/test/chatAssets.unit.test.ts | sessionLabel モックに title と setAttribute を追加してコードの実行エラーを防いでいるが、新たに設定される title / aria-label の値を検証するアサーションが追加されていないため、テストカバレッジに不足がある。 |
| .Jules/palette.md | 今回の変更から学んだアクセシビリティのベストプラクティスを Jules の学習ログに追記。内容・形式ともに問題なし。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant VS as VSCode Extension
    participant W as Webview (chatAssets.ts)
    participant D as DOM (#sessionLabel)
    participant SR as Screen Reader

    VS->>W: "postMessage({ type: "chatState", payload })"
    W->>W: updateUI(state)
    W->>D: "sessionLabel.textContent = "Session: ...""
    W->>D: "sessionLabel.title = textContent"
    W->>D: sessionLabel.setAttribute("aria-label", textContent)
    D-->>SR: "aria-live="polite" により変更を通知"
    SR-->>SR: 更新された aria-label を読み上げ
    Note over D: ホバー時に title がツールチップ表示<br/>（ellipsis で省略されたテキストの全文）
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/test/chatAssets.unit.test.ts`, line 678-680 ([link](https://github.com/hiroki-org/jules-extension/blob/20864ab8d9f00803106c07b1a79f8cbc25dd5bef/src/test/chatAssets.unit.test.ts#L678-L680)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> `sessionLabel` の `title` と `aria-label` を検証するアサーションが追加されていません。モックには `title` と `setAttribute` が追加されているにもかかわらず、これらの値を確認するアサーションがないため、将来的にその代入処理が削除・変更されてもテストが通り続けてしまいます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 678-680

   Comment:
   `sessionLabel` の `title` と `aria-label` を検証するアサーションが追加されていません。モックには `title` と `setAttribute` が追加されているにもかかわらず、これらの値を確認するアサーションがないため、将来的にその代入処理が削除・変更されてもテストが通り続けてしまいます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/test/chatAssets.unit.test.ts`, line 687-689 ([link](https://github.com/hiroki-org/jules-extension/blob/20864ab8d9f00803106c07b1a79f8cbc25dd5bef/src/test/chatAssets.unit.test.ts#L687-L689)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> セッションIDが存在するケース（シナリオ2・3）でも `sessionLabel.title` と `aria-label` のアサーションが欠けています。上記と同様に、代入が正しく行われているかを確認する検証を追加してください。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 687-689

   Comment:
   セッションIDが存在するケース（シナリオ2・3）でも `sessionLabel.title` と `aria-label` のアサーションが欠けています。上記と同様に、代入が正しく行われているかを確認する検証を追加してください。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/test/chatAssets.unit.test.ts:678-680
`sessionLabel` の `title` と `aria-label` を検証するアサーションが追加されていません。モックには `title` と `setAttribute` が追加されているにもかかわらず、これらの値を確認するアサーションがないため、将来的にその代入処理が削除・変更されてもテストが通り続けてしまいます。

```suggestion
    assert.strictEqual(elements.sessionLabel.textContent, "Session: None selected");
    assert.strictEqual(elements.sessionLabel.title, "Session: None selected");
    assert.strictEqual(elements.sessionLabel["aria-label"], "Session: None selected");

    // (2) sessionId present + empty input value
```

### Issue 2 of 2
src/test/chatAssets.unit.test.ts:687-689
セッションIDが存在するケース（シナリオ2・3）でも `sessionLabel.title` と `aria-label` のアサーションが欠けています。上記と同様に、代入が正しく行われているかを確認する検証を追加してください。

```suggestion
    assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
    assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
    assert.strictEqual(elements.sessionLabel["aria-label"], "Session: session-123");

    // (3) sessionId present + non-empty input value
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: \[UX improvement\] Add ARIA la..."](https://github.com/hiroki-org/jules-extension/commit/20864ab8d9f00803106c07b1a79f8cbc25dd5bef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33255389)</sub>

<!-- /greptile_comment -->