### PR TITLE
🎨 Palette: disabledな要素のARIAステータスを改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-05-26 - Title Tooltip Support for Truncated Text
 **Learning:** When applying CSS `text-overflow: ellipsis` to truncate long dynamically generated content (like a session ID), it is necessary to provide an accessible way for users to view the complete text. Mirroring the `textContent` into the `title` attribute creates a native browser tooltip, enabling hover-based discovery of the full content without requiring custom UI components.
 **Action:** Whenever using `text-overflow: ellipsis` to clip text in the DOM, synchronously update the element's `title` attribute to match the full `textContent`.
+## 2026-05-31 - Explicitly mirror disabled state to ARIA for legacy screen readers
+**Learning:** Legacy screen readers in dynamic webviews often fail to announce state changes when only the native disabled property is manipulated via JavaScript.
+**Action:** Explicitly mirror native disabled state changes (e.g., element.disabled = true;) with the corresponding ARIA attribute (e.g., element.setAttribute('aria-disabled', 'true');) on form controls.

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -124,7 +124,8 @@ export function getComposerHtml(
     outline: 1px solid var(--vscode-focusBorder);
   }
 
-  textarea:disabled {
+  textarea:disabled,
+  textarea[aria-disabled="true"] {
     opacity: 0.5;
     cursor: not-allowed;
   }
@@ -177,7 +178,8 @@ export function getComposerHtml(
     outline-offset: 2px;
   }
 
-  button:disabled {
+  button:disabled,
+  button[aria-disabled="true"] {
     opacity: 0.5;
     cursor: not-allowed;
   }
@@ -193,7 +195,9 @@ export function getComposerHtml(
   }
 
   input[type="checkbox"]:disabled,
-  input[type="checkbox"]:disabled + label {
+  input[type="checkbox"][aria-disabled="true"],
+  input[type="checkbox"]:disabled + label,
+  input[type="checkbox"][aria-disabled="true"] + label {
     opacity: 0.5;
     cursor: not-allowed;
   }
@@ -257,6 +261,7 @@ export function getComposerHtml(
     const validate = () => {
       const isValid = textarea.value.trim().length > 0;
       submitButton.disabled = !isValid;
+      submitButton.setAttribute('aria-disabled', !isValid ? 'true' : 'false');
       submitButton.title = isValid ? 'Send (Cmd/Ctrl+Enter)' : 'Type a message to send';
       submitButton.setAttribute('aria-label', isValid ? 'Send message (Cmd/Ctrl+Enter)' : 'Type a message to send');
       return isValid;
@@ -268,6 +273,7 @@ export function getComposerHtml(
       }
 
       submitButton.disabled = true;
+      submitButton.setAttribute('aria-disabled', 'true');
       submitButton.textContent = 'Sending... ';
       const spinnerSpan = document.createElement('span');
       spinnerSpan.className = 'spinner';
@@ -278,9 +284,12 @@ export function getComposerHtml(
       const srStatus = document.getElementById('sr-status');
       if (srStatus) srStatus.textContent = 'Sending message...';
       textarea.disabled = true;
-      if (createPrCheckbox) createPrCheckbox.disabled = true;
-      if (requireApprovalCheckbox) requireApprovalCheckbox.disabled = true;
-      document.getElementById('cancel').disabled = true;
+      textarea.setAttribute('aria-disabled', 'true');
+      if (createPrCheckbox) { createPrCheckbox.disabled = true; createPrCheckbox.setAttribute('aria-disabled', 'true'); }
+      if (requireApprovalCheckbox) { requireApprovalCheckbox.disabled = true; requireApprovalCheckbox.setAttribute('aria-disabled', 'true'); }
+      const cancelBtn = document.getElementById('cancel');
+      cancelBtn.disabled = true;
+      cancelBtn.setAttribute('aria-disabled', 'true');
       document.body.style.cursor = 'wait';
 
       vscode.postMessage({

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -312,7 +312,8 @@ suite("Composer Test Suite", () => {
         { title: "Test" },
         "nonce-123"
       );
-      assert.ok(html.includes('button:disabled {'));
+      assert.ok(html.includes('button:disabled,'));
+      assert.ok(html.includes('button[aria-disabled="true"] {'));
       assert.ok(html.includes('opacity: 0.5;'));
       assert.ok(html.includes('cursor: not-allowed;'));
     });
@@ -602,8 +603,12 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("const srStatus = document.getElementById('sr-status');"));
       assert.ok(html.includes("if (srStatus) srStatus.textContent = 'Sending message...';"));
       assert.ok(html.includes("submitButton.disabled = true;"));
+      assert.ok(html.includes("submitButton.setAttribute('aria-disabled', 'true');"));
       assert.ok(html.includes("textarea.disabled = true;"));
-      assert.ok(html.includes("document.getElementById('cancel').disabled = true;"));
+      assert.ok(html.includes("textarea.setAttribute('aria-disabled', 'true');"));
+      assert.ok(html.includes("const cancelBtn = document.getElementById('cancel');"));
+      assert.ok(html.includes("cancelBtn.disabled = true;"));
+      assert.ok(html.includes("cancelBtn.setAttribute('aria-disabled', 'true');"));
       assert.ok(html.includes("document.body.style.cursor = 'wait';"));
     });
 
@@ -641,8 +646,8 @@ suite("Composer Test Suite", () => {
         { title: "Test", showCreatePrCheckbox: true, showRequireApprovalCheckbox: true },
         "nonce-123"
       );
-      assert.ok(html.includes("if (createPrCheckbox) createPrCheckbox.disabled = true;"));
-      assert.ok(html.includes("if (requireApprovalCheckbox) requireApprovalCheckbox.disabled = true;"));
+      assert.ok(html.includes("if (createPrCheckbox) { createPrCheckbox.disabled = true; createPrCheckbox.setAttribute('aria-disabled', 'true'); }"));
+      assert.ok(html.includes("if (requireApprovalCheckbox) { requireApprovalCheckbox.disabled = true; requireApprovalCheckbox.setAttribute('aria-disabled', 'true'); }"));
     });
   });
 });


