### PR TITLE
🎨 Palette: [UX improvement] セッションラベルにツールチップを追加し、省略されたテキストを確認可能にする

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-11 - Dynamic ARIA Labeling for Context-Aware Inputs
 **Learning:** When using context-aware placeholders (like dynamically changing the placeholder from "Select a session to start typing" to "Enter message (Ctrl/Cmd+Enter to send)"), it is crucial to synchronize these changes with ARIA attributes (`aria-label` and `title`) to ensure screen readers provide accurate, up-to-date context, preventing users from becoming disoriented by outdated or mismatched labels.
 **Action:** Next time an input element's visual cue (like a placeholder) is dynamically updated based on state, immediately map that updated string to the element's `aria-label` and `title` properties within the same DOM update cycle.
+
+## 2026-05-26 - Title Tooltip Support for Truncated Text
+**Learning:** When applying CSS `text-overflow: ellipsis` to truncate long dynamically generated content (like a session ID), it is necessary to provide an accessible way for users to view the complete text. Mirroring the `textContent` into the `title` attribute creates a native browser tooltip, enabling hover-based discovery of the full content without requiring custom UI components.
+**Action:** Whenever using `text-overflow: ellipsis` to clip text in the DOM, synchronously update the element's `title` attribute to match the full `textContent`.

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -41,7 +41,7 @@ function createChatScriptHarness(
       setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
       addEventListener: () => {},
     },
-    sessionLabel: { textContent: "", title: "", setAttribute: function(k: string, v: string) { (this as any)[k] = v; } },
+    sessionLabel: { textContent: "", title: "" },
     composer: { addEventListener: (evt: string, cb: any) => { listeners.composer[evt] = cb; } },
   };
   const messageListeners: Array<(event: { data: any }) => void> = [];
@@ -636,7 +636,7 @@ suite("chatAssets unit tests", () => {
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
       },
-      sessionLabel: { textContent: "", title: "", setAttribute: function(k: string, v: string) { (this as any)[k] = v; } },
+      sessionLabel: { textContent: "", title: "" },
       composer: { addEventListener: () => {} },
     };
 
@@ -669,7 +669,6 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Select a session to send a message)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: None selected");
     assert.strictEqual(elements.sessionLabel.title, "Session: None selected");
-    assert.strictEqual(elements.sessionLabel["aria-label"], "Session: None selected");
 
     // (2) sessionId present + empty input value
     elements.messageInput.value = "   "; // whitespace
@@ -680,7 +679,6 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Type a message to send)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
     assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
-    assert.strictEqual(elements.sessionLabel["aria-label"], "Session: session-123");
 
     // (3) sessionId present + non-empty input value
     elements.messageInput.value = "Hello";

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -41,7 +41,7 @@ function createChatScriptHarness(
       setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
       addEventListener: () => {},
     },
-    sessionLabel: { textContent: "" },
+    sessionLabel: { textContent: "", title: "" },
     composer: { addEventListener: (evt: string, cb: any) => { listeners.composer[evt] = cb; } },
   };
   const messageListeners: Array<(event: { data: any }) => void> = [];
@@ -636,7 +636,7 @@ suite("chatAssets unit tests", () => {
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
       },
-      sessionLabel: { textContent: "" },
+      sessionLabel: { textContent: "", title: "" },
       composer: { addEventListener: () => {} },
     };
 
@@ -668,6 +668,7 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton.title, "Select a session to send a message");
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Select a session to send a message)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: None selected");
+    assert.strictEqual(elements.sessionLabel.title, "Session: None selected");
 
     // (2) sessionId present + empty input value
     elements.messageInput.value = "   "; // whitespace
@@ -677,6 +678,7 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton.title, "Type a message to send");
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Type a message to send)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
+    assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
 
     // (3) sessionId present + non-empty input value
     elements.messageInput.value = "Hello";

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -41,7 +41,7 @@ function createChatScriptHarness(
       setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
       addEventListener: () => {},
     },
-    sessionLabel: { textContent: "", title: "" },
+    sessionLabel: { textContent: "", title: "", setAttribute: function(k: string, v: string) { (this as any)[k] = v; } },
     composer: { addEventListener: (evt: string, cb: any) => { listeners.composer[evt] = cb; } },
   };
   const messageListeners: Array<(event: { data: any }) => void> = [];
@@ -636,7 +636,7 @@ suite("chatAssets unit tests", () => {
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
       },
-      sessionLabel: { textContent: "", title: "" },
+      sessionLabel: { textContent: "", title: "", setAttribute: function(k: string, v: string) { (this as any)[k] = v; } },
       composer: { addEventListener: () => {} },
     };
 
@@ -669,6 +669,7 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Select a session to send a message)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: None selected");
     assert.strictEqual(elements.sessionLabel.title, "Session: None selected");
+    assert.strictEqual(elements.sessionLabel["aria-label"], "Session: None selected");
 
     // (2) sessionId present + empty input value
     elements.messageInput.value = "   "; // whitespace
@@ -679,6 +680,7 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Type a message to send)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
     assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
