### PR TITLE
🛡️ Sentinel: [HIGH] innerHTML による XSS 脆弱性の修正と安全な DOM 更新への移行

### DIFF
--- a/review.js
+++ b/review.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+const content = fs.readFileSync('src/webview/chatAssets.ts', 'utf8');
+if (content.includes('function replaceChildren(element, nodes) {')) {
+  console.log('replaceChildren IS defined as a global helper function');
+}

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -7,6 +7,35 @@ function createChatScriptHarness(
 ) {
   let chatInnerHTML = "";
   let chatInnerHTMLSetCount = 0;
+
+  const mockDocumentCreateElement = (tag: string) => {
+    const el: any = {
+      tagName: tag.toUpperCase(),
+      className: "",
+      textContent: "",
+      childNodes: [] as any[],
+      attributes: {} as Record<string, string>,
+      setAttribute(name: string, value: string) {
+        this.attributes[name] = value;
+      },
+      getAttribute(name: string) {
+        return this.attributes[name] || null;
+      },
+      appendChild(node: any) {
+        this.childNodes.push(node);
+      },
+      replaceChildren(...nodes: any[]) {
+        this.childNodes = nodes;
+      },
+      get outerHTML(): string {
+        const text = this.textContent || "";
+        const childrenHTML = this.childNodes.map((c: any) => c.outerHTML || c.textContent || "").join("");
+        const attrStr = Object.entries(this.attributes).map(([k, v]) => ` ${k}="${v}"`).join("");
+        return `<${tag}${this.className ? ` class="${this.className}"` : ""}${attrStr}>${text}${childrenHTML}</${tag}>`;
+      }
+    };
+    return el;
+  };
   const listeners: Record<string, Record<string, any>> = {
     chat: {},
     messageInput: {},
@@ -18,6 +47,10 @@ function createChatScriptHarness(
       set innerHTML(value: string) {
         chatInnerHTMLSetCount += 1;
         chatInnerHTML = value;
+      },
+      replaceChildren: (...nodes: any[]) => {
+        chatInnerHTML = nodes.map((node) => node.outerHTML ?? node.textContent ?? "").join("");
+        chatInnerHTMLSetCount += 1;
       },
       get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
       scrollTop: 0,
@@ -47,6 +80,7 @@ function createChatScriptHarness(
   const messageListeners: Array<(event: { data: any }) => void> = [];
   const mockDocument = {
     getElementById: (id: string) => elements[id],
+    createElement: mockDocumentCreateElement,
   };
   const mockWindow = {
     addEventListener: (evt: string, cb: (event: { data: any }) => void) => {
@@ -619,7 +653,7 @@ suite("chatAssets unit tests", () => {
 
   test("CHAT_JS updateUI should properly configure disabled states and ARIA attributes", () => {
     const elements: any = {
-      chat: { innerHTML: "", scrollTop: 0, scrollHeight: 0, addEventListener: () => {}, querySelectorAll: () => [] },
+      chat: { innerHTML: "", replaceChildren: () => {}, scrollTop: 0, scrollHeight: 0, addEventListener: () => {}, querySelectorAll: () => [] },
       typing: { classList: { toggle: () => {} } },
       messageInput: {
         value: "",

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -277,24 +277,43 @@ export const CHAT_JS = `(function() {
 
   function renderMessages() {
     if (state.messages.length === 0 && !state.isTyping) {
-      const emptyStateContent = state.sessionId
-        ? '<h3>Ready to assist</h3><p>Type a message to start interacting with Jules.</p>'
-        : '<h3>Welcome to Jules</h3><p>Select a session or create a new one to begin.</p>';
-      const emptyStateHtml = \`<div class="empty-state">\${emptyStateContent}</div>\`;
-      if (chatContainer.innerHTML !== emptyStateHtml) {
-        chatContainer.innerHTML = emptyStateHtml;
-      }
+      const isReady = !!state.sessionId;
+      const titleText = isReady ? 'Ready to assist' : 'Welcome to Jules';
+      const descText = isReady ? 'Type a message to start interacting with Jules.' : 'Select a session or create a new one to begin.';
+
+      const emptyStateDiv = document.createElement('div');
+      emptyStateDiv.className = 'empty-state';
+
+      const h3 = document.createElement('h3');
+      h3.textContent = titleText;
+      emptyStateDiv.appendChild(h3);
+
+      const p = document.createElement('p');
+      p.textContent = descText;
+      emptyStateDiv.appendChild(p);
+
+      replaceChildren(chatContainer, [emptyStateDiv]);
     } else {
-      chatContainer.innerHTML = state.messages.map(m => {
-        const sanitizedHtml = sanitizeHtml(m.html);
+      const messageNodes = state.messages.map(m => {
         const roleClass = m.role === "user" ? "user" : "assistant";
-        return \`
-        <div class="message \${roleClass}">
-          <div class="bubble">\${sanitizedHtml}</div>
-          <div class="meta">\${formatTime(m.createTime)}</div>
-        </div>
-      \`;
-      }).join("");
+        const messageDiv = document.createElement('div');
+        messageDiv.className = "message " + roleClass;
+
+        const bubbleDiv = document.createElement('div');
+        bubbleDiv.className = "bubble";
+
+        renderSanitizedDetailsHtml(bubbleDiv, sanitizeHtml(m.html));
+
+        messageDiv.appendChild(bubbleDiv);
+
+        const metaDiv = document.createElement('div');
+        metaDiv.className = "meta";
+        metaDiv.textContent = formatTime(m.createTime);
+        messageDiv.appendChild(metaDiv);
+
+        return messageDiv;
+      });
+      replaceChildren(chatContainer, messageNodes);
       restoreExpandedDetails();
     }
     typingIndicator.classList.toggle("visible", !!state.isTyping);


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** `src/webview/chatAssets.ts` にて、チャットメッセージおよび空ステータスの描画に `.innerHTML` への文字列代入が行われていました。一部の DOMPurify のバイパスや不完全なサニタイズ設定があった場合、XSS（クロスサイトスクリプティング）を許容する可能性があります。
**🎯 Impact:** 悪意のあるユーザー入力や細工されたペイロードがそのまま DOM に注入され、任意のスクリプトが実行されることでセッショントークンの窃取や意図しない動作を引き起こす恐れがあります。
**🔧 Fix:**
1. `chatAssets.ts` において、空ステータスの描画を `document.createElement` と `replaceChildren` に置き換えました。
2. メッセージ描画時も `.innerHTML` を避け、既存の `sanitizeHtml` および `renderSanitizedDetailsHtml` ヘルパーを利用し、`DOMPurify` が生成する `DocumentFragment` を `replaceChildren` で安全にアペンドするようリファクタリングしました。
3. これに伴い、テストのモック（`src/test/chatAssets.unit.test.ts`）を更新し、`replaceChildren` メソッドと属性操作のスタブを実装しました。
**✅ Verification:**
- `pnpm run test:unit` がすべてパスすることを確認しました。
- `pnpm run lint` がパスすることを確認しました。
- `pnpm run check-types` がパスすることを確認しました。

---
*PR created automatically by Jules for task [15011514847469765243](https://jules.google.com/task/15011514847469765243) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `chatAssets.ts` における `innerHTML` 直接代入を `document.createElement` + `replaceChildren` ベースの安全な DOM 操作に置き換え、XSS リスクを低減します。テストモックも対応する形で更新されています。

- **XSS 修正**: 空ステータスおよびメッセージ描画の両方で `innerHTML` を廃止し、テキストコンテンツは `textContent`、HTML コンテンツは `renderSanitizedDetailsHtml` 経由の `DocumentFragment` で注入するよう変更。
- **テスト更新**: `mockDocumentCreateElement` と `replaceChildren` スタブを追加し、新しい DOM 操作パターンをカバー。
- **誤コミット**: デバッグ用の `review.js` がリポジトリルートに残っており、削除が必要。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

XSS対策のコアロジック自体は正しいが、デバッグスクリプトの誤コミットが残っており、そのままマージするには整理が必要。

review.js というデバッグスクリプトが誤コミットされており、また renderSanitizedDetailsHtml に sanitizeHtml の戻り値を渡す二重サニタイズにより sanitizedHtmlCache が実質的に無効化されている。

review.js（削除必須）、src/webview/chatAssets.ts の renderMessages 関数（二重サニタイズの修正推奨）
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| review.js | デバッグ検証スクリプト（誤コミット）。リポジトリルートに残すべきではない。 |
| src/webview/chatAssets.ts | innerHTML を createElement + replaceChildren に置き換えてXSS対策を強化。ただし renderSanitizedDetailsHtml に sanitizeHtml の戻り値を渡すことで二重サニタイズが発生している。 |
| src/test/chatAssets.unit.test.ts | replaceChildren および createElement のモックを追加し、新しい DOM 操作パターンのテストをカバー。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[renderMessages] --> B{messages が空かつ isTyping=false?}
    B -- Yes --> C[createElement div.empty-state]
    C --> D[h3/p を textContent で生成]
    D --> E[replaceChildren chatContainer]
    B -- No --> F[messages.map でノード生成]
    F --> G[createElement div.message]
    G --> H[bubbleDiv 生成]
    H --> I[renderSanitizedDetailsHtml bubbleDiv]
    I --> J[DOMPurify.sanitize RETURN_DOM_FRAGMENT true]
    J --> K[fragment.childNodes を replaceChildren]
    K --> L[metaDiv.textContent = formatTime]
    L --> M[replaceChildren chatContainer messageNodes]
    M --> N[restoreExpandedDetails]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
review.js:1-5
**デバッグ用スクリプトが誤ってコミットされています**

このファイルは `replaceChildren` ヘルパーの存在を確認するための一時的な検証スクリプトです。本番コードとは無関係であり、リポジトリルートに残すべきではありません。このファイルを削除してください。

### Issue 2 of 2
src/webview/chatAssets.ts:305
**二重サニタイズ（冗長な処理）**

`sanitizeHtml(m.html)` は既に DOMPurify でサニタイズ済みの HTML 文字列を返し、その結果をさらに `renderSanitizedDetailsHtml` に渡すと内部でもう一度 DOMPurify が実行されます。`renderSanitizedDetailsHtml` は生の HTML を受け取ってサニタイズ＋レンダリングすることを意図した関数であるため、引数には `m.html` を直接渡すべきです。`sanitizedHtmlCache` へのキャッシュが実際のレンダリングに活かされず無駄になります。

```suggestion
        renderSanitizedDetailsHtml(bubbleDiv, m.html);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[HIGH\] .innerHTML の XSS 脆弱..."](https://github.com/hiroki-org/jules-extension/commit/7ac349c07e9daf953f2ce331c09c7d10e9a5ebd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34180419)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->