### PR TITLE
🛡️ Sentinel: [DOMPurifyのMathML設定によるXSS対策]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,7 +6,7 @@
 ## 2024-05-13 - [DOMPurify MathML Tags Disable]
 **Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS), but using `USE_PROFILES` incorrectly strips default HTML tags.
 **Learning:** `USE_PROFILES` resets `ALLOWED_TAGS`. If you provide an invalid key or do not include standard profiles like `html`, DOMPurify removes safe HTML tags like `<p>` and `<a>`, causing UI breakage.
-**Prevention:** To disable specific attack vectors like MathML while preserving default safe tags, use `FORBID_TAGS: ['math', 'annotation', ...]` rather than altering profiles.
+**Prevention:** Superseded by the 2026-06-03 entry below. Use explicit `USE_PROFILES: { html: true, svg: true, math: false }`; `FORBID_TAGS` is not sufficient for robustly disabling the MathML namespace.
 
 ## 2024-05-25 - [innerHTML replacement]
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,3 +13,7 @@
 **Vulnerability:** Use of innerHTML in composer.ts to set loading spinner.
 **Learning:** Assigning strings containing HTML to innerHTML is inherently risky and can lead to XSS if user inputs are ever involved. Using document.createElement and appendChild is the safe and secure approach.
 **Prevention:** Avoid .innerHTML and use safer DOM APIs like textContent, document.createElement, and appendChild.
+## 2026-06-03 - DOMPurify MathML bypass prevention
+**Vulnerability:** mXSS vulnerability via MathML parsing bypass in DOMPurify.
+**Learning:** Using FORBID_TAGS is insufficient for disabling MathML namespace robustly. DOMPurify's USE_PROFILES configuration is required, but setting { math: false } alone resets defaults and breaks standard HTML tags.
+**Prevention:** Explicitly configure USE_PROFILES: { html: true, svg: true, math: false } to securely disable MathML while preserving expected rendering.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,7 +6,7 @@
 ## 2024-05-13 - [DOMPurify MathML Tags Disable]
 **Vulnerability:** Unnecessary MathML parsing in DOMPurify could widen the attack surface for Cross-Site Scripting (XSS), but using `USE_PROFILES` incorrectly strips default HTML tags.
 **Learning:** `USE_PROFILES` resets `ALLOWED_TAGS`. If you provide an invalid key or do not include standard profiles like `html`, DOMPurify removes safe HTML tags like `<p>` and `<a>`, causing UI breakage.
-**Prevention:** Superseded by the 2026-06-03 entry below. Use explicit `USE_PROFILES: { html: true, svg: true, math: false }`; `FORBID_TAGS` is not sufficient for robustly disabling the MathML namespace.
+**Prevention:** To disable specific attack vectors like MathML while preserving default safe tags, use `FORBID_TAGS: ['math', 'annotation', ...]` rather than altering profiles.
 
 ## 2024-05-25 - [innerHTML replacement]
 

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -764,8 +764,8 @@ suite("chatAssets unit tests", () => {
     harness.listeners.messageInput.input();
     assert.strictEqual(harness.elements.messageInput.style.height, "53px");
   });
+});
 
   test("CHAT_JS should ignore clicks while copy feedback is active", () => {
     assert.ok(CHAT_JS.includes('copyButton.hasAttribute("data-copy-feedback-active")'));
   });
-});

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -189,7 +189,7 @@ suite("chatAssets unit tests", () => {
     ]);
     assert.strictEqual(sanitizeConfig.RETURN_DOM, false);
     assert.strictEqual(sanitizeConfig.RETURN_DOM_FRAGMENT, true);
-    assert.deepStrictEqual(sanitizeConfig.FORBID_TAGS, ["math", "annotation", "annotation-xml", "maction", "mi", "mn", "mo", "ms", "mtext", "semantics"]);
+    assert.deepStrictEqual(sanitizeConfig.USE_PROFILES, { html: true, svg: true, math: false });
   });
 
   test("CHAT_JS should fail closed when DOMPurify is unavailable", () => {

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -764,8 +764,8 @@ suite("chatAssets unit tests", () => {
     harness.listeners.messageInput.input();
     assert.strictEqual(harness.elements.messageInput.style.height, "53px");
   });
-});
 
   test("CHAT_JS should ignore clicks while copy feedback is active", () => {
     assert.ok(CHAT_JS.includes('copyButton.hasAttribute("data-copy-feedback-active")'));
   });
