### PR TITLE
🎨 Palette: [UX improvement] - Ensure Explicit ARIA Disabled State in Webviews

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-05-11 - Dynamic ARIA Labeling for Context-Aware Inputs
 **Learning:** When using context-aware placeholders (like dynamically changing the placeholder from "Select a session to start typing" to "Enter message (Ctrl/Cmd+Enter to send)"), it is crucial to synchronize these changes with ARIA attributes (`aria-label` and `title`) to ensure screen readers provide accurate, up-to-date context, preventing users from becoming disoriented by outdated or mismatched labels.
 **Action:** Next time an input element's visual cue (like a placeholder) is dynamically updated based on state, immediately map that updated string to the element's `aria-label` and `title` properties within the same DOM update cycle.
+## 2026-05-26 - [Explicit ARIA Disabled State in Webviews]
+**Learning:** [To ensure robust accessibility for legacy screen readers in dynamic webviews, explicitly mirror native disabled state changes with the corresponding aria-disabled attribute on form controls.]
+**Action:** [Always update both disabled and aria-disabled attributes when toggling interactability in injected script logic.]

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -257,6 +257,7 @@ export function getComposerHtml(
     const validate = () => {
       const isValid = textarea.value.trim().length > 0;
       submitButton.disabled = !isValid;
+      submitButton.setAttribute('aria-disabled', !isValid ? 'true' : 'false');
       submitButton.title = isValid ? 'Send (Cmd/Ctrl+Enter)' : 'Type a message to send';
       submitButton.setAttribute('aria-label', isValid ? 'Send message (Cmd/Ctrl+Enter)' : 'Type a message to send');
       return isValid;
@@ -268,6 +269,7 @@ export function getComposerHtml(
       }
 
       submitButton.disabled = true;
+      submitButton.setAttribute('aria-disabled', 'true');
       submitButton.textContent = 'Sending... ';
       const spinnerSpan = document.createElement('span');
       spinnerSpan.className = 'spinner';
@@ -278,9 +280,18 @@ export function getComposerHtml(
       const srStatus = document.getElementById('sr-status');
       if (srStatus) srStatus.textContent = 'Sending message...';
       textarea.disabled = true;
-      if (createPrCheckbox) createPrCheckbox.disabled = true;
-      if (requireApprovalCheckbox) requireApprovalCheckbox.disabled = true;
-      document.getElementById('cancel').disabled = true;
+      textarea.setAttribute('aria-disabled', 'true');
+      if (createPrCheckbox) {
+        createPrCheckbox.disabled = true;
+        createPrCheckbox.setAttribute('aria-disabled', 'true');
+      }
+      if (requireApprovalCheckbox) {
+        requireApprovalCheckbox.disabled = true;
+        requireApprovalCheckbox.setAttribute('aria-disabled', 'true');
+      }
+      const cancelButton = document.getElementById('cancel');
+      cancelButton.disabled = true;
+      cancelButton.setAttribute('aria-disabled', 'true');
       document.body.style.cursor = 'wait';
 
       vscode.postMessage({

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -247,6 +247,7 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes('const validate = () => {'));
       assert.ok(html.includes('const isValid = textarea.value.trim().length > 0;'));
       assert.ok(html.includes('submitButton.disabled = !isValid;'));
+      assert.ok(html.includes("submitButton.setAttribute('aria-disabled', !isValid ? 'true' : 'false');"));
       assert.ok(html.includes('return isValid;'));
     });
 
@@ -602,8 +603,11 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("const srStatus = document.getElementById('sr-status');"));
       assert.ok(html.includes("if (srStatus) srStatus.textContent = 'Sending message...';"));
       assert.ok(html.includes("submitButton.disabled = true;"));
+      assert.ok(html.includes("submitButton.setAttribute('aria-disabled', 'true');"));
       assert.ok(html.includes("textarea.disabled = true;"));
-      assert.ok(html.includes("document.getElementById('cancel').disabled = true;"));
+      assert.ok(html.includes("textarea.setAttribute('aria-disabled', 'true');"));
+      assert.ok(html.includes("cancelButton.disabled = true;"));
+      assert.ok(html.includes("cancelButton.setAttribute('aria-disabled', 'true');"));
       assert.ok(html.includes("document.body.style.cursor = 'wait';"));
     });
 
@@ -641,8 +645,10 @@ suite("Composer Test Suite", () => {
         { title: "Test", showCreatePrCheckbox: true, showRequireApprovalCheckbox: true },
         "nonce-123"
       );
-      assert.ok(html.includes("if (createPrCheckbox) createPrCheckbox.disabled = true;"));
-      assert.ok(html.includes("if (requireApprovalCheckbox) requireApprovalCheckbox.disabled = true;"));
+      assert.ok(html.includes("createPrCheckbox.disabled = true;"));
+      assert.ok(html.includes("createPrCheckbox.setAttribute('aria-disabled', 'true');"));
+      assert.ok(html.includes("requireApprovalCheckbox.disabled = true;"));
+      assert.ok(html.includes("requireApprovalCheckbox.setAttribute('aria-disabled', 'true');"));
     });
   });
 });


### PR DESCRIPTION
💡 What:
Added explicit `aria-disabled` attributes to form elements (submit button, text area, checkboxes, and cancel button) in the `src/composer.ts` webview. These attributes are now dynamically toggled in JavaScript alongside the native `disabled` properties.

