### PR TITLE
⚡ Bolt: [Performance] 固定文字列プレフィックス削除の最適化

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,6 +42,7 @@
 ## 2026-05-15 - [Performance] Eliminating spread operators and .filter() chains
 **Learning:** Using spread syntax `...` inside an array literal followed by `.filter()` creates multiple intermediate arrays and forces multiple O(N) iterations, leading to unnecessary memory allocations and CPU overhead during simple array processing.
 **Action:** Use a single-pass `for...of` loop combined with a `Set` to handle array concatenation, type checking, and deduplication simultaneously.
+
 ## 2024-05-19 - Avoid Chaining Array Methods for UI Lists
 **Learning:** Chaining functional array methods like `.filter().map()` to generate lists for UI components (like VS Code's `showQuickPick`) introduces unnecessary intermediate array allocations and redundant sequential traversals. This is particularly relevant when mapping data for dropdowns, quick picks, or tree views where performance matters.
 **Action:** When filtering and transforming arrays for UI components, use a single-pass loop (e.g., `for...of`) to combine both operations. This directly populates the final array, reducing GC pressure and avoiding O(2N) iteration.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 ## 2026-05-21 - Optimize string suffix removal
 **Learning:** Using regular expressions like `.replace(/\.git$/, '')` inside loops or hot paths introduces unnecessary compilation and execution overhead compared to basic string operations.
 **Action:** When conditionally removing a fixed string suffix, prefer using `.endsWith()` combined with `.slice()` (e.g., `str.endsWith('.git') ? str.slice(0, -4) : str`) for better execution speed and reduced memory allocation.
+
+## 2026-06-04 - [Performance] Optimize string prefix removal
+**Learning:** Using regular expressions like `.replace(/^sessions\//, '')` introduces unnecessary compilation and execution overhead compared to basic string operations.
+**Action:** When conditionally removing a fixed string prefix, prefer using `.startsWith()` combined with `.slice()` for better execution speed and reduced memory allocation.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,7 +72,7 @@ import {
   type ActivityUnionKey,
 } from "./activityUtils";
 
-import { JULES_API_BASE_URL, ALL_SOURCES_ID } from "./julesApiConstants";
+import { JULES_API_BASE_URL, ALL_SOURCES_ID, SESSION_URI_PREFIX } from "./julesApiConstants";
 import {
   createJulesSession,
   sendMessage as sendMessageToApi,
@@ -1181,8 +1181,6 @@ interface SessionsResponse {
 }
 
 const sessionActivitiesCache: Map<string, Activity[]> = new Map();
-const SESSION_URI_PREFIX = "sessions/";
-
 export class JulesActivitiesDocumentProvider
   implements vscode.TextDocumentContentProvider
 {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1196,7 +1196,8 @@ class JulesActivitiesDocumentProvider
   }
 
   buildUri(sessionId: string): vscode.Uri {
-    const normalized = sessionId.replace(/^sessions\//, "");
+    // Performance optimization: Avoid regex replace for fixed string prefix removal to reduce overhead.
+    const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
     return vscode.Uri.parse(
       `jules-activities://sessions/${normalized}/activities.log`,
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1182,7 +1182,7 @@ interface SessionsResponse {
 
 const sessionActivitiesCache: Map<string, Activity[]> = new Map();
 
-class JulesActivitiesDocumentProvider
+export class JulesActivitiesDocumentProvider
   implements vscode.TextDocumentContentProvider
 {
   private readonly contents = new Map<string, string>();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1181,6 +1181,7 @@ interface SessionsResponse {
 }
 
 const sessionActivitiesCache: Map<string, Activity[]> = new Map();
+const SESSION_URI_PREFIX = "sessions/";
 
 export class JulesActivitiesDocumentProvider
   implements vscode.TextDocumentContentProvider
@@ -1197,7 +1198,9 @@ export class JulesActivitiesDocumentProvider
 
   buildUri(sessionId: string): vscode.Uri {
     // Performance optimization: Avoid regex replace for fixed string prefix removal to reduce overhead.
-    const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
+    const normalized = sessionId.startsWith(SESSION_URI_PREFIX)
+      ? sessionId.slice(SESSION_URI_PREFIX.length)
+      : sessionId;
     return vscode.Uri.parse(
       `jules-activities://sessions/${normalized}/activities.log`,
     );

--- a/src/julesApiConstants.ts
+++ b/src/julesApiConstants.ts
@@ -1,3 +1,4 @@
 export const JULES_API_BASE_URL = "https://jules.googleapis.com/v1alpha";
 export const ALL_SOURCES_ID = "all_repos";
+/** Prefix used when normalizing VS Code virtual document session URIs. */
 export const SESSION_URI_PREFIX = "sessions/";

--- a/src/julesApiConstants.ts
+++ b/src/julesApiConstants.ts
@@ -1,2 +1,3 @@
 export const JULES_API_BASE_URL = "https://jules.googleapis.com/v1alpha";
 export const ALL_SOURCES_ID = "all_repos";
+export const SESSION_URI_PREFIX = "sessions/";

--- a/src/planDocumentProvider.ts
+++ b/src/planDocumentProvider.ts
@@ -2,6 +2,8 @@ import * as vscode from "vscode";
 import { formatFullPlan, type Plan } from "./planUtils";
 import { isValidSessionId } from "./securityUtils";
 
+const SESSION_URI_PREFIX = "sessions/";
+
 /**
  * TextDocumentContentProvider for displaying plan content in a virtual document.
  * Uses the `jules-plan` URI scheme to provide Markdown-formatted plan content.
@@ -23,7 +25,9 @@ export class JulesPlanDocumentProvider implements vscode.TextDocumentContentProv
 
     buildUri(sessionId: string): vscode.Uri {
         // Performance optimization: Avoid regex replace for fixed string prefix removal to reduce overhead.
-        const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
+        const normalized = sessionId.startsWith(SESSION_URI_PREFIX)
+            ? sessionId.slice(SESSION_URI_PREFIX.length)
+            : sessionId;
         // Use .md extension to enable Markdown syntax highlighting
         return vscode.Uri.parse(`jules-plan://sessions/${normalized}/plan.md`);
     }

--- a/src/planDocumentProvider.ts
+++ b/src/planDocumentProvider.ts
@@ -22,7 +22,8 @@ export class JulesPlanDocumentProvider implements vscode.TextDocumentContentProv
     }
 
     buildUri(sessionId: string): vscode.Uri {
-        const normalized = sessionId.replace(/^sessions\//, "");
+        // Performance optimization: Avoid regex replace for fixed string prefix removal to reduce overhead.
+        const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
         // Use .md extension to enable Markdown syntax highlighting
         return vscode.Uri.parse(`jules-plan://sessions/${normalized}/plan.md`);
     }

--- a/src/planDocumentProvider.ts
+++ b/src/planDocumentProvider.ts
@@ -1,8 +1,7 @@
 import * as vscode from "vscode";
 import { formatFullPlan, type Plan } from "./planUtils";
 import { isValidSessionId } from "./securityUtils";
-
-const SESSION_URI_PREFIX = "sessions/";
+import { SESSION_URI_PREFIX } from "./julesApiConstants";
 
 /**
  * TextDocumentContentProvider for displaying plan content in a virtual document.

--- a/src/sessionContextMenuArtifacts.ts
+++ b/src/sessionContextMenuArtifacts.ts
@@ -3,8 +3,7 @@ import * as path from "path";
 import { fetchLatestSessionArtifacts, getCachedSessionArtifacts, ChangeSetSummary } from "./sessionArtifacts";
 import { sanitizeError } from "./errorUtils";
 import { isValidSessionId } from "./securityUtils";
-
-const SESSION_URI_PREFIX = "sessions/";
+import { SESSION_URI_PREFIX } from "./julesApiConstants";
 
 export class JulesDiffDocumentProvider implements vscode.TextDocumentContentProvider {
     private readonly contents = new Map<string, string>();

--- a/src/sessionContextMenuArtifacts.ts
+++ b/src/sessionContextMenuArtifacts.ts
@@ -16,7 +16,8 @@ export class JulesDiffDocumentProvider implements vscode.TextDocumentContentProv
     }
 
     buildUri(sessionId: string, kind: "before" | "after"): vscode.Uri {
-        const normalized = sessionId.replace(/^sessions\//, "");
+        // Performance optimization: Avoid regex replace for fixed string prefix removal to reduce overhead.
+        const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
         return vscode.Uri.parse(`jules-diff://sessions/${normalized}/${kind}.patch`);
     }
 }

--- a/src/sessionContextMenuArtifacts.ts
+++ b/src/sessionContextMenuArtifacts.ts
@@ -4,6 +4,8 @@ import { fetchLatestSessionArtifacts, getCachedSessionArtifacts, ChangeSetSummar
 import { sanitizeError } from "./errorUtils";
 import { isValidSessionId } from "./securityUtils";
 
+const SESSION_URI_PREFIX = "sessions/";
+
 export class JulesDiffDocumentProvider implements vscode.TextDocumentContentProvider {
     private readonly contents = new Map<string, string>();
 
@@ -17,7 +19,9 @@ export class JulesDiffDocumentProvider implements vscode.TextDocumentContentProv
 
     buildUri(sessionId: string, kind: "before" | "after"): vscode.Uri {
         // Performance optimization: Avoid regex replace for fixed string prefix removal to reduce overhead.
-        const normalized = sessionId.startsWith("sessions/") ? sessionId.slice(9) : sessionId;
+        const normalized = sessionId.startsWith(SESSION_URI_PREFIX)
+            ? sessionId.slice(SESSION_URI_PREFIX.length)
+            : sessionId;
         return vscode.Uri.parse(`jules-diff://sessions/${normalized}/${kind}.patch`);
     }
 }

--- a/src/test/extensionHelpers.unit.test.ts
+++ b/src/test/extensionHelpers.unit.test.ts
@@ -29,6 +29,7 @@ import {
   resolveSelectedSessionItems,
   deleteSingleSession,
   executeDeleteSessionCommand,
+  JulesActivitiesDocumentProvider,
 } from "../extension";
 import { updateSessionArtifactsCache } from "../sessionArtifacts";
 import * as fetchUtils from "../fetchUtils";
@@ -1752,6 +1753,26 @@ suite("Extension helper unit tests", () => {
 
       windowMock.verify();
       assert.strictEqual(mockSessionsProvider.refresh.calledWith(true), true);
+    });
+  });
+
+  suite("JulesActivitiesDocumentProvider", () => {
+    test("buildUri should build correct URI", () => {
+      const provider = new JulesActivitiesDocumentProvider();
+      const uri = provider.buildUri("sessions/test-session-123");
+      const uriString = uri.toString();
+      assert.ok(uriString.startsWith("jules-activities://"));
+      assert.ok(uriString.includes("test-session-123"));
+      assert.ok(!uriString.includes("sessions/sessions/"));
+    });
+
+    test("buildUri should handle missing sessions/ prefix", () => {
+      const provider = new JulesActivitiesDocumentProvider();
+      const uri = provider.buildUri("test-session-123");
+      const uriString = uri.toString();
+      assert.ok(uriString.startsWith("jules-activities://"));
+      assert.ok(uriString.includes("test-session-123"));
+      assert.ok(uriString.match(/sessions\/test-session-123/));
     });
   });
 });

--- a/src/test/planDocumentProvider.unit.test.ts
+++ b/src/test/planDocumentProvider.unit.test.ts
@@ -172,6 +172,18 @@ suite("JulesPlanDocumentProvider", () => {
         assert.ok(uriString.endsWith(".md"));
     });
 
+    test("should normalize session ID by removing 'sessions/' prefix", () => {
+        const provider = new JulesPlanDocumentProvider();
+        const sessionIdWithPrefix = "sessions/abc-123-def";
+        const uri = provider.buildUri(sessionIdWithPrefix);
+
+        const uriString = uri.toString();
+        assert.ok(uriString.startsWith("jules-plan://"), "URI should have 'jules-plan' scheme");
+        assert.ok(uriString.includes("abc-123-def"), "URI should include normalized session ID");
+        // Verify no double 'sessions/' prefix in the final URI
+        assert.ok(uriString.match(/sessions\/abc-123-def/), "Should have sessions/ prefix followed by normalized ID");
+    });
+
     test("handles multiple sessions independently", () => {
         const provider = new JulesPlanDocumentProvider();
         const uri1 = provider.buildUri("session-1");

--- a/src/test/sessionContextMenuArtifacts.unit.test.ts
+++ b/src/test/sessionContextMenuArtifacts.unit.test.ts
@@ -199,7 +199,7 @@ suite("JulesDiffDocumentProvider", () => {
         assert.ok(uriString.startsWith("jules-diff://"), "URI should have 'jules-diff' scheme");
         assert.ok(uriString.includes("abc-123-def"), "URI should include normalized session ID");
         // Verify no double 'sessions/' prefix in the final URI
-        assert.ok(uriString.match(/sessions\/.*abc-123-def/), "Should have sessions/ prefix followed by normalized ID");
+        assert.ok(uriString.match(/sessions\/abc-123-def/), "Should have sessions/ prefix followed by normalized ID");
     });
 
     test("should handle session ID without 'sessions/' prefix", () => {


### PR DESCRIPTION
💡 What: 正規表現を使った文字列の置換（`sessionId.replace(/^sessions\//, "")`）を、より高速な基本的な文字列操作（`.startsWith()` と `.slice()`）に置き換えました。対象ファイルは `src/extension.ts`、`src/planDocumentProvider.ts`、および `src/sessionContextMenuArtifacts.ts` です。

🎯 Why: 正規表現を使用した文字列操作は、頻繁に呼び出される関数やループ内において、コンパイルや実行に不要なオーバーヘッドを生じさせます。固定の文字列プレフィックスを削除するだけの場合、組み込みの文字列メソッドを利用する方がパフォーマンス面で有利だからです。

📊 Impact: 文字列操作におけるメモリ割り当てとCPUのオーバーヘッドを削減し、拡張機能の全体的なレスポンス向上に貢献します。

🔬 Measurement: `pnpm run test:unit` を実行して既存のテストがすべて通過することを確認しました。また、コード内のコメントで最適化の意図を明確にしています。

---
*PR created automatically by Jules for task [2874850660646985060](https://jules.google.com/task/2874850660646985060) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

正規表現ベースの `replace(/^sessions\//, "")` を、`startsWith()` + `slice()` を使った文字列操作に置き換えるパフォーマンス最適化です。プレフィックス文字列は `SESSION_URI_PREFIX` 定数として `julesApiConstants.ts` に集約されました。

- **対象ファイル**: `extension.ts`、`planDocumentProvider.ts`、`sessionContextMenuArtifacts.ts` の 3 つの `buildUri` メソッドを統一的に変更。
- **定数の導入**: `SESSION_URI_PREFIX = \"sessions/\"` を一元管理することで、前回レビューで指摘されたマジックナンバー問題（`9`）が解消されています。
- **テスト追加**: プレフィックスあり・なしの両ケースをカバーするユニットテストが各プロバイダーに追加されました。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はすべて機能的に等価であり、安全にマージできます。

正規表現から文字列操作への置き換えは動作が同等で、プレフィックス文字列は SESSION_URI_PREFIX 定数で一元管理されています。前回指摘されたマジックナンバー問題も解消済みで、各プロバイダーにテストが追加されています。ロジックの変更はなく、リグレッションリスクは非常に低いです。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/julesApiConstants.ts | `SESSION_URI_PREFIX = "sessions/"` 定数を新規追加。プレフィックス文字列を一元管理することでマジックナンバー問題を解決している。 |
| src/extension.ts | `buildUri` の正規表現を `startsWith` + `slice` に置き換え。`JulesActivitiesDocumentProvider` をテスト用に `export class` へ変更。 |
| src/planDocumentProvider.ts | `buildUri` の正規表現置換を `SESSION_URI_PREFIX` を用いた文字列操作に変更。動作は既存と同等。 |
| src/sessionContextMenuArtifacts.ts | `buildUri` の正規表現置換を `SESSION_URI_PREFIX` を用いた文字列操作に変更。動作は既存と同等。 |
| src/test/extensionHelpers.unit.test.ts | `JulesActivitiesDocumentProvider` のインポートと、プレフィックスあり・なし両ケースをカバーする新規テストスイートを追加。 |
| src/test/planDocumentProvider.unit.test.ts | プレフィックス除去の正規化動作をカバーする新規テストを追加。 |
| src/test/sessionContextMenuArtifacts.unit.test.ts | 既存テストのアサーション正規表現を `/sessions\/.*abc-123-def/` から `/sessions\/abc-123-def/` へ精度向上。 |
| .jules/bolt.md | 文字列プレフィックス削除の最適化パターンについての学習エントリを追加。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["buildUri(sessionId)"] --> B{"sessionId.startsWith('sessions/')"}
    B -- "true" --> C["sessionId.slice(SESSION_URI_PREFIX.length)"]
    B -- "false" --> D["sessionId をそのまま使用"]
    C --> E["normalized"]
    D --> E
    E --> F["vscode.Uri.parse('scheme://sessions/{normalized}/...')"]
```

<sub>Reviews (4): Last reviewed commit: ["docs: clarify session URI prefix constan..."](https://github.com/hiroki-org/jules-extension/commit/c3e682d4cc3d4fb494413adcf95f56c4c3ea69ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35641722)</sub>

<!-- /greptile_comment -->