### PR TITLE
🎨 Palette: セッションラベルにホバーツールチップを追加して視認性を向上

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-11 - Dynamic ARIA Labeling for Context-Aware Inputs
 **Learning:** When using context-aware placeholders (like dynamically changing the placeholder from "Select a session to start typing" to "Enter message (Ctrl/Cmd+Enter to send)"), it is crucial to synchronize these changes with ARIA attributes (`aria-label` and `title`) to ensure screen readers provide accurate, up-to-date context, preventing users from becoming disoriented by outdated or mismatched labels.
 **Action:** Next time an input element's visual cue (like a placeholder) is dynamically updated based on state, immediately map that updated string to the element's `aria-label` and `title` properties within the same DOM update cycle.
+
+## 2025-05-23 - Dynamic Tooltips for Truncated Text
+**Learning:** When text truncation is used on dynamic UI elements via CSS (`text-overflow: ellipsis`, `white-space: nowrap`), assigning the `textContent` to the `title` attribute dynamically resolves accessibility and usability issues where users cannot read the full truncated content.
+**Action:** Next time an element's text content is prone to truncation, dynamically map its `textContent` to the `title` attribute during the update cycle so the complete text is available on hover.

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -41,7 +41,7 @@ function createChatScriptHarness(
       setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
       addEventListener: () => {},
     },
-    sessionLabel: { textContent: "" },
+    sessionLabel: { textContent: "", title: "" },
     composer: { addEventListener: (evt: string, cb: any) => { listeners.composer[evt] = cb; } },
   };
   const messageListeners: Array<(event: { data: any }) => void> = [];
