### PR TITLE
🎨 Palette: 冗長な aria-disabled 属性の削除によるアクセシビリティの向上

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-05-26 - Title Tooltip Support for Truncated Text
 **Learning:** When applying CSS `text-overflow: ellipsis` to truncate long dynamically generated content (like a session ID), it is necessary to provide an accessible way for users to view the complete text. Mirroring the `textContent` into the `title` attribute creates a native browser tooltip, enabling hover-based discovery of the full content without requiring custom UI components.
 **Action:** Whenever using `text-overflow: ellipsis` to clip text in the DOM, synchronously update the element's `title` attribute to match the full `textContent`.
+## 2026-06-05 - Native disabled state and ARIA
+**Learning:** HTML elements that natively support the `disabled` attribute (such as `<button>`, `<input>`, `<textarea>`) automatically expose their disabled state to screen readers. Adding `aria-disabled="true"` to these elements is redundant, clutters the DOM, and can cause some assistive technologies to announce the state twice or become confused.
+**Action:** Next time an element's disabled state needs to be managed dynamically, rely entirely on the native HTML `disabled` property, and avoid applying `aria-disabled` to natively supported elements. Update CSS selectors to target `:disabled` instead of `[aria-disabled="true"]`.

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -722,12 +722,10 @@ suite("chatAssets unit tests", () => {
     // (1) state.sessionId = null
     messageListener({ data: { type: "chatState", payload: { sessionId: null, messages: [], isTyping: false } } });
     assert.strictEqual(elements.messageInput.disabled, true);
-    assert.strictEqual(elements.messageInput["aria-disabled"], "true");
     assert.ok(elements.messageInput.placeholder.startsWith("Select a session"));
     assert.strictEqual(elements.messageInput["aria-label"], elements.messageInput.placeholder);
     assert.strictEqual(elements.messageInput.title, elements.messageInput.placeholder);
     assert.strictEqual(elements.sendButton.disabled, true);
-    assert.strictEqual(elements.sendButton["aria-disabled"], "true");
     assert.strictEqual(elements.sendButton.title, "Select a session to send a message");
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Select a session to send a message)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: None selected");
@@ -737,7 +735,6 @@ suite("chatAssets unit tests", () => {
     elements.messageInput.value = "   "; // whitespace
     messageListener({ data: { type: "chatState", payload: { sessionId: "session-123", messages: [], isTyping: false } } });
     assert.strictEqual(elements.sendButton.disabled, true);
-    assert.strictEqual(elements.sendButton["aria-disabled"], "true");
     assert.strictEqual(elements.sendButton.title, "Type a message to send");
     assert.strictEqual(elements.sendButton["aria-label"], "Send (Type a message to send)");
     assert.strictEqual(elements.sessionLabel.textContent, "Session: session-123");
@@ -749,7 +746,6 @@ suite("chatAssets unit tests", () => {
     assert.strictEqual(elements.messageInput["aria-label"], elements.messageInput.placeholder);
     assert.strictEqual(elements.messageInput.title, elements.messageInput.placeholder);
     assert.strictEqual(elements.sendButton.disabled, false);
-    assert.strictEqual(elements.sendButton["aria-disabled"], "false");
     assert.strictEqual(elements.sendButton.title, "Send message (Ctrl/Cmd+Enter)");
     assert.strictEqual(elements.sendButton["aria-label"], "Send message (Ctrl/Cmd+Enter)");
   });

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -30,13 +30,13 @@ p { margin: 0 0 8px; }
 #composer { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: var(--vscode-editor-background); border-top: 1px solid var(--vscode-widget-border, transparent); }
 #messageInput { width: 100%; min-height: 40px; max-height: 120px; resize: none; overflow-y: auto; padding: 8px 12px; border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); color: var(--vscode-input-foreground); font-family: inherit; font-size: var(--vscode-editor-font-size); border-radius: 6px; outline: none; box-sizing: border-box; }
 #messageInput:focus-visible { border-color: var(--vscode-focusBorder); }
-#messageInput:disabled, #messageInput[aria-disabled="true"] { opacity: 0.6; cursor: not-allowed; resize: none; }
+#messageInput:disabled { opacity: 0.6; cursor: not-allowed; resize: none; }
 .composer-actions { display: flex; justify-content: space-between; align-items: center; }
 .session-label { color: var(--vscode-descriptionForeground); font-size: 11px; user-select: none; max-width: 70%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #sendButton { padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }
 #sendButton:hover:not(:disabled) { background: var(--vscode-button-hoverBackground); }
 #sendButton:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
-#sendButton:disabled, #sendButton[aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
+#sendButton:disabled { opacity: 0.5; cursor: not-allowed; }
 .activity-log { font-size: 0.9em; opacity: 0.75; margin-bottom: 2px; }
 .activity-details { margin-top: 4px; font-size: 0.9em; }
 .activity-details summary { cursor: pointer; user-select: none; font-weight: 600; opacity: 0.8; padding: 2px 0; outline: none; }
@@ -232,10 +232,8 @@ export const CHAT_JS = `(function() {
 
     const sendDisabled = !hasSession || !hasText;
     sendButton.disabled = sendDisabled;
-    sendButton.setAttribute("aria-disabled", sendDisabled ? "true" : "false");
     
     messageInput.disabled = !hasSession;
-    messageInput.setAttribute("aria-disabled", !hasSession ? "true" : "false");
 
     if (!hasSession) {
       messageInput.value = "";


### PR DESCRIPTION
💡 What:
`<textarea>` (messageInput) と `<button>` (sendButton) の `disabled` 状態を動的に切り替える際、ネイティブの `disabled` プロパティの更新に加えて付与されていた冗長な `aria-disabled` 属性の付与・削除ロジックを撤去しました。また、これに関連する CSS のセレクタ (`[aria-disabled="true"]`) と、該当属性の存在を確認するユニットテストのアサーションも削除しています。

🎯 Why:
W3CのARIA仕様によれば、ネイティブで `disabled` 属性をサポートする HTML 要素（ボタンや入力フィールドなど）は、その属性だけでスクリーンリーダーに対して状態が正確に伝わります。ここに `aria-disabled="true"` を追加すると冗長になるだけでなく、一部の支援技術では状態が2回読み上げられるなど、ユーザーに混乱を招く原因となります。アクセシビリティツリーをクリーンに保ち、よりシンプルで標準的な実装にするためです。

📸 Before/After:
UIの見た目や動作に変更はありません。

♿ Accessibility:
ネイティブの機能に依存することで、スクリーンリーダーの読み上げがより自然かつ標準的になり、冗長なアナウンスメントを防止します。

---
*PR created automatically by Jules for task [850077052077586855](https://jules.google.com/task/850077052077586855) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ネイティブ HTML 要素（`<textarea>`, `<button>`）に対して冗長に付与されていた `aria-disabled` 属性の設定・削除ロジックを撤去するクリーンアップ PRです。CSS は `[aria-disabled="true"]` セレクタを `:disabled` 疑似クラスのみに統一し、対応するテストアサーションも削除されています。

- **`chatAssets.ts`**: `updateUI()` 内の `sendButton` と `messageInput` に対する `setAttribute("aria-disabled", ...)` の2行を削除し、CSS セレクタを `:disabled` 単独に変更。
- **`chatAssets.unit.test.ts`**: `aria-disabled` 属性値を検証していた3件のアサーションを削除。`.disabled` プロパティのアサーションは引き続き残っており、テスト網羅性は維持されている。
- **`.Jules/palette.md`**: 今回の変更から得られたネイティブ `disabled` と `aria-disabled` の使い分けに関する知見を追記。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はネイティブ `disabled` プロパティへの依存に統一する純粋なクリーンアップであり、動作に影響するロジック変更は含まれていない。安全にマージできる。

削除されたコードはすべて冗長な `aria-disabled` 操作のみで、ネイティブ `disabled` によって既に同等の状態が伝達されている。CSS の `:disabled` 疑似クラスへの統一も標準的な手法であり、ブラウザ互換性の懸念はない。テストも実装変更と一致している。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | `updateUI()` から `aria-disabled` の `setAttribute` 呼び出しを2箇所削除し、CSS セレクタを `:disabled` のみに簡略化。変更は正確で副作用なし。 |
| src/test/chatAssets.unit.test.ts | `aria-disabled` に関する3つのアサーションを削除。実装側の変更と完全に対応しており、テストの網羅性は維持されている。 |
| .Jules/palette.md | 今回の変更から得られたアクセシビリティの知見をドキュメントに追記。将来の類似作業への参考情報として適切。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[chatState メッセージ受信] --> B[updateUI 呼び出し]
    B --> C{hasSession?}
    C -- No --> D[messageInput.disabled = true]
    C -- Yes --> E[messageInput.disabled = false]
    D --> F{hasText?}
    E --> F
    F -- No --> G[sendButton.disabled = true]
    F -- Yes --> H[sendButton.disabled = false]
    G --> I[aria-label / title を更新]
    H --> I
    I --> J[UI 反映完了]
```

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: ネイティブな disabled 属性を活かし、重複する ..."](https://github.com/hiroki-org/jules-extension/commit/a3edf876980452c5232c39d2295eb1a2f6b6d4dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35849148)</sub>

<!-- /greptile_comment -->