### PR TITLE
🎨 Palette: セッションラベルの動的なツールチップ同期の追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-11 - Dynamic ARIA Labeling for Context-Aware Inputs
 **Learning:** When using context-aware placeholders (like dynamically changing the placeholder from "Select a session to start typing" to "Enter message (Ctrl/Cmd+Enter to send)"), it is crucial to synchronize these changes with ARIA attributes (`aria-label` and `title`) to ensure screen readers provide accurate, up-to-date context, preventing users from becoming disoriented by outdated or mismatched labels.
 **Action:** Next time an input element's visual cue (like a placeholder) is dynamically updated based on state, immediately map that updated string to the element's `aria-label` and `title` properties within the same DOM update cycle.
+
+## 2024-05-22 - Session Label Title Synchronization
+**Learning:** When text truncation is applied via CSS (`text-overflow: ellipsis`) to dynamically populated UI elements like the session label, it is necessary to dynamically sync the `title` attribute to match the `textContent`. This ensures that screen reader users and those hovering over the truncated text can access the full context.
+**Action:** Next time an element's text dynamically updates and may be truncated visually, immediately map the updated text to the element's `title` property within the same DOM update cycle.

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -41,7 +41,7 @@ function createChatScriptHarness(
       setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
       addEventListener: () => {},
     },
-    sessionLabel: { textContent: "" },
+    sessionLabel: { textContent: "", title: "" },
     composer: { addEventListener: (evt: string, cb: any) => { listeners.composer[evt] = cb; } },
   };
   const messageListeners: Array<(event: { data: any }) => void> = [];
@@ -636,7 +636,7 @@ suite("chatAssets unit tests", () => {
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
       },
-      sessionLabel: { textContent: "" },
+      sessionLabel: { textContent: "", title: "" },
       composer: { addEventListener: () => {} },
     };
 
@@ -668,6 +668,7 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton.title, "Select a session to send a message");
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Select a session to send a message)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: None selected");
+    assert.strictEqual(elements.sessionLabel.title, "Session: None selected");
 
     // (2) sessionId present + empty input value
     elements.messageInput.value = "   "; // whitespace
@@ -677,6 +678,7 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton.title, "Type a message to send");
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Type a message to send)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
+    assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
 
     // (3) sessionId present + non-empty input value
     elements.messageInput.value = "Hello";

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -267,6 +267,7 @@ export const CHAT_JS = `(function() {
     }
 
     sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
+    sessionLabel.title = sessionLabel.textContent;
   }
 
   function formatTime(timestamp) {


### PR DESCRIPTION
💡 What: セッションラベルのテキストが動的に更新される際、その `title` 属性も新しいテキスト内容と同期して更新されるようにしました。
🎯 Why: セッションラベルはUI上で `text-overflow: ellipsis` によって視覚的に切り詰められる可能性があります。`title` 属性を最新のテキストと同期させることで、ユーザーがホバーした際に常に正確で完全なセッション情報を確認できるようになり、使い勝手が向上します。
📸 Before/After: （視覚的な変更はホバー時のネイティブツールチップ内容の更新のみです）
♿ Accessibility: マウスホバーで省略された情報を確認するユーザーに対して、正確なフルコンテキストのテキスト情報が提供されるようになります。

---
*PR created automatically by Jules for task [12617030550980427356](https://jules.google.com/task/12617030550980427356) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、セッションラベルの `textContent` が更新される際に `title` 属性も同期させる1行の変更です。CSS の `text-overflow: ellipsis` で切り詰められたテキストにホバーした際、常に完全なセッション情報が表示されるようになります。

- `chatAssets.ts`: `sessionLabel.textContent` の直後に `sessionLabel.title = sessionLabel.textContent` を追加し、ツールチップを常に最新の状態に保つ。
- `chatAssets.unit.test.ts`: モックオブジェクトに `title: ""` を追加し、シナリオ (1)(2) の検証を追加（シナリオ (3) のアサーションは未追加）。
- `.Jules/palette.md`: 今回の対応から得た学習をエントリとして記録（ただし年が "2024" と誤記）。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージ自体は安全。変更は最小限で既存パターンに沿っており、テストのシナリオ (3) でのアサーション漏れと palette.md の年の誤記という軽微な点のみ。

コアロジックの変更は1行のみで動作上の問題はない。テストカバレッジがシナリオ (3) で不完全な点と、ドキュメントの日付誤記がある。

`src/test/chatAssets.unit.test.ts` のシナリオ (3) におけるアサーション追加と、`.Jules/palette.md` の年の修正を確認すること。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | `sessionLabel.title` を `textContent` と同期するための1行追加。変更は最小限かつ正確で、既存の `messageInput` のパターンと一致している。 |
| src/test/chatAssets.unit.test.ts | モックに `title: ""` を追加し、シナリオ (1)(2) の検証を追加。ただしシナリオ (3) の `sessionLabel.title` アサーションが欠落している。 |
| .Jules/palette.md | 新しい学習エントリを追加。年が "2024" と誤記されており、正しくは "2026" であるべき。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant VS as VSCode Extension
    participant WV as WebView (chatAssets.ts)
    participant DOM as DOM Elements

    VS->>WV: "postMessage({ type: "chatState", payload })"
    WV->>WW: updateUI(state)
    WV->>DOM: "sessionLabel.textContent = "Session: " + sessionId"
    WV->>DOM: "sessionLabel.title = sessionLabel.textContent"
    Note over DOM: title と textContent が常に同期<br/>ellipsis 時もホバーで全文表示
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/test/chatAssets.unit.test.ts`, line 690-692 ([link](https://github.com/hiroki-org/jules-extension/blob/1b19c884adab3f5918193e1ed394210e234c7725/src/test/chatAssets.unit.test.ts#L690-L692)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> シナリオ (1) と (2) では `sessionLabel.title` の検証が追加されていますが、シナリオ (3)（`sessionId` あり + 非空入力）では対応するアサーションが欠落しています。一貫性のためにここでも検証を追加することを推奨します。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 690-692

   Comment:
   シナリオ (1) と (2) では `sessionLabel.title` の検証が追加されていますが、シナリオ (3)（`sessionId` あり + 非空入力）では対応するアサーションが欠落しています。一貫性のためにここでも検証を追加することを推奨します。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.Jules/palette.md:13
`palette.md` に追加されたエントリの年が誤っています。現在の日付は 2026-05-22 ですが、`2024-05-22` と記録されています。

```suggestion
## 2026-05-22 - Session Label Title Synchronization
```

### Issue 2 of 2
src/test/chatAssets.unit.test.ts:690-692
シナリオ (1) と (2) では `sessionLabel.title` の検証が追加されていますが、シナリオ (3)（`sessionId` あり + 非空入力）では対応するアサーションが欠落しています。一貫性のためにここでも検証を追加することを推奨します。

```suggestion
    assert.strictEqual(elements.sendButton.title, "Send message (Ctrl/Cmd+Enter)");
    assert.strictEqual(elements.sendButton["aria-label"], "Send message (Ctrl/Cmd+Enter)");
    assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
  });
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: セッションラベルのツールチップを動的に同期"](https://github.com/hiroki-org/jules-extension/commit/1b19c884adab3f5918193e1ed394210e234c7725) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33461978)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->