🎯 Why:
While modern screen readers can interpret the native `disabled` attribute, dynamically managing `aria-disabled` ensures robust accessibility support for legacy screen readers interacting with dynamically injected HTML elements within VS Code webviews.

📸 Before/After:
Before: Disabled UI elements in the composer relied solely on the native `disabled` attribute.
After: Disabled UI elements explicitly mirror their disabled status using the `aria-disabled` attribute as well.

♿ Accessibility:
Improved communication of element state (interactable vs. non-interactable) for assistive technologies.

---
*PR created automatically by Jules for task [9656268677141393236](https://jules.google.com/task/9656268677141393236) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Webview コンポーザーのフォーム要素（送信ボタン、テキストエリア、チェックボックス、キャンセルボタン）に対し、ネイティブの `disabled` 属性と並行して `aria-disabled` 属性を動的に制御するよう変更されました。レガシースクリーンリーダーへのアクセシビリティ改善が目的です。

- **`src/composer.ts`**: `validate()` と `submit()` の両関数で `aria-disabled` 属性をネイティブ `disabled` と同期させるように更新。
- **`src/test/composer.unit.test.ts`**: `aria-disabled` 属性のセットを確認するアサーションを追加。チェックボックスのガード節検証は一部弱くなっている。
- **`.Jules/palette.md`**: 今回の変更から得た学習内容をドキュメントに追記。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更はアクセシビリティ属性の追加のみで、既存の動作ロジックへの影響はなく、マージは概ね安全です。

フォーム要素の disabled と aria-disabled の同期処理自体は正しく、既存の動作を壊すリスクはほぼありません。ただし validate() で有効化時に aria-disabled=false をセットする実装は removeAttribute が推奨されるパターンであり、また cancelButton の null チェック欠如とテストでのガード節検証削除という小さな品質上の懸念が残ります。

src/composer.ts の validate() 関数と src/test/composer.unit.test.ts のチェックボックス無効化テストを確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | フォーム要素の無効化時に aria-disabled 属性を同期的にセットするよう変更。aria-disabled=false の明示的なセット（removeAttribute が望ましい）と cancelButton の null チェック欠如という P2 の問題あり。 |
| src/test/composer.unit.test.ts | aria-disabled 属性のセットを検証するテストを追加。ただし if (createPrCheckbox) ガードの存在検証が削除されており、テストのカバレッジが低下している。 |
| .Jules/palette.md | 今回の変更から得られた学習内容をパレットドキュメントに追記しただけで、コードへの影響なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as ユーザー
    participant Webview as Webview
    participant AT as スクリーンリーダー
    User->>Webview: テキスト入力
    Webview->>Webview: validate() 実行
    alt "isValid = true"
        Webview->>Webview: "disabled=false, removeAttribute aria-disabled"
        Webview->>AT: ボタン有効状態を通知
    else "isValid = false"
        Webview->>Webview: "disabled=true, aria-disabled=true"
        Webview->>AT: ボタン無効状態を通知
    end
    User->>Webview: 送信ボタンクリック
    Webview->>Webview: submit() 実行
    Webview->>Webview: "全要素を disabled + aria-disabled=true に設定"
    Webview->>AT: 全フォーム要素の無効状態を通知
    Webview->>Webview: vscode.postMessage submit
    Webview-->>User: パネル破棄
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/composer.ts:259-260
`aria-disabled` を `'false'` に明示的にセットすることは冗長で、一部のレガシー AT (支援技術) が属性の「存在」だけを確認する場合に誤解を招く可能性があります。WAI-ARIA の慣例では、要素が有効な状態に戻ったときは `setAttribute('aria-disabled', 'false')` の代わりに `removeAttribute('aria-disabled')` を使うことが推奨されています。

```suggestion
      submitButton.disabled = !isValid;
      if (!isValid) {
        submitButton.setAttribute('aria-disabled', 'true');
      } else {
        submitButton.removeAttribute('aria-disabled');
      }
```

### Issue 2 of 3
src/composer.ts:292-294
**キャンセルボタンの null チェック欠如**

`document.getElementById('cancel')` は `HTMLElement | null` を返します。`createPrCheckbox` や `requireApprovalCheckbox` には `if (...)` ガードが設けられているのに、`cancelButton` には同様のガードがありません。キャンセルボタンは常にテンプレートに含まれるため実害はありませんが、一貫性の観点から `if (cancelButton)` によるガード、または元の一行式のパターンに統一することを検討してください。

### Issue 3 of 3
src/test/composer.unit.test.ts:648-651
**ガード節の検証が失われたテスト**

変更前のテストは `"if (createPrCheckbox) createPrCheckbox.disabled = true;"` という文字列を含むかどうかを確認することで、null ガードの存在も間接的にテストしていました。変更後は `"createPrCheckbox.disabled = true;"` という部分文字列の照合に変わったため、将来誰かが `if (createPrCheckbox)` ガードを誤って削除しても、このテストは通過し続けます。`if (createPrCheckbox) {` という文字列を含むアサーションも追加することで、ガードの存在を明示的に検証してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: \[UX improvement\] - Ensure Ex..."](https://github.com/hiroki-org/jules-extension/commit/6adcc767eb21abf3222507b1c2a46264fe476922) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33956235)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->