+});

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -88,7 +88,7 @@ export const CHAT_JS = `(function() {
       ADD_ATTR: ["data-activity-id", "data-detail-type", "data-index"],
       RETURN_DOM: false,
       RETURN_DOM_FRAGMENT: false,
-      FORBID_TAGS: ["math", "annotation", "annotation-xml", "maction", "mi", "mn", "mo", "ms", "mtext", "semantics"],
+      USE_PROFILES: { html: true, svg: true, math: false },
     }, overrides || {});
   }
 

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -79,6 +79,7 @@ export const CHAT_JS = `(function() {
   const DOMPURIFY_ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto|tel|callto|sms|cid|xmpp|vscode-webview-resource):|(?![a-z][a-z0-9+.-]*:))/i;
   const SANITIZATION_FAILURE_HTML = '<span class="message-unavailable" role="status" aria-label="Message unavailable">Message unavailable</span>';
   const SANITIZED_HTML_CACHE_LIMIT = 500;
+  const SANITIZE_USE_PROFILES = { html: true, svg: true, math: false };
   const sanitizedHtmlCache = new Map();
 
   function createSanitizeConfig(overrides) {
@@ -88,8 +89,9 @@ export const CHAT_JS = `(function() {
       ADD_ATTR: ["data-activity-id", "data-detail-type", "data-index"],
       RETURN_DOM: false,
       RETURN_DOM_FRAGMENT: false,
-      USE_PROFILES: { html: true, svg: true, math: false },
-    }, overrides || {});
+    }, overrides || {}, {
+      USE_PROFILES: SANITIZE_USE_PROFILES,
+    });
   }
 
   function rememberSanitizedHtml(html, sanitizedHtml) {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -79,7 +79,6 @@ export const CHAT_JS = `(function() {
   const DOMPURIFY_ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto|tel|callto|sms|cid|xmpp|vscode-webview-resource):|(?![a-z][a-z0-9+.-]*:))/i;
   const SANITIZATION_FAILURE_HTML = '<span class="message-unavailable" role="status" aria-label="Message unavailable">Message unavailable</span>';
   const SANITIZED_HTML_CACHE_LIMIT = 500;
-  const SANITIZE_USE_PROFILES = { html: true, svg: true, math: false };
   const sanitizedHtmlCache = new Map();
 
   function createSanitizeConfig(overrides) {
@@ -89,9 +88,8 @@ export const CHAT_JS = `(function() {
       ADD_ATTR: ["data-activity-id", "data-detail-type", "data-index"],
       RETURN_DOM: false,
       RETURN_DOM_FRAGMENT: false,
-    }, overrides || {}, {
-      USE_PROFILES: SANITIZE_USE_PROFILES,
-    });
+      USE_PROFILES: { html: true, svg: true, math: false },
+    }, overrides || {});
   }
 
   function rememberSanitizedHtml(html, sanitizedHtml) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: DOMPurifyに設定されていた `FORBID_TAGS` によるMathMLタグの無効化だけでは、MathML名前空間を悪用したmXSS（Mutation XSS）バイパスの可能性があります。
🎯 Impact: Webview内に悪意のあるスクリプトが挿入され、実行されるリスクがあります。
🔧 Fix: `USE_PROFILES: { html: true, svg: true, math: false }` を明示的に設定し、デフォルトの安全なHTML/SVGタグのレンダリングを維持しつつ、セキュアにMathMLを無効化しました。
✅ Verification: `pnpm run test:unit` を実行し、`src/test/chatAssets.unit.test.ts` で `USE_PROFILES` の設定が正しく適用されていることを確認しました。また、lintと型チェックが通過することを確認しました。

---
*PR created automatically by Jules for task [3477594418548339392](https://jules.google.com/task/3477594418548339392) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

DOMPurify の MathML 無効化を `FORBID_TAGS` から `USE_PROFILES: { html: true, svg: true, math: false }` に変更し、mXSS バイパスリスクを解消します。また、前回レビューで指摘されたセキュリティ設定の上書き可能問題と孤立テスト問題がいずれも本 PR で修正されています。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージ安全。MathML mXSS 対策が正しく実装されており、過去の指摘事項もすべて解消されています。

`USE_PROFILES` を `Object.assign` の最終引数に置くことで安全設定が上書きされない構造になっており、孤立していたテストも `suite()` 内に移動して正しく実行されます。セキュリティ上の懸念となる新たな欠陥は確認されません。

特に注意が必要なファイルはありません。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | `FORBID_TAGS` による MathML 無効化を `USE_PROFILES: { html: true, svg: true, math: false }` に置き換え、`Object.assign` の最後の引数として配置することで上書き不可を保証。 |
| src/test/chatAssets.unit.test.ts | `USE_PROFILES` の設定検証に更新し、`suite()` ブロック外に孤立していたテストを正しくブロック内に移動。 |
| .jules/sentinel.md | センチネルログを更新し、`FORBID_TAGS` アプローチの廃止と `USE_PROFILES` への移行理由を記録。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/test/chatAssets.unit.test.ts`, line 769-771 ([link](https://github.com/hiroki-org/jules-extension/blob/1c294dd80aeb043e1173ea5d081d0d2a48cc87bf/src/test/chatAssets.unit.test.ts#L769-L771)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **suite() の外に配置された孤立テスト**

   このテストは `suite("chatAssets unit tests", ...)` ブロック（767行目で閉じる）の外に記述されており、テストランナーに正しく登録されません。このため、`pnpm run test:unit` を実行してもこのテストは実行されず、コピーフィードバックの二重クリック防止ロジックが検証されない状態です。この問題はこの PR で導入されたものではありませんが、セキュリティ関連テストの網羅性を維持するために修正が推奨されます。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 769-771

   Comment:
   **suite() の外に配置された孤立テスト**

   このテストは `suite("chatAssets unit tests", ...)` ブロック（767行目で閉じる）の外に記述されており、テストランナーに正しく登録されません。このため、`pnpm run test:unit` を実行してもこのテストは実行されず、コピーフィードバックの二重クリック防止ロジックが検証されない状態です。この問題はこの PR で導入されたものではありませんが、セキュリティ関連テストの網羅性を維持するために修正が推奨されます。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `src/webview/chatAssets.ts`, line 84-93 ([link](https://github.com/hiroki-org/jules-extension/blob/1c294dd80aeb043e1173ea5d081d0d2a48cc87bf/src/webview/chatAssets.ts#L84-L93)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `USE_PROFILES` が `overrides` で上書き可能な設計

   `Object.assign` のマージ順序により、`overrides` に `USE_PROFILES` キーが含まれている場合、セキュリティクリティカルな MathML 無効化設定が上書きされます。現時点では呼び出し元が `{ RETURN_DOM_FRAGMENT: true }` のみを渡しているため実害はありませんが、将来の呼び出し元が誤って `USE_PROFILES` を渡した場合に無効化される潜在リスクがあります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 84-93

   Comment:
   `USE_PROFILES` が `overrides` で上書き可能な設計

   `Object.assign` のマージ順序により、`overrides` に `USE_PROFILES` キーが含まれている場合、セキュリティクリティカルな MathML 無効化設定が上書きされます。現時点では呼び出し元が `{ RETURN_DOM_FRAGMENT: true }` のみを渡しているため実害はありませんが、将来の呼び出し元が誤って `USE_PROFILES` を渡した場合に無効化される潜在リスクがあります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Fix: securely disable MathML parsing for..."](https://github.com/hiroki-org/jules-extension/commit/719e5e4109f464a37a4c19db08ddc52b82813f2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35389347)</sub>

<!-- /greptile_comment -->