### PR TITLE
🎨 Palette: フォーム要素の無効化状態とARIA属性の同期

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-05-26 - Title Tooltip Support for Truncated Text
 **Learning:** When applying CSS `text-overflow: ellipsis` to truncate long dynamically generated content (like a session ID), it is necessary to provide an accessible way for users to view the complete text. Mirroring the `textContent` into the `title` attribute creates a native browser tooltip, enabling hover-based discovery of the full content without requiring custom UI components.
 **Action:** Whenever using `text-overflow: ellipsis` to clip text in the DOM, synchronously update the element's `title` attribute to match the full `textContent`.
+## 2024-06-03 - Mirror Disabled States
+**Learning:** Legacy screen readers in dynamic webviews may fail to announce native disabled state changes reliably.
+**Action:** Always mirror native disabled property changes (e.g., .disabled = true) with explicit ARIA attributes (e.g., .setAttribute('aria-disabled', 'true')) on form controls.

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -124,7 +124,8 @@ export function getComposerHtml(
     outline: 1px solid var(--vscode-focusBorder);
   }
 
-  textarea:disabled {
+  textarea:disabled,
+  textarea[aria-disabled="true"] {
     opacity: 0.5;
     cursor: not-allowed;
   }
@@ -164,11 +165,11 @@ export function getComposerHtml(
     color: var(--vscode-button-foreground);
   }
 
-  button.primary:hover:not(:disabled) {
+  button.primary:hover:not(:disabled):not([aria-disabled="true"]) {
     background: var(--vscode-button-hoverBackground);
   }
 
-  button:not(.primary):hover:not(:disabled) {
+  button:not(.primary):hover:not(:disabled):not([aria-disabled="true"]) {
     background: var(--vscode-button-secondaryHoverBackground);
   }
 
@@ -177,7 +178,8 @@ export function getComposerHtml(
     outline-offset: 2px;
   }
 
-  button:disabled {
+  button:disabled,
+  button[aria-disabled="true"] {
     opacity: 0.5;
     cursor: not-allowed;
   }
@@ -193,7 +195,9 @@ export function getComposerHtml(
   }
 
   input[type="checkbox"]:disabled,
-  input[type="checkbox"]:disabled + label {
+  input[type="checkbox"]:disabled + label,
+  input[type="checkbox"][aria-disabled="true"],
+  input[type="checkbox"][aria-disabled="true"] + label {
     opacity: 0.5;
     cursor: not-allowed;
   }
@@ -257,6 +261,7 @@ export function getComposerHtml(
     const validate = () => {
       const isValid = textarea.value.trim().length > 0;
       submitButton.disabled = !isValid;
+      submitButton.setAttribute('aria-disabled', !isValid ? 'true' : 'false');
       submitButton.title = isValid ? 'Send (Cmd/Ctrl+Enter)' : 'Type a message to send';
       submitButton.setAttribute('aria-label', isValid ? 'Send message (Cmd/Ctrl+Enter)' : 'Type a message to send');
       return isValid;
@@ -268,6 +273,7 @@ export function getComposerHtml(
       }
 
       submitButton.disabled = true;
+      submitButton.setAttribute('aria-disabled', 'true');
       submitButton.textContent = 'Sending... ';
       const spinnerSpan = document.createElement('span');
       spinnerSpan.className = 'spinner';
@@ -278,9 +284,18 @@ export function getComposerHtml(
       const srStatus = document.getElementById('sr-status');
       if (srStatus) srStatus.textContent = 'Sending message...';
       textarea.disabled = true;
-      if (createPrCheckbox) createPrCheckbox.disabled = true;
-      if (requireApprovalCheckbox) requireApprovalCheckbox.disabled = true;
-      document.getElementById('cancel').disabled = true;
+      textarea.setAttribute('aria-disabled', 'true');
+      if (createPrCheckbox) {
+        createPrCheckbox.disabled = true;
+        createPrCheckbox.setAttribute('aria-disabled', 'true');
+      }
+      if (requireApprovalCheckbox) {
+        requireApprovalCheckbox.disabled = true;
+        requireApprovalCheckbox.setAttribute('aria-disabled', 'true');
+      }
+      const cancelButton = document.getElementById('cancel');
+      cancelButton.disabled = true;
+      cancelButton.setAttribute('aria-disabled', 'true');
       document.body.style.cursor = 'wait';
 
       vscode.postMessage({

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -312,7 +312,8 @@ suite("Composer Test Suite", () => {
         { title: "Test" },
         "nonce-123"
       );
-      assert.ok(html.includes('button:disabled {'));
+      assert.ok(html.includes('button:disabled,'));
+      assert.ok(html.includes('button[aria-disabled="true"] {'));
       assert.ok(html.includes('opacity: 0.5;'));
       assert.ok(html.includes('cursor: not-allowed;'));
     });
@@ -325,11 +326,11 @@ suite("Composer Test Suite", () => {
       );
       assert.match(
         html,
-        /button\.primary:hover:not\(:disabled\)\s*\{\s*background:\s*var\(--vscode-button-hoverBackground\);\s*\}/
+        /button\.primary:hover:not\(:disabled\):not\(\[aria-disabled="true"\]\)\s*\{\s*background:\s*var\(--vscode-button-hoverBackground\);\s*\}/
       );
       assert.match(
         html,
-        /button:not\(\.primary\):hover:not\(:disabled\)\s*\{\s*background:\s*var\(--vscode-button-secondaryHoverBackground\);\s*\}/
+        /button:not\(\.primary\):hover:not\(:disabled\):not\(\[aria-disabled="true"\]\)\s*\{\s*background:\s*var\(--vscode-button-secondaryHoverBackground\);\s*\}/
       );
     });
 
@@ -511,6 +512,7 @@ suite("Composer Test Suite", () => {
       );
       // The validate function should set submitButton.disabled
       assert.ok(html.includes('submitButton.disabled = !isValid;'));
+      assert.ok(html.includes("submitButton.setAttribute('aria-disabled', !isValid ? 'true' : 'false');"));
     });
 
     test("should prevent default on Cmd/Ctrl+Enter before validation", () => {
@@ -602,8 +604,12 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("const srStatus = document.getElementById('sr-status');"));
       assert.ok(html.includes("if (srStatus) srStatus.textContent = 'Sending message...';"));
       assert.ok(html.includes("submitButton.disabled = true;"));
+      assert.ok(html.includes("submitButton.setAttribute('aria-disabled', 'true');"));
       assert.ok(html.includes("textarea.disabled = true;"));
-      assert.ok(html.includes("document.getElementById('cancel').disabled = true;"));
+      assert.ok(html.includes("textarea.setAttribute('aria-disabled', 'true');"));
+      assert.ok(html.includes("const cancelButton = document.getElementById('cancel');"));
+      assert.ok(html.includes("cancelButton.disabled = true;"));
+      assert.ok(html.includes("cancelButton.setAttribute('aria-disabled', 'true');"));
       assert.ok(html.includes("document.body.style.cursor = 'wait';"));
     });
 
@@ -641,8 +647,12 @@ suite("Composer Test Suite", () => {
         { title: "Test", showCreatePrCheckbox: true, showRequireApprovalCheckbox: true },
         "nonce-123"
       );
-      assert.ok(html.includes("if (createPrCheckbox) createPrCheckbox.disabled = true;"));
-      assert.ok(html.includes("if (requireApprovalCheckbox) requireApprovalCheckbox.disabled = true;"));
+      assert.ok(html.includes("if (createPrCheckbox) {"));
+      assert.ok(html.includes("createPrCheckbox.disabled = true;"));
+      assert.ok(html.includes("createPrCheckbox.setAttribute('aria-disabled', 'true');"));
+      assert.ok(html.includes("if (requireApprovalCheckbox) {"));
+      assert.ok(html.includes("requireApprovalCheckbox.disabled = true;"));
+      assert.ok(html.includes("requireApprovalCheckbox.setAttribute('aria-disabled', 'true');"));
     });
   });
 });


### PR DESCRIPTION
💡 What: ComposerのWebviewにおける動的なフォーム要素（textarea、ボタン、チェックボックス）に対して、ネイティブの `.disabled` 状態の変更を `aria-disabled="true"` 属性で同期するように実装しました。対応するCSSおよびユニットテストも更新しています。

🎯 Why: Webview環境において、古いスクリーンリーダーはネイティブの `.disabled` プロパティの動的な変更を正しくアナウンスしない場合があります。ARIA属性を明示的に付与することで、無効化された要素の状態がスクリーンリーダーユーザーに正確に伝わり、アクセシビリティとUXが向上します。

📸 Before/After: （視覚的な変更はありませんが、スクリーンリーダーの読み上げが正確になります）

♿ Accessibility: フォーム送信時のローディング中やバリデーションエラー時に、各操作要素へ即座に `aria-disabled` を付与し、フォーカス可能な状態であってもスクリーンリーダーが正しく「無効」と認識できるように改善しました。

---
*PR created automatically by Jules for task [3558656508516158446](https://jules.google.com/task/3558656508516158446) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、ComposerのWebviewにおけるフォーム要素（textarea・ボタン・チェックボックス）の `disabled` 状態変更時に `aria-disabled` 属性を同期することで、古いスクリーンリーダー向けのアクセシビリティを向上させます。対応するCSSセレクターとユニットテストも更新されています。

- `submit()` 実行時に textarea・submit ボタン・キャンセルボタン・チェックボックスへ `aria-disabled="true"` を付与し、`validate()` でのボタン有効化時には `aria-disabled="false"` を設定するよう変更。
- CSS に `[aria-disabled="true"]` セレクターを追加し、ネイティブの `:disabled` と同等のスタイル（opacity・カーソル・ホバー抑制）を適用。
- `.Jules/palette.md` に今回の知見（legacyスクリーンリーダー向けARIA同期）を記録。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

スタイル上の微細な改善点のみで、動作上の問題は存在しない。マージ安全。

変更はアクセシビリティ改善が目的のシンプルなARIA属性の同期で、既存のネイティブ disabled 制御と組み合わせて正しく動作する。唯一気になる点は、submitButton が有効になる際に aria-disabled="false" をセットしている箇所で、WAI-ARIA 推奨パターンの removeAttribute に変更した方がスクリーンリーダーとの相性が良い。致命的なバグは見当たらない。

src/composer.ts の validate() 内の aria-disabled="false" 設定箇所、および .Jules/palette.md の日付誤記。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | フォーム要素（textarea・ボタン・チェックボックス）の disabled 変更時に aria-disabled 属性を同期するよう修正。CSS セレクターも対応。aria-disabled="false" の設定は removeAttribute の方が望ましい。 |
| src/test/composer.unit.test.ts | 新しい aria-disabled 属性の付与とキャンセルボタンのリファクタリングに合わせてテストを更新。既存の検証が維持されており問題なし。 |
| .Jules/palette.md | 今回の学習内容を記録したドキュメント更新。日付が 2024-06-03 と誤記されており、正しくは 2026-06-03。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Textarea
    participant SubmitButton
    participant CancelButton
    participant Checkboxes
    participant ScreenReader

    User->>Textarea: 入力
    Textarea->>SubmitButton: validate()
    SubmitButton->>SubmitButton: "disabled = false"
    SubmitButton->>ScreenReader: aria-disabled removed

    User->>SubmitButton: クリック（送信）
    SubmitButton->>SubmitButton: "disabled = true"
    SubmitButton->>ScreenReader: "aria-disabled=true"
    SubmitButton->>Textarea: "disabled=true, aria-disabled=true"
    SubmitButton->>CancelButton: "disabled=true, aria-disabled=true"
    SubmitButton->>Checkboxes: "disabled=true, aria-disabled=true"
    ScreenReader-->>User: 各要素を「無効」とアナウンス
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/composer.ts:264
`aria-disabled="false"` を明示的に設定するよりも、属性を削除する方が推奨パターンです。一部のスクリーンリーダーは `aria-disabled="false"` を "disabled: false" と読み上げてしまう場合があり、ユーザーに余分な情報を伝えてしまいます。WAI-ARIA の仕様では、要素が有効な状態のときは属性を削除するか省略するのが望ましいとされています。

```suggestion
      if (!isValid) {
        submitButton.setAttribute('aria-disabled', 'true');
      } else {
        submitButton.removeAttribute('aria-disabled');
      }
```

### Issue 2 of 2
.Jules/palette.md:16
見出しの年が `2024` になっていますが、正しくは `2026` です。

```suggestion
## 2026-06-03 - Mirror Disabled States
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: mirror native disabled state with ..."](https://github.com/hiroki-org/jules-extension/commit/3d8f9c68a629e38cd1106f7b07fbc9e3c489d325) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35393535)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->