@@ -636,7 +636,7 @@ suite("chatAssets unit tests", () => {
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
       },
-      sessionLabel: { textContent: "" },
+      sessionLabel: { textContent: "", title: "" },
       composer: { addEventListener: () => {} },
     };
 

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -267,6 +267,7 @@ export const CHAT_JS = `(function() {
     }
 
     sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
+    sessionLabel.title = sessionLabel.textContent;
   }
 
   function formatTime(timestamp) {


### PR DESCRIPTION
💡 What: セッションラベルが長すぎて省略（truncate）された場合でも、ホバー時にフルテキストをツールチップとして表示できるように `title` 属性を動的に追加しました。

🎯 Why: 非常に長いセッションIDの場合、CSSの `text-overflow: ellipsis` によって文字が途切れてしまい、ユーザーがセッションの全容を確認できなくなるというユーザビリティの問題を解決するためです。

📸 Before/After:
（Before） "Session: session-123-very-long..." と省略され、全テキストを確認できない。
（After） 省略されたテキストの上にホバーすると、ブラウザのネイティブツールチップで完全なセッション名が表示される。

♿ Accessibility:
スクリーンリーダー等を使用しないユーザーであっても、長い情報を確実に読むことができるようになります。ネイティブの `title` 属性は視覚的なツールチップを提供し、シンプルなUX改善となります。

---
*PR created automatically by Jules for task [10395811368493846264](https://jules.google.com/task/10395811368493846264) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

セッションラベルが CSS `text-overflow: ellipsis` で省略された際に、ネイティブの `title` 属性をホバーツールチップとして動的に付与するUX改善PRです。

- `chatAssets.ts` に1行 (`sessionLabel.title = sessionLabel.textContent`) を追加し、テキスト設定と同時に `title` を同期するよう変更。
- テストのモックオブジェクトに `title: ""` を追加したが、新動作を検証するアサーションが欠落しており、テストカバレッジが不完全な状態。
- `.Jules/palette.md` に今回の学習内容を記録するドキュメント追記を含む。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

実装変更はシンプルで安全。テストのアサーション追加のみ対応すれば問題なくマージ可能。

実装本体の変更は1行のみで、既存の `textContent` 設定直後に `title` を同期するだけのシンプルな変更。ロジック的なリスクはない。一方、テストファイルでモックに `title: ""` を追加しておきながら、その値が正しく設定されることを検証するアサーションが書かれていないため、新機能の動作がテストで保証されていない状態になっている。

src/test/chatAssets.unit.test.ts — `sessionLabel.title` の値を検証するアサーションの追加が必要。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | `sessionLabel.title` を `textContent` と同期する1行を追加。ロジックはシンプルで問題なし。 |
| src/test/chatAssets.unit.test.ts | モックに `title: ""` を追加したが、新機能の動作を検証するアサーションが欠落している。 |
| .Jules/palette.md | 今回の学習内容を記録したドキュメント追記のみ。問題なし。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Extension as VS Code Extension
    participant Webview as Webview (chatAssets.ts)
    participant DOM as DOM Element (sessionLabel)
    participant User as ユーザー

    Extension->>Webview: "postMessage({ type: "chatState", payload: { sessionId } })"
    Webview->>Webview: updateUI(state)
    Webview->>DOM: "sessionLabel.textContent = "Session: " + sessionId"
    Webview->>DOM: "sessionLabel.title = sessionLabel.textContent"
    User->>DOM: ホバー
    DOM-->>User: ブラウザネイティブツールチップでフルテキスト表示
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/test/chatAssets.unit.test.ts`, line 670-672 ([link](https://github.com/hiroki-org/jules-extension/blob/204279445d2c8639e61f4d6f011eb1a77cd38bba/src/test/chatAssets.unit.test.ts#L670-L672)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `sessionLabel.title` が正しく設定されているかを検証するアサーションが追加されていません。モックオブジェクトに `title: ""` を追加していますが、テスト本体で値を確認していないため、実装の正しさが保証されません。AGENTS.md でも「新しい機能を追加した場合は、対応するテストも追加してください」と定めています。

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 670-672
   
   Comment:
   `sessionLabel.title` が正しく設定されているかを検証するアサーションが追加されていません。モックオブジェクトに `title: ""` を追加していますが、テスト本体で値を確認していないため、実装の正しさが保証されません。AGENTS.md でも「新しい機能を追加した場合は、対応するテストも追加してください」と定めています。
   
   
   
   **Context Used:** AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/test/chatAssets.unit.test.ts`, line 679-681 ([link](https://github.com/hiroki-org/jules-extension/blob/204279445d2c8639e61f4d6f011eb1a77cd38bba/src/test/chatAssets.unit.test.ts#L679-L681)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> セッションIDが存在するケース（2番目のシナリオ）でも `sessionLabel.title` のアサーションが不足しています。上のケースと同様に、実装の正しさを保証するために追加が必要です。

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 679-681
   
   Comment:
   セッションIDが存在するケース（2番目のシナリオ）でも `sessionLabel.title` のアサーションが不足しています。上のケースと同様に、実装の正しさを保証するために追加が必要です。
   
   
   
   **Context Used:** AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/test/chatAssets.unit.test.ts:670-672
`sessionLabel.title` が正しく設定されているかを検証するアサーションが追加されていません。モックオブジェクトに `title: ""` を追加していますが、テスト本体で値を確認していないため、実装の正しさが保証されません。AGENTS.md でも「新しい機能を追加した場合は、対応するテストも追加してください」と定めています。

```suggestion
    assert.strictEqual(elements.sessionLabel.textContent, "Session: None selected");
    assert.strictEqual(elements.sessionLabel.title, "Session: None selected");

    // (2) sessionId present + empty input value
```

### Issue 2 of 2
src/test/chatAssets.unit.test.ts:679-681
セッションIDが存在するケース（2番目のシナリオ）でも `sessionLabel.title` のアサーションが不足しています。上のケースと同様に、実装の正しさを保証するために追加が必要です。

```suggestion
    assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
    assert.strictEqual(elements.sessionLabel.title, "Session: session-123");

    // (3) sessionId present + non-empty input value
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): add native tooltip to session ..."](https://github.com/hiroki-org/jules-extension/commit/204279445d2c8639e61f4d6f011eb1a77cd38bba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33592264)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->