### PR TITLE
🎨 Palette: [UX improvement] 長いセッションIDが省略された際にツールチップで全文を表示するように改善

### DIFF
--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -510,7 +510,7 @@ export function getChatWebviewHtml(
     nonce +
     '">' +
     CHAT_CSS +
-    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
+    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" title="Session: None selected" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
     nonce +
     '" src="' +
     domPurifyScriptUri +

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -41,7 +41,7 @@ function createChatScriptHarness(
       setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
       addEventListener: () => {},
     },
-    sessionLabel: { textContent: "" },
+    sessionLabel: { textContent: "", title: "" },
     composer: { addEventListener: (evt: string, cb: any) => { listeners.composer[evt] = cb; } },
   };
   const messageListeners: Array<(event: { data: any }) => void> = [];
@@ -636,7 +636,7 @@ suite("chatAssets unit tests", () => {
         setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
         addEventListener: () => {}
       },
-      sessionLabel: { textContent: "" },
+      sessionLabel: { textContent: "", title: "" },
       composer: { addEventListener: () => {} },
     };
 
@@ -668,6 +668,7 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton.title, "Select a session to send a message");
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Select a session to send a message)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: None selected");
+    assert.strictEqual(elements.sessionLabel.title, "Session: None selected");
 
     // (2) sessionId present + empty input value
     elements.messageInput.value = "   "; // whitespace
@@ -677,6 +678,7 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.sendButton.title, "Type a message to send");
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Type a message to send)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
+    assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
 
     // (3) sessionId present + non-empty input value
     elements.messageInput.value = "Hello";

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -267,6 +267,7 @@ export const CHAT_JS = `(function() {
     }
 
     sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
+    sessionLabel.title = sessionLabel.textContent;
   }
 
   function formatTime(timestamp) {


### PR DESCRIPTION
💡 What:
チャットビューのセッションラベル（「Session: ...」の表示）に、テキスト内容と連動する `title` 属性（ネイティブツールチップ）を追加しました。

🎯 Why:
セッションIDが長く表示領域に収まらない場合、CSSの `text-overflow: ellipsis` によって省略（...）されます。これまでは省略された全文を確認する手段がありませんでしたが、`title` 属性を追加することで、マウスホバー時にセッションIDの全文をツールチップとして確認できるようになり、利便性が向上します。

📸 Before/After:
*   **Before:** 長いセッションIDが省略され、全文が確認できない。
*   **After:** マウスオーバーすると、ネイティブのツールチップが表示され、省略されたセッションIDの全文が読める。

♿ Accessibility:
スクリーンリーダーなどの支援技術を使用するユーザーにとっても、ラベルの完全なコンテキストを補足する役割を果たします。（※ただし、主に視覚的に省略されたテキストを補完するUX改善です）

---
*PR created automatically by Jules for task [2690000983827305809](https://jules.google.com/task/2690000983827305809) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

セッションラベル（`sessionLabel`）に `title` 属性を追加し、テキストが省略（`text-overflow: ellipsis`）された場合でもマウスホバーでセッションIDの全文をネイティブツールチップとして確認できるようにした UX 改善 PR です。静的 HTML テンプレートへの初期値追加と、`updateUI` 内での動的同期、テストの更新がセットで行われています。

- **`src/chatView.ts`**: 静的 HTML の `sessionLabel` に `title="Session: None selected"` を初期値として追加。
- **`src/webview/chatAssets.ts`**: `updateUI` 関数内で `sessionLabel.title = sessionLabel.textContent` を追加し、状態変化のたびにツールチップ内容をラベルテキストと同期するように実装。
- **`src/test/chatAssets.unit.test.ts`**: モックオブジェクトと既存テストケースに `title` プロパティの検証を追加。ただしテストケース (3) の `sessionLabel.title` アサーションが欠落しており、軽微なカバレッジの不足がある。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は最小限かつ正確で、マージしても問題ありません。

実装・静的 HTML・テストの三箇所がすべて一貫して更新されており、ロジック面の問題はありません。テストケース (3) に sessionLabel.title のアサーションが欠けているというカバレッジの小さな不足が一点あるものの、機能の正確性には影響しません。

テストファイル src/test/chatAssets.unit.test.ts のケース (3) に title アサーションが未追加です。他のファイルは問題なし。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/chatView.ts | 静的 HTML テンプレートの `sessionLabel` 要素に初期値 `title="Session: None selected"` を追加。テキストコンテンツと一致しており問題なし。 |
| src/webview/chatAssets.ts | `updateUI` に `sessionLabel.title = sessionLabel.textContent` を追加。`textContent` 経由のため XSS リスクなし。変更は最小限で正確。 |
| src/test/chatAssets.unit.test.ts | モックオブジェクトに `title: ""` を追加し、ケース (1)(2) の title アサーションを追加。ケース (3) の `sessionLabel.title` アサーションが欠落している。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WebviewHTML as 静的 HTML (chatView.ts)
    participant ChatAssets as CHAT_JS (chatAssets.ts)
    participant DOM as sessionLabel DOM

    WebviewHTML->>DOM: "初期レンダリング textContent/title="Session: None selected""
    Note over DOM: 初期状態で title と textContent が一致
    ChatAssets->>DOM: updateUI() 呼び出し
    DOM-->>DOM: "textContent = "Session: " + sessionId"
    DOM-->>DOM: "title = textContent（新規追加）"
    Note over DOM: 状態変化のたびに title を textContent と同期
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/test/chatAssets.unit.test.ts`, line 690-692 ([link](https://github.com/hiroki-org/jules-extension/blob/9b396f762e172c99b88e30cf1998145ed4e7424d/src/test/chatAssets.unit.test.ts#L690-L692)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> テストケース (3) に `sessionLabel.title` のアサーションが抜けています。ケース (1)・(2) では `title` の検証が追加されていますが、ケース (3)（セッションID 有り＋入力テキスト有り）では同様の検証がありません。`updateUI` はすべての状態変化で呼び出されるため、カバレッジを揃えておくと将来の回帰を防ぎやすくなります。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 690-692

   Comment:
   テストケース (3) に `sessionLabel.title` のアサーションが抜けています。ケース (1)・(2) では `title` の検証が追加されていますが、ケース (3)（セッションID 有り＋入力テキスト有り）では同様の検証がありません。`updateUI` はすべての状態変化で呼び出されるため、カバレッジを揃えておくと将来の回帰を防ぎやすくなります。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/test/chatAssets.unit.test.ts:690-692
テストケース (3) に `sessionLabel.title` のアサーションが抜けています。ケース (1)・(2) では `title` の検証が追加されていますが、ケース (3)（セッションID 有り＋入力テキスト有り）では同様の検証がありません。`updateUI` はすべての状態変化で呼び出されるため、カバレッジを揃えておくと将来の回帰を防ぎやすくなります。

```suggestion
    assert.strictEqual(elements.sendButton.title, "Send message (Ctrl/Cmd+Enter)");
    assert.strictEqual(elements.sendButton["aria-label"], "Send message (Ctrl/Cmd+Enter)");
    assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
    assert.strictEqual(elements.sessionLabel.title, "Session: session-123");
  });
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add title attribute to session label to ..."](https://github.com/hiroki-org/jules-extension/commit/9b396f762e172c99b88e30cf1998145ed4e7424d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33779297)</sub>

<!-- /greptile_comment -->