### PR TITLE
🎨 Palette: セッションラベルのツールチップ追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-11 - Dynamic ARIA Labeling for Context-Aware Inputs
 **Learning:** When using context-aware placeholders (like dynamically changing the placeholder from "Select a session to start typing" to "Enter message (Ctrl/Cmd+Enter to send)"), it is crucial to synchronize these changes with ARIA attributes (`aria-label` and `title`) to ensure screen readers provide accurate, up-to-date context, preventing users from becoming disoriented by outdated or mismatched labels.
 **Action:** Next time an input element's visual cue (like a placeholder) is dynamically updated based on state, immediately map that updated string to the element's `aria-label` and `title` properties within the same DOM update cycle.
+
+## 2025-05-28 - Tooltips for Truncated Text
+**Learning:** When applying CSS text truncation (`text-overflow: ellipsis`) to dynamically populated UI elements (like session labels), users cannot read the full content if it exceeds the container's width. Without an explicit tooltip, the hidden text becomes inaccessible.
+**Action:** Next time an element uses `text-overflow: ellipsis`, ensure that its `title` attribute is synchronized with its `textContent` (e.g., `element.title = element.textContent;`) so the complete information is always available on hover.

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -510,7 +510,7 @@ export function getChatWebviewHtml(
     nonce +
     '">' +
     CHAT_CSS +
-    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
+    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true" title="Session: None selected">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
     nonce +
     '" src="' +
     domPurifyScriptUri +

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -267,6 +267,7 @@ export const CHAT_JS = `(function() {
     }
 
     sessionLabel.textContent = hasSession ? "Session: " + state.sessionId : "Session: None selected";
+    sessionLabel.title = sessionLabel.textContent;
   }
 
   function formatTime(timestamp) {


### PR DESCRIPTION
💡 What: セッションラベル (`sessionLabel`) の `title` 属性を動的な `textContent` に同期するよう変更しました。
🎯 Why: 長いセッション名が CSS の `text-overflow: ellipsis` によって省略された場合でも、ユーザーがホバーして全文を読めるようにするためです。
📸 Before/After: （視覚的な変更はありませんが、ホバー時のツールチップが追加されました）
♿ Accessibility: 画面上では隠れてしまう長いテキストをツールチップとして提供することで、情報へのアクセスを担保しました。

---
*PR created automatically by Jules for task [1166127237158880644](https://jules.google.com/task/1166127237158880644) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CSS の `text-overflow: ellipsis` により省略されるセッションラベルに対して、ホバー時のツールチップを追加するシンプルな変更です。初期 HTML と `updateUI()` の両方で `title` 属性を `textContent` と同期させることで、一貫した動作を実現しています。

- `src/webview/chatAssets.ts`: `updateUI()` 内で `sessionLabel.textContent` を設定した直後に `sessionLabel.title = sessionLabel.textContent` を追加し、動的なセッション名の変化にも対応。
- `src/chatView.ts`: 初期 HTML の `sessionLabel` 要素に `title="Session: None selected"` を追加し、JavaScript 実行前の初期状態でも tooltip が機能するよう対応。
- `.Jules/palette.md`: `text-overflow: ellipsis` 使用時の tooltip 同期パターンをチームの学習メモとして記録。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はごく小規模で、既存の DOM 操作パターンに沿った1行の追加です。初期 HTML と動的更新の両方でタイトルが正しく同期されており、安全にマージできます。

textContent を設定した直後に title を同期させる1行を追加しており、既存のロジックを壊すリスクはほぼありません。初期 HTML の title 属性も初期テキストと一致しており、一貫性があります。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | updateUI() 内で sessionLabel.textContent を設定した直後に sessionLabel.title を同期させる1行を追加。CSS の text-overflow: ellipsis による省略時にホバーで全文表示できるようになる。 |
| src/chatView.ts | 初期 HTML の sessionLabel div に title="Session: None selected" を追加し、JavaScript によるタイトル同期が行われるまでの初期状態でも tooltip が表示されるよう対応。 |
| .Jules/palette.md | text-overflow: ellipsis を使う要素には title 属性を textContent と同期させるべきという学習メモを追記。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant State as アプリ状態
    participant updateUI as updateUI()
    participant Label as sessionLabel (DOM)
    participant User as ユーザー

    State->>updateUI: セッション選択 / 状態変化
    updateUI->>Label: "textContent = "Session: id""
    updateUI->>Label: "title = textContent (NEW)"
    Label-->>User: テキストが省略された場合
    User->>Label: ホバー
    Label-->>User: ツールチップで全文表示 (NEW)
```

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: セッションラベルのツールチップ追加"](https://github.com/hiroki-org/jules-extension/commit/9ad0b1400de3e05fa74af5c6e54a1ca44ba4e442) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34382883)</sub>

<!-- /greptile_comment -->