### PR TITLE
⚡ Bolt: [パフォーマンス改善] キャッシュクリア処理での配列生成を最適化

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 ## 2026-05-21 - Optimize string suffix removal
 **Learning:** Using regular expressions like `.replace(/\.git$/, '')` inside loops or hot paths introduces unnecessary compilation and execution overhead compared to basic string operations.
 **Action:** When conditionally removing a fixed string suffix, prefer using `.endsWith()` combined with `.slice()` (e.g., `str.endsWith('.git') ? str.slice(0, -4) : str`) for better execution speed and reduced memory allocation.
+
+## 2026-05-15 - [Performance] Eliminating spread operators and .filter() chains
+**Learning:** Using spread syntax `...` inside an array literal followed by `.filter()` creates multiple intermediate arrays and forces multiple O(N) iterations, leading to unnecessary memory allocations and CPU overhead during simple array processing.
+**Action:** Use a single-pass `for...of` loop combined with a `Set` to handle array concatenation, type checking, and deduplication simultaneously.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3836,10 +3836,14 @@ export function activate(context: vscode.ExtensionContext) {
         const allKeys = context.globalState.keys();
 
         // Sources & Branches キャッシュをフィルタ
-        const branchCacheKeys = allKeys.filter((key) =>
-          key.startsWith("jules.branches."),
-        );
-        const cacheKeys = ["jules.sources", ...branchCacheKeys];
+        // パフォーマンス最適化: 中間配列の生成（.filter()とスプレッド構文）を避け、
+        // 単一のfor...ofループで直接配列を構築することで、メモリ割り当てとGCのオーバーヘッドを削減します。
+        const cacheKeys = ["jules.sources"];
+        for (const key of allKeys) {
+          if (key.startsWith("jules.branches.")) {
+            cacheKeys.push(key);
+          }
+        }
 
         // すべてのキャッシュをクリア
         await Promise.all(
@@ -3850,7 +3854,7 @@ export function activate(context: vscode.ExtensionContext) {
           `Jules cache cleared: ${cacheKeys.length} entries removed`,
         );
         logChannel.appendLine(
-          `[Jules] Cache cleared: ${cacheKeys.length} entries (1 sources + ${branchCacheKeys.length} branches)`,
+          `[Jules] Cache cleared: ${cacheKeys.length} entries (1 sources + ${cacheKeys.length - 1} branches)`,
         );
       } catch (error: any) {
         logChannel.appendLine(`[Jules] Error clearing cache: ${error.message}`);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -754,7 +754,12 @@ suite("Extension Test Suite", () => {
       (mockContext.globalState.keys as sinon.SinonStub).returns(allKeys);
 
       // キャッシュクリア処理をシミュレート
-      const branchCacheKeys = allKeys.filter(key => key.startsWith('jules.branches.'));
+      const branchCacheKeys: string[] = [];
+      for (const key of allKeys) {
+        if (key.startsWith('jules.branches.')) {
+          branchCacheKeys.push(key);
+        }
+      }
       const cacheKeys = ['jules.sources', ...branchCacheKeys];
 
       // 検証：正しいキーがフィルタされることを確認


### PR DESCRIPTION
💡 What: `clearCacheDisposable` における `allKeys.filter()` とスプレッド演算子 `...branchCacheKeys` を使った配列連結処理を、単一の `for...of` ループに置き換えました。
🎯 Why: `.filter()` による中間配列の生成と、スプレッド演算子による不要なイテレーションを避けることで、メモリ割り当て（GC負荷）とCPUオーバーヘッドを削減するためです。
📊 Impact: キャッシュクリア時の O(2N) の処理が O(N) の単一パスになり、複数の中間配列のメモリ割り当てが排除されます。
🔬 Measurement: `pnpm run test:unit` および `xvfb-run -a pnpm test` が通過することを確認しました。

---
*PR created automatically by Jules for task [10860502540829433484](https://jules.google.com/task/10860502540829433484) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

キャッシュクリア処理において `.filter()` とスプレッド演算子を使った2段階の配列構築を、単一の `for...of` ループによる直接 `push` に置き換えたパフォーマンス改善PRです。ロジックの等価性は保たれており、ログメッセージの計算も正しく更新されています。

- **`src/extension.ts`**: `branchCacheKeys` の中間配列を排除し、`cacheKeys` に直接 `push` する実装に変更。機能的に等価であり、安全な変更。
- **`src/test/extension.test.ts`**: ブランチキーのフィルタ部分を `for...of` に変更したが、`cacheKeys` の構築にはスプレッド演算子が残存しており、本番コードとの一貫性がない。
- **`.jules/bolt.md`**: 学習ノートに `Set` の使用を推奨する記述があるが、実際の実装では `Set` を用いていないため、将来の自動変更を誤誘導する可能性がある。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

本番コードの変更は機能的に等価であり、マージしても安全です。

本番コード（extension.ts）の変更は元の実装と完全に等価であり、リグレッションのリスクはほぼありません。テストファイルではスプレッド演算子が残存しており、本番コードとの実装方針が一致していません。また bolt.md の学習ノートが Set を推奨しているのに実装では使われておらず、将来の自動生成コードに影響を与える可能性があります。

src/test/extension.test.ts のスプレッド演算子の残存と、.jules/bolt.md の学習ノートの記述を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `.filter()` + スプレッド演算子を単一の `for...of` ループに置き換え。ロジック上は等価であり、ログメッセージの計算も `cacheKeys.length - 1` で正しく維持されている。 |
| src/test/extension.test.ts | `branchCacheKeys` のフィルタを `for...of` に変更したが、`cacheKeys` 構築にスプレッド演算子が残存しており、本番コードと実装方針が一致していない。 |
| .jules/bolt.md | パフォーマンス改善の学習ノートを追加。ただし `Set` の使用を推奨しているが、実際の実装では `Set` を使っていない点が乖離している。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["clearCache コマンド実行"] --> B["context.globalState.keys() で全キー取得"]
    B --> C["cacheKeys = ['jules.sources'] で初期化"]
    C --> D{"for...of ループ\n各 key を走査"}
    D -->|"key.startsWith('jules.branches.')"| E["cacheKeys.push(key)"]
    D -->|"条件不一致"| D
    E --> D
    D -->|"ループ終了"| F["Promise.all でキャッシュをクリア"]
    F --> G["成功メッセージを表示\ncacheKeys.length - 1 ブランチを報告"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/test/extension.test.ts:763
**テストの実装が本番コードと不整合**

本PRの目的はスプレッド演算子の除去ですが、テスト内の `cacheKeys` 構築は依然として `['jules.sources', ...branchCacheKeys]` のスプレッド構文を使っています。本番コードは `cacheKeys` に直接 `push` する方式に変更されているため、テストの実装との乖離があります。テストが本番ロジックをインライン再現しているなら、同じ構築方法（`cacheKeys.push(key)` 方式）に揃えるべきです。

### Issue 2 of 2
.jules/bolt.md:52-54
**学習ノートと実装の乖離（`Set` の使用）**

追加された学習ノートは「`for...of` ループと `Set` を組み合わせる」と推奨していますが、実際の `extension.ts` の実装では `Set` を使わず普通の配列への `push` のみで実現しています。今回のケースではキーの重複が発生しないため `Set` は不要であり、ノートの記述が将来の自動変更において不要な `Set` の導入を誘発する可能性があります。実際の実装に合わせてノートの記述を修正することを検討してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: \[パフォーマンス改善\] キャッシュクリア処理での配列生成を最適化"](https://github.com/hiroki-org/jules-extension/commit/72a9addaecddc66b3679af4fe38fa792648f8a6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34798102)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->