### PR DESCRIPTION
💡 What:
textarea, button, checkbox などの要素に対して、JavaScriptで `disabled` 状態を操作する際に `aria-disabled` 属性も同期的に変更し、CSSのセレクタに `[aria-disabled="true"]` も追加しました。

🎯 Why:
レガシースクリーンリーダーを利用している場合、ネイティブの `disabled` プロパティの変更だけでは動的なステータス変更が読み上げられない（あるいは通知されない）問題があるため、ARIA属性を明示的に指定してアクセシビリティを向上させました。

📸 Before/After:
Before:
JavaScript での `element.disabled = true;` など
CSSセレクタでの `element:disabled`

After:
JavaScript で `element.disabled = true;` と同時に `element.setAttribute('aria-disabled', 'true');` も実行。
CSSセレクタで `element:disabled` と `element[aria-disabled="true"]` を併用。

♿ Accessibility:
スクリーンリーダー向けに、フォームコントロールが非アクティブ化された際のステータスが適切に通知されるようになりました。

---
*PR created automatically by Jules for task [11467875545094689697](https://jules.google.com/task/11467875545094689697) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

レガシースクリーンリーダー向けのアクセシビリティ改善として、`textarea`・`button`・`checkbox` に対して JavaScript で `disabled` を操作する際に `aria-disabled` を同期セットし、CSS セレクタにも `[aria-disabled="true"]` を追加しました。

- `validate()` 関数で `submitButton` の `aria-disabled` を `'true'`/`'false'` で切り替え、`submit()` フローでは全フォームコントロールを一括無効化する際に `aria-disabled="true"` を同時設定。
- CSS の `:disabled` セレクタに `[aria-disabled="true"]` を組み合わせることで、ARIA 属性のみが付与された場合でも視覚的な無効スタイルが適用される。
- テストは変更されたすべての動作（CSS、submit フロー、チェックボックス）に対応したアサーションが追加されており、カバレッジは十分。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

アクセシビリティ改善が目的の変更であり、既存動作を壊すリスクは低い。

`cancelBtn` を変数に切り出した際に null ガードが付いておらず、`createPrCheckbox` / `requireApprovalCheckbox` の処理と一貫性がない。また `validate()` で `aria-disabled="false"` を明示セットする方法は一部のレガシースクリーンリーダーで混乱を招く可能性がある。いずれも現在のコードで実害が出にくい小さな改善点であり、コアロジックとテストカバレッジは問題なし。

`src/composer.ts` の submit 関数内 `cancelBtn` 周辺と `validate()` の `aria-disabled` 設定部分を確認することを推奨。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | JS で `disabled` と `aria-disabled` を同期設定、CSS セレクタに `[aria-disabled="true"]` を追加。`cancelBtn` の null ガード欠落と `aria-disabled="false"` のベストプラクティス違反が軽微に存在。 |
| src/test/composer.unit.test.ts | 変更された全動作（CSS セレクタ、submit フロー、チェックボックス）に対応するテストアサーションが追加されており、カバレッジは十分。 |
| .Jules/palette.md | 今回の変更のラーニングメモを追記。内容は実装と一致しており問題なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant textarea
    participant submitButton
    participant cancelBtn
    participant checkboxes

    User->>textarea: 文字入力 (input event)
    textarea->>submitButton: validate()
    Note over submitButton: disabled = !isValid / aria-disabled = 'true' or 'false'

    User->>submitButton: クリック (submit)
    submitButton->>submitButton: "disabled=true / aria-disabled='true'"
    submitButton->>textarea: "disabled=true / aria-disabled='true'"
    submitButton->>checkboxes: "disabled=true / aria-disabled='true'"
    submitButton->>cancelBtn: "disabled=true / aria-disabled='true'"
    submitButton->>User: "vscode.postMessage({ type: 'submit' })"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/composer.ts:264
**`aria-disabled="false"` はベストプラクティスとしては `removeAttribute` が推奨**

ARIA 仕様上 `aria-disabled="false"` は有効ですが、一部のレガシースクリーンリーダーが「disabled false」と読み上げ、ユーザーに混乱を与えることがあります。ボタンが有効な状態に戻る際は `removeAttribute('aria-disabled')` を使うと、その属性が存在しない（＝デフォルトで有効）という意味になり、より明確です。

### Issue 2 of 2
src/composer.ts:290-292
**`cancelBtn` の null ガードが欠落**

`createPrCheckbox` や `requireApprovalCheckbox` には `if (...)` で null ガードが付いていますが、`cancelBtn` には付いていません。`cancel` ボタンは静的 HTML に常に含まれているため実害は現在ありませんが、コードベース内の他の null ガードパターンと不一致であり、将来的にテンプレートが変更された場合に `TypeError` が発生するリスクがあります。

```suggestion
      const cancelBtn = document.getElementById('cancel');
      if (cancelBtn) { cancelBtn.disabled = true; cancelBtn.setAttribute('aria-disabled', 'true'); }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: disabledな要素のARIAステータスを改善"](https://github.com/hiroki-org/jules-extension/commit/528dd42cebf109e913ae120a40423820b5e904d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34797600)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->