### PR TITLE
⚡ Bolt: 文字列プレフィックス削除のパフォーマンス改善

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2026-05-21 - Optimize string suffix removal
 **Learning:** Using regular expressions like `.replace(/\.git$/, '')` inside loops or hot paths introduces unnecessary compilation and execution overhead compared to basic string operations.
 **Action:** When conditionally removing a fixed string suffix, prefer using `.endsWith()` combined with `.slice()` (e.g., `str.endsWith('.git') ? str.slice(0, -4) : str`) for better execution speed and reduced memory allocation.
+## 2026-05-30 - Optimize string suffix and prefix removal
+**Learning:** Using regular expressions like `.replace(/^sessions\//, '')` inside loops or utility functions introduces unnecessary compilation and execution overhead compared to basic string operations.
+**Action:** When conditionally removing a fixed string prefix or suffix, prefer using `.startsWith()` or `.endsWith()` combined with `.slice()` (e.g., `str.startsWith('sessions/') ? str.slice(9) : str`) for better execution speed and reduced memory allocation.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1196,7 +1196,8 @@ class JulesActivitiesDocumentProvider
   }
 
   buildUri(sessionId: string): vscode.Uri {
-    const normalized = sessionId.replace(/^sessions\//, "");
+    // Performance optimization: Avoid regex execution for prefix removal.
+    const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
     return vscode.Uri.parse(
       `jules-activities://sessions/${normalized}/activities.log`,
     );

--- a/src/planDocumentProvider.ts
+++ b/src/planDocumentProvider.ts
@@ -22,7 +22,8 @@ export class JulesPlanDocumentProvider implements vscode.TextDocumentContentProv
     }
 
     buildUri(sessionId: string): vscode.Uri {
-        const normalized = sessionId.replace(/^sessions\//, "");
+        // Performance optimization: Avoid regex execution for prefix removal.
+        const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
         // Use .md extension to enable Markdown syntax highlighting
         return vscode.Uri.parse(`jules-plan://sessions/${normalized}/plan.md`);
     }

--- a/src/sessionContextMenuArtifacts.ts
+++ b/src/sessionContextMenuArtifacts.ts
@@ -16,7 +16,8 @@ export class JulesDiffDocumentProvider implements vscode.TextDocumentContentProv
     }
 
     buildUri(sessionId: string, kind: "before" | "after"): vscode.Uri {
-        const normalized = sessionId.replace(/^sessions\//, "");
+        // Performance optimization: Avoid regex execution for prefix removal.
+        const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
         return vscode.Uri.parse(`jules-diff://sessions/${normalized}/${kind}.patch`);
     }
 }


### PR DESCRIPTION
💡 **What:** 
セッションIDから `"sessions/"` プレフィックスを削除する処理において、正規表現 (`replace(/^sessions\//, "")`) の代わりに `startsWith` と `slice(9)` を使用するよう最適化しました。

🎯 **Why:** 
正規表現のコンパイルおよび実行は、単純な文字列操作に比べてオーバーヘッドが大きく、特にユーティリティ関数などで繰り返し実行されるパスにおいては、メモリアロケーションとCPUの無駄な消費を引き起こすためです。

📊 **Impact:** 
URI生成時などの文字列操作における実行速度が向上し、不要な正規表現エンジンの呼び出しを削減します（塵も積もれば山となるパフォーマンス改善です）。

🔬 **Measurement:** 
既存のユニットテスト (`pnpm run test:unit`) および E2Eテスト がすべて成功し、ロジックに変更がない（デグレがない）ことを確認しています。

---
*PR created automatically by Jules for task [8740761169349683202](https://jules.google.com/task/8740761169349683202) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

3つの `buildUri` メソッド（`extension.ts`、`planDocumentProvider.ts`、`sessionContextMenuArtifacts.ts`）で `sessions/` プレフィックスを除去する処理を、正規表現から `startsWith` + `slice` に置き換えるパフォーマンス改善PRです。ロジックの正確性は維持されており、動作変更はありません。

- 3ファイルの `buildUri` で `.replace(/^sessions\//, "")` を `startsWith("sessions/") ? slice(9) : str` に変更。
- `slice(9)` の `9` は `"sessions/".length` に相当するマジックナンバーであり、3箇所すべてで同じ問題が存在する。
- `.jules/bolt.md` に今回の学習内容をエージェントログとして追記。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

動作は正規表現版と等価であり、マージしても既存機能への影響はない。

`slice(9)` というマジックナンバーが3ファイルで繰り返されており、`"sessions/"` プレフィックスが変更された場合に数値の更新漏れが起きやすい。機能的な問題はないが、保守性の観点でわずかに改善の余地がある。

3つの `buildUri` 実装ファイル（`src/extension.ts`、`src/planDocumentProvider.ts`、`src/sessionContextMenuArtifacts.ts`）すべてで `slice(9)` のマジックナンバーを確認することを推奨。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `buildUri` 内の正規表現を `startsWith` + `slice(9)` に置き換え。ロジックは等価だが、`9` というマジックナンバーが残存している。 |
| src/planDocumentProvider.ts | `buildUri` 内の正規表現を `startsWith` + `slice(9)` に置き換え。同じマジックナンバーの問題あり。 |
| src/sessionContextMenuArtifacts.ts | `buildUri` 内の正規表現を `startsWith` + `slice(9)` に置き換え。同じマジックナンバーの問題あり。 |
| .jules/bolt.md | 今回の最適化内容をエージェント向け学習ログに追記。問題なし。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/extension.ts:1200
`slice(9)` のマジックナンバーは `"sessions/"` が9文字であることを前提としていますが、コード上では不明瞭です。プレフィックス文字列が将来変更された際に、数値の更新漏れが生じる可能性があります。`"sessions/".length` を使うことで自己文書化でき、保守性が上がります。

```suggestion
    const PREFIX = "sessions/";
    const normalized = sessionId.startsWith(PREFIX) ? sessionId.slice(PREFIX.length) : sessionId;
```

### Issue 2 of 3
src/planDocumentProvider.ts:26
`slice(9)` のマジックナンバーは `"sessions/"` が9文字であることを前提としていますが、コード上では不明瞭です。`"sessions/".length` を使うことで自己文書化でき、保守性が上がります。

```suggestion
        const PREFIX = "sessions/";
        const normalized = sessionId.startsWith(PREFIX) ? sessionId.slice(PREFIX.length) : sessionId;
```

### Issue 3 of 3
src/sessionContextMenuArtifacts.ts:20
`slice(9)` のマジックナンバーは `"sessions/"` が9文字であることを前提としていますが、コード上では不明瞭です。`"sessions/".length` を使うことで自己文書化でき、保守性が上がります。

```suggestion
        const PREFIX = "sessions/";
        const normalized = sessionId.startsWith(PREFIX) ? sessionId.slice(PREFIX.length) : sessionId;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: optimize session prefix removal av..."](https://github.com/hiroki-org/jules-extension/commit/2a38f6318b97c8bae45fda3342b2291e8a999a69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34725810)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->