### PR TITLE
⚡ Bolt: [パフォーマンス改善] sessionIdの正規表現によるプレフィックス削除を最適化

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2026-05-21 - Optimize string suffix removal
 **Learning:** Using regular expressions like `.replace(/\.git$/, '')` inside loops or hot paths introduces unnecessary compilation and execution overhead compared to basic string operations.
 **Action:** When conditionally removing a fixed string suffix, prefer using `.endsWith()` combined with `.slice()` (e.g., `str.endsWith('.git') ? str.slice(0, -4) : str`) for better execution speed and reduced memory allocation.
+## 2026-06-02 - Optimize string prefix removal
+**Learning:** When conditionally removing a fixed string prefix like 'sessions/' in performance-sensitive logic, using '.startsWith()' combined with '.slice()' provides better execution speed and reduced overhead compared to regular expressions like '.replace(/^sessions\//, "")'.
+**Action:** Use '.startsWith()' and '.slice()' instead of regex '.replace()' for removing fixed string prefixes.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1182,7 +1182,7 @@ interface SessionsResponse {
 
 const sessionActivitiesCache: Map<string, Activity[]> = new Map();
 
-class JulesActivitiesDocumentProvider
+export class JulesActivitiesDocumentProvider
   implements vscode.TextDocumentContentProvider
 {
   private readonly contents = new Map<string, string>();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1196,7 +1196,8 @@ class JulesActivitiesDocumentProvider
   }
 
   buildUri(sessionId: string): vscode.Uri {
-    const normalized = sessionId.replace(/^sessions\//, "");
+    // Performance optimization: Use .startsWith() and .slice() instead of regex for faster prefix removal
+    const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
     return vscode.Uri.parse(
       `jules-activities://sessions/${normalized}/activities.log`,
     );

--- a/src/planDocumentProvider.ts
+++ b/src/planDocumentProvider.ts
@@ -22,7 +22,8 @@ export class JulesPlanDocumentProvider implements vscode.TextDocumentContentProv
     }
 
     buildUri(sessionId: string): vscode.Uri {
-        const normalized = sessionId.replace(/^sessions\//, "");
+        // Performance optimization: Use .startsWith() and .slice() instead of regex for faster prefix removal
+        const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
         // Use .md extension to enable Markdown syntax highlighting
         return vscode.Uri.parse(`jules-plan://sessions/${normalized}/plan.md`);
     }

--- a/src/sessionContextMenuArtifacts.ts
+++ b/src/sessionContextMenuArtifacts.ts
@@ -16,7 +16,8 @@ export class JulesDiffDocumentProvider implements vscode.TextDocumentContentProv
     }
 
     buildUri(sessionId: string, kind: "before" | "after"): vscode.Uri {
-        const normalized = sessionId.replace(/^sessions\//, "");
+        // Performance optimization: Use .startsWith() and .slice() instead of regex for faster prefix removal
+        const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
         return vscode.Uri.parse(`jules-diff://sessions/${normalized}/${kind}.patch`);
     }
 }

--- a/src/test/extension.buildUri.unit.test.ts
+++ b/src/test/extension.buildUri.unit.test.ts
@@ -1,7 +1,24 @@
 import * as assert from "assert";
+import * as vscode from "vscode";
 import { JulesActivitiesDocumentProvider } from "../extension";
 
 suite("JulesActivitiesDocumentProvider Test Suite", () => {
+    test("should return empty string for unknown URI", () => {
+        const provider = new JulesActivitiesDocumentProvider();
+        const uri = vscode.Uri.parse("jules-activities://sessions/unknown/activities.log");
+        const result = provider.provideTextDocumentContent(uri);
+        assert.strictEqual(result, "");
+    });
+
+    test("should store and retrieve content for URI", () => {
+        const provider = new JulesActivitiesDocumentProvider();
+        const uri = vscode.Uri.parse("jules-activities://sessions/test/activities.log");
+        provider.setContent(uri, "Test Content");
+
+        const result = provider.provideTextDocumentContent(uri);
+        assert.strictEqual(result, "Test Content");
+    });
+
     test("should normalize session ID by removing 'sessions/' prefix", () => {
         const provider = new JulesActivitiesDocumentProvider();
         const sessionIdWithPrefix = "sessions/abc-123-def";

--- a/src/test/extension.buildUri.unit.test.ts
+++ b/src/test/extension.buildUri.unit.test.ts
@@ -42,3 +42,13 @@ suite("JulesActivitiesDocumentProvider Test Suite", () => {
         assert.ok(uriString.endsWith("activities.log"), "URI should end with 'activities.log'");
     });
 });
+
+    test("should handle session ID with multiple sessions/ prefixes", () => {
+        const provider = new JulesActivitiesDocumentProvider();
+        const sessionIdWithPrefix = "sessions/sessions/abc-123-def";
+        const uri = provider.buildUri(sessionIdWithPrefix);
+
+        const uriString = uri.toString();
+        assert.ok(uriString.startsWith("jules-activities://"), "URI should have 'jules-activities' scheme");
+        assert.ok(uriString.includes("sessions/abc-123-def"), "URI should include normalized session ID");
+    });

--- a/src/test/extension.buildUri.unit.test.ts
+++ b/src/test/extension.buildUri.unit.test.ts
@@ -1,0 +1,27 @@
+import * as assert from "assert";
+import { JulesActivitiesDocumentProvider } from "../extension";
+
+suite("JulesActivitiesDocumentProvider Test Suite", () => {
+    test("should normalize session ID by removing 'sessions/' prefix", () => {
+        const provider = new JulesActivitiesDocumentProvider();
+        const sessionIdWithPrefix = "sessions/abc-123-def";
+        const uri = provider.buildUri(sessionIdWithPrefix);
+
+        const uriString = uri.toString();
+        assert.ok(uriString.startsWith("jules-activities://"), "URI should have 'jules-activities' scheme");
+        assert.ok(uriString.includes("abc-123-def"), "URI should include normalized session ID");
+        // Verify no double 'sessions/' prefix in the final URI
+        assert.ok(uriString.match(/sessions\/.*abc-123-def/), "Should have sessions/ prefix followed by normalized ID");
+    });
+
+    test("should handle session ID without 'sessions/' prefix", () => {
+        const provider = new JulesActivitiesDocumentProvider();
+        const sessionIdWithoutPrefix = "abc-123-def";
+        const uri = provider.buildUri(sessionIdWithoutPrefix);
+
+        const uriString = uri.toString();
+        assert.ok(uriString.startsWith("jules-activities://"), "URI should have 'jules-activities' scheme");
+        assert.ok(uriString.includes("abc-123-def"), "URI should include session ID");
+        assert.ok(uriString.endsWith("activities.log"), "URI should end with 'activities.log'");
+    });
+});

--- a/src/test/planDocumentProvider.unit.test.ts
+++ b/src/test/planDocumentProvider.unit.test.ts
@@ -305,3 +305,12 @@ suite("reviewPlanForSession", () => {
     });
 });
 
+    test("buildUri should remove 'sessions/' prefix", () => {
+        const provider = new JulesPlanDocumentProvider();
+        const uriWithPrefix = provider.buildUri("sessions/test-session-123");
+        assert.ok(uriWithPrefix.toString().includes("/test-session-123/"));
+        assert.ok(!uriWithPrefix.toString().includes("sessions/sessions/"));
+
+        const uriWithoutPrefix = provider.buildUri("test-session-456");
+        assert.ok(uriWithoutPrefix.toString().includes("/test-session-456/"));
+    });

--- a/src/test/sessionContextMenuArtifacts.unit.test.ts
+++ b/src/test/sessionContextMenuArtifacts.unit.test.ts
@@ -202,6 +202,14 @@ suite("JulesDiffDocumentProvider", () => {
         assert.ok(uriString.match(/sessions\/.*abc-123-def/), "Should have sessions/ prefix followed by normalized ID");
     });
 
+    test("should handle session ID with multiple sessions/ prefixes", () => {
+        const sessionIdWithPrefix = "sessions/sessions/abc-123-def";
+        const uri = provider.buildUri(sessionIdWithPrefix, "after");
+        const uriString = uri.toString();
+        assert.ok(uriString.startsWith("jules-diff://"));
+        assert.ok(uriString.includes("sessions/abc-123-def"));
+    });
+
     test("should handle session ID without 'sessions/' prefix", () => {
         const sessionIdWithoutPrefix = "abc-123-def";
         const uri = provider.buildUri(sessionIdWithoutPrefix, "before");


### PR DESCRIPTION
💡 What:
sessionIdから 'sessions/' プレフィックスを削除する処理において、正規表現の `.replace(/^sessions\//, "")` を `.startsWith("sessions/") ? sessionId.slice(9) : sessionId` に置き換えました。

🎯 Why:
パフォーマンス向上のためです。特定の固定文字列プレフィックスを条件付きで削除する場合、正規表現よりも `.startsWith()` と `.slice()` を組み合わせた方が、不要な正規表現のコンパイルや実行時のオーバーヘッドを削減できます。

📊 Impact:
セッションIDなどの高頻度でアクセスされる文字列の処理において、正規表現処理エンジンをバイパスし、メモリ割り当てとCPUオーバーヘッドが削減されます。

🔬 Measurement:
すべてのローカルの単体テスト（`pnpm run test:unit`、`xvfb-run -a pnpm test`）と静的解析（`pnpm run lint`、`pnpm run check-types`）が成功し、最適化された処理が正しく動作することを確認しました。

---
*PR created automatically by Jules for task [3027687066604470474](https://jules.google.com/task/3027687066604470474) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

3つのドキュメントプロバイダー（`extension.ts`、`planDocumentProvider.ts`、`sessionContextMenuArtifacts.ts`）で `sessionId` のプレフィックス削除処理を正規表現から `.startsWith()` + `.slice()` に置き換えるパフォーマンス最適化です。ロジック自体は正しく動作しますが、スタイル上の懸念が残ります。

- 3ファイルすべてで `slice(9)` のマジックナンバーを使用しており、`"sessions/".length` に置き換えるとより保守しやすくなります。
- AGENTS.md の規約（コメントは日本語で記述）に反し、追加されたコメントがすべて英語になっています。
- `.jules/bolt.md` に今回の最適化の学習メモが追記されています。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は安全にマージ可能です。最適化のロジックは正しく、既存の動作を変えません。

置き換えたロジックは正しく（`"sessions/"` は9文字）、動作に影響はありません。指摘事項はマジックナンバー `9` の使用とコメントの言語（英語 vs 日本語）のみで、いずれもスタイル上の問題です。

`src/extension.ts`、`src/planDocumentProvider.ts`、`src/sessionContextMenuArtifacts.ts` の3ファイルに同じパターンの修正候補があります。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `buildUri` 内の正規表現を `.startsWith()` + `.slice(9)` に置き換え。ロジックは正しいが、マジックナンバー `9` と英語コメントが残存。 |
| src/planDocumentProvider.ts | `buildUri` 内で同様の最適化を適用。マジックナンバー `9` と英語コメントが残存。 |
| src/sessionContextMenuArtifacts.ts | `buildUri` 内で同様の最適化を適用。マジックナンバー `9` と英語コメントが残存。 |
| .jules/bolt.md | 今回の最適化に関する学習メモを追記。内容は適切。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/extension.ts:1200
`9` はハードコードされたマジックナンバーです。プレフィックス文字列 `"sessions/"` を変更した場合、この数値も合わせて修正し忘れるリスクがあります。`"sessions/".length` を使用することで、文字列と長さの一致が常に保証されます。同様の変更が `planDocumentProvider.ts` と `sessionContextMenuArtifacts.ts` にも必要です。

```suggestion
    const normalized = sessionId.startsWith("sessions/") ? sessionId.slice("sessions/".length) : sessionId;
```

### Issue 2 of 4
src/extension.ts:1199-1200
AGENTS.md のコーディング規約では「コメントは日本語で記述する」と定められていますが、追加されたコメントが英語になっています。

```suggestion
    // パフォーマンス最適化: 正規表現の代わりに .startsWith() と .slice() を使用してプレフィックスを削除
    const normalized = sessionId.startsWith("sessions/") ? sessionId.slice("sessions/".length) : sessionId;
```

### Issue 3 of 4
src/planDocumentProvider.ts:25-26
同様に、マジックナンバー `9` を `"sessions/".length` に置き換え、コメントも日本語に統一することを推奨します（AGENTS.md の規約に準拠）。

```suggestion
        // パフォーマンス最適化: 正規表現の代わりに .startsWith() と .slice() を使用してプレフィックスを削除
        const normalized = sessionId.startsWith("sessions/") ? sessionId.slice("sessions/".length) : sessionId;
```

### Issue 4 of 4
src/sessionContextMenuArtifacts.ts:19-20
同様に、マジックナンバー `9` を `"sessions/".length` に置き換え、コメントも日本語に統一することを推奨します（AGENTS.md の規約に準拠）。

```suggestion
        // パフォーマンス最適化: 正規表現の代わりに .startsWith() と .slice() を使用してプレフィックスを削除
        const normalized = sessionId.startsWith("sessions/") ? sessionId.slice("sessions/".length) : sessionId;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: \[パフォーマンス改善\] sessionIdの正規表現によるプレフ..."](https://github.com/hiroki-org/jules-extension/commit/47d0e3d38bc9e5f8818e28c65078b5b581c85f25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35167117)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->