+    assert.strictEqual(elements.sessionLabel["aria-label"], "Session: session-123");
 
     // (3) sessionId present + non-empty input value
     elements.messageInput.value = "Hello";

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -266,7 +266,9 @@ export const CHAT_JS = `(function() {
       sendButton.setAttribute("aria-label", "Send message (Ctrl/Cmd+Enter)");
     }
 
-    sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
+    const sessionText = hasSession ? "Session: " + state.sessionId : "Session: None selected";
+    sessionLabel.textContent = sessionText;
+    sessionLabel.title = sessionText;
   }
 
   function formatTime(timestamp) {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -269,7 +269,6 @@ export const CHAT_JS = `(function() {
     const sessionText = hasSession ? "Session: " + state.sessionId : "Session: None selected";
     sessionLabel.textContent = sessionText;
     sessionLabel.title = sessionText;
-    sessionLabel.setAttribute("aria-label", sessionText);
   }
 
   function formatTime(timestamp) {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -269,6 +269,7 @@ export const CHAT_JS = `(function() {
     const sessionText = hasSession ? "Session: " + state.sessionId : "Session: None selected";
     sessionLabel.textContent = sessionText;
     sessionLabel.title = sessionText;
+    sessionLabel.setAttribute("aria-label", sessionText);
   }
 
   function formatTime(timestamp) {


### PR DESCRIPTION
💡 What:
チャットWebview内のセッションラベル (`#sessionLabel`) 要素に対して、`textContent` と同じ内容を `title` 属性として設定するようにしました。

🎯 Why:
長いセッション名がCSSの `text-overflow: ellipsis` によって切り詰められた場合でも、ユーザーがホバーすることでセッションの全文字列をツールチップとして確認できるようにするためです。

📸 Before/After:
Before: 長いセッション名が「...」と省略されても、全文を確認する手段がありませんでした。
After: 省略されたセッション名にマウスを重ねると、ネイティブのツールチップとして全文が表示されます。

♿ Accessibility:
UI要素が視覚的に省略表示される場合でも、完全な情報へのアクセス手段を提供することでユーザビリティが向上します。

---
*PR created automatically by Jules for task [11249300832631989681](https://jules.google.com/task/11249300832631989681) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

省略表示されたセッション名にホバーすると全文をツールチップで確認できるよう、`sessionLabel` 要素に `title` 属性と `aria-label` 属性を設定する変更です。

- **`src/webview/chatAssets.ts`**: セッションテキストを変数 `sessionText` に切り出し、`textContent` / `title` / `aria-label` の3属性に一括設定するようリファクタリング。
- **`src/test/chatAssets.unit.test.ts`**: モックオブジェクトに `title` プロパティと `setAttribute` メソッドを追加し、ケース(1)(2)に `sessionLabel.title` / `aria-label` のアサーションを追加。ただしケース(3)には対応するアサーションが欠けている。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はセッションラベルへの属性追加のみで、既存のロジックに影響しない安全な改善です。

実装は単純な属性セットで副作用がなく、既存のパターン（`messageInput` や `sendButton` の `title` / `aria-label` 設定）と一貫しています。テスト上の抜け（ケース3のアサーション欠落）はあるものの、実装自体の正確性には影響しません。

特に注意が必要なファイルはありません。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | `sessionLabel` に `title` と `aria-label` を設定する実装を追加。変数 `sessionText` に切り出してコードの重複も排除しており、変更は正確で問題なし。 |
| src/test/chatAssets.unit.test.ts | モックオブジェクトに `title` と `setAttribute` を追加し、ケース(1)(2)にアサーションを追加。ただしケース(3)の `sessionLabel.title` / `aria-label` アサーションが欠落している。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant VS as VSCode Extension
    participant WV as Webview (chatAssets.ts)
    participant DOM as DOM (sessionLabel)
    participant User as ユーザー

    VS->>WV: "postMessage({ type: "chatState", payload })"
    WV->>WV: updateUI(state)
    WV->>WV: "sessionText = hasSession ? "Session: " + id : "Session: None selected""
    WV->>DOM: "sessionLabel.textContent = sessionText"
    WV->>DOM: "sessionLabel.title = sessionText"
    WV->>DOM: sessionLabel.setAttribute("aria-label", sessionText)
    User->>DOM: マウスホバー
    DOM-->>User: ネイティブツールチップ（全文表示）
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/test/chatAssets.unit.test.ts`, line 690-692 ([link](https://github.com/hiroki-org/jules-extension/blob/8ed8857becc03840f8e87702cc586411896e8457/src/test/chatAssets.unit.test.ts#L690-L692)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> ケース (3)（`sessionId` あり + 非空テキスト）では `sessionLabel.title` のアサーションが追加されていません。ケース (1)(2) と同様に検証することで、`sessionLabel.title` が正しく設定されていることを保証できます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 690-692

   Comment:
   ケース (3)（`sessionId` あり + 非空テキスト）では `sessionLabel.title` のアサーションが追加されていません。ケース (1)(2) と同様に検証することで、`sessionLabel.title` が正しく設定されていることを保証できます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/test/chatAssets.unit.test.ts:692-694
ケース (3)（`sessionId` あり + 非空テキスト）で `sessionLabel.title` と `sessionLabel["aria-label"]` のアサーションが欠けています。ケース (1)(2) では追加されているのに、ケース (3) だけ検証されておらず、今後のリグレッションを検出できません。

```suggestion
    assert.strictEqual(elements.sendButton.title, "Send message (Ctrl/Cmd+Enter)");
    assert.strictEqual(elements.sendButton["aria-label"], "Send message (Ctrl/Cmd+Enter)");
    assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
    assert.strictEqual(elements.sessionLabel["aria-label"], "Session: session-123");
  });
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): sync session label aria text"](https://github.com/hiroki-org/jules-extension/commit/9ab6447fec4314018df68fa4d2eabfdf6222703a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33659035)</sub>

<!-- /greptile_comment -->