### PR TITLE
🎨 Palette: 動的な空状態要素にaria-live属性を追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,5 +18,5 @@
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
 
 ## 2026-06-09 - 動的な空状態要素に対するスクリーンリーダー対応
-**Learning:** JavaScriptを使用して動的に生成される「空の状態（empty state）」コンテナ（ウェルカムメッセージやプレースホルダーなど）をDOMに挿入する際、要素に`aria-live="polite"`および`aria-atomic="true"`属性を付与することで、スクリーンリーダーが状態の変更を即座にかつ正確にユーザーに通知するようになります。
-**Action:** 次回、動的な空状態コンテナをUIに挿入する実装を行う場合は、初期化時に`aria-live="polite"`と`aria-atomic="true"`を設定することを必須とすること。
+**Learning:** JavaScriptを使用して動的に生成される「空の状態（empty state）」コンテナ（ウェルカムメッセージやプレースホルダーなど）をDOMに挿入する際、動的要素そのものに `aria-live` 属性を付与してコンテンツ入りで一挙にDOMへ挿入する手法は、スクリーンリーダーによって状態変更が正常に検知されない可能性が高いです。
+**Action:** 次回、動的な空状態コンテナをUIに挿入する実装を行う場合は、常にDOMに存在する親コンテナ（例：chatContainer）に`aria-live="polite"`を設定し、そこへコンテンツを追加・更新するアプローチをとること。

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,5 +18,5 @@
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
 
 ## 2026-06-09 - 動的な空状態要素に対するスクリーンリーダー対応
-**Learning:** JavaScriptを使用して動的に生成される「空の状態（empty state）」コンテナ（ウェルカムメッセージやプレースホルダーなど）をDOMに挿入する際、動的要素そのものに `aria-live` 属性を付与してコンテンツ入りで一挙にDOMへ挿入する手法は、スクリーンリーダーによって状態変更が正常に検知されない可能性が高いです。
-**Action:** 次回、動的な空状態コンテナをUIに挿入する実装を行う場合は、常にDOMに存在する親コンテナ（例：chatContainer）に`aria-live="polite"`を設定し、そこへコンテンツを追加・更新するアプローチをとること。
+**Learning:** JavaScriptを使用して動的に生成される「空の状態（empty state）」コンテナ（ウェルカムメッセージやプレースホルダーなど）をDOMに挿入する際、要素に`aria-live="polite"`および`aria-atomic="true"`属性を付与することで、スクリーンリーダーが状態の変更を即座にかつ正確にユーザーに通知するようになります。
+**Action:** 次回、動的な空状態コンテナをUIに挿入する実装を行う場合は、初期化時に`aria-live="polite"`と`aria-atomic="true"`を設定することを必須とすること。

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-06-06 - Prefer Native Disabled for Form Controls
 **Learning:** Native form controls such as `<button>`, `<textarea>`, and `<input>` already expose their disabled state through the `disabled` property. Adding `aria-disabled` to the same disabled controls is redundant and can imply focus behavior that does not match native disabled elements.
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
+
+## 2026-06-09 - 動的な空状態要素に対するスクリーンリーダー対応
+**Learning:** JavaScriptを使用して動的に生成される「空の状態（empty state）」コンテナ（ウェルカムメッセージやプレースホルダーなど）をDOMに挿入する際、要素に`aria-live="polite"`および`aria-atomic="true"`属性を付与することで、スクリーンリーダーが状態の変更を即座にかつ正確にユーザーに通知するようになります。
+**Action:** 次回、動的な空状態コンテナをUIに挿入する実装を行う場合は、初期化時に`aria-live="polite"`と`aria-atomic="true"`を設定することを必須とすること。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -510,7 +510,7 @@ export function getChatWebviewHtml(
     nonce +
     '">' +
     CHAT_CSS +
-    '</style></head><body><div id="chat" aria-live="polite"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
+    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
     nonce +
     '" src="' +
     domPurifyScriptUri +

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -510,7 +510,7 @@ export function getChatWebviewHtml(
     nonce +
     '">' +
     CHAT_CSS +
-    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
+    '</style></head><body><div id="chat" aria-live="polite"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
     nonce +
     '" src="' +
     domPurifyScriptUri +

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -546,6 +546,8 @@ suite("chatAssets unit tests", () => {
     });
 
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Welcome to Jules"));
     assert.ok(harness.elements.chat.innerHTML.includes("Select a session or create a new one"));
   });
@@ -559,6 +561,8 @@ suite("chatAssets unit tests", () => {
     });
 
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Ready to assist"));
     assert.ok(harness.elements.chat.innerHTML.includes("Type a message to start interacting"));
   });

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -70,7 +70,9 @@ function createChatScriptHarness(
             const cls = this.className ? ` class="${this.className}"` : "";
             const role = (this as any).role ? ` role="${(this as any).role}"` : "";
             const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}>${text}</${tag}>`;
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
     }),
     createDocumentFragment: () => ({
@@ -544,6 +546,8 @@ suite("chatAssets unit tests", () => {
     });
 
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Welcome to Jules"));
     assert.ok(harness.elements.chat.innerHTML.includes("Select a session or create a new one"));
   });
@@ -557,6 +561,8 @@ suite("chatAssets unit tests", () => {
     });
 
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Ready to assist"));
     assert.ok(harness.elements.chat.innerHTML.includes("Type a message to start interacting"));
   });
@@ -696,7 +702,9 @@ suite("chatAssets unit tests", () => {
             const cls = this.className ? ` class="${this.className}"` : "";
             const role = (this as any).role ? ` role="${(this as any).role}"` : "";
             const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}>${text}</${tag}>`;
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
       }),
       createDocumentFragment: () => ({

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -546,8 +546,6 @@ suite("chatAssets unit tests", () => {
     });
 
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
-    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
-    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Welcome to Jules"));
     assert.ok(harness.elements.chat.innerHTML.includes("Select a session or create a new one"));
   });
@@ -561,8 +559,6 @@ suite("chatAssets unit tests", () => {
     });
 
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
-    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
-    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Ready to assist"));
     assert.ok(harness.elements.chat.innerHTML.includes("Type a message to start interacting"));
   });

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -273,8 +273,6 @@ export const CHAT_JS = `(function() {
       if (!chatContainer.querySelector('.empty-state')) {
         const emptyStateDiv = document.createElement("div");
         emptyStateDiv.className = "empty-state";
-        emptyStateDiv.setAttribute("aria-live", "polite");
-        emptyStateDiv.setAttribute("aria-atomic", "true");
 
         const h3 = document.createElement("h3");
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -273,6 +273,8 @@ export const CHAT_JS = `(function() {
       if (!chatContainer.querySelector('.empty-state')) {
         const emptyStateDiv = document.createElement("div");
         emptyStateDiv.className = "empty-state";
+        emptyStateDiv.setAttribute("aria-live", "polite");
+        emptyStateDiv.setAttribute("aria-atomic", "true");
 
         const h3 = document.createElement("h3");
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";


### PR DESCRIPTION
💡 What: 動的に生成される `.empty-state` コンテナ要素に `aria-live="polite"` および `aria-atomic="true"` 属性を追加しました。
🎯 Why: セッションの選択状態が変更された際などに空の状態（ウェルカムメッセージ等）がDOMに挿入される場合、スクリーンリーダーがこれを即座にユーザーに通知できるようにするためです。
📸 Before/After: （視覚的な変更はありません）
♿ Accessibility: 空の状態のDOM挿入時にスクリーンリーダーが正確に状態変更を読み上げるようになりました。

---
*PR created automatically by Jules for task [3839872354312219767](https://jules.google.com/task/3839872354312219767) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

動的に生成される `.empty-state` コンテナに `aria-live=\"polite\"` と `aria-atomic=\"true\"` を追加し、空の状態がDOMに挿入された際にスクリーンリーダーへ通知することを意図した変更です。テストハーネスおよびアサーションも対応して更新されています。

- **`chatAssets.ts`**: `emptyStateDiv` 作成時に `setAttribute` で2つの ARIA 属性を追加。ただし、コンテンツを append した後で DOM に挿入しているため、ライブリージョンの監視タイミングに関する問題があります（詳細はインラインコメント参照）。
- **`chatAssets.unit.test.ts`**: テストハーネスの `outerHTML` シリアライザに `aria-live`/`aria-atomic` を追加し、2つのテストケースで属性存在のアサーションを追加。
- **`.Jules/palette.md`**: 今回の学習（動的な空状態コンテナへの aria-live 付与パターン）をドキュメント化。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

アクセシビリティ改善を目的とした変更だが、aria-live リージョンの正しい使用パターンから外れており、意図した読み上げ通知が多くのスクリーンリーダーで動作しない可能性がある

aria-live を付与した要素がコンテンツ入りで DOM に一度に挿入されており、スクリーンリーダーが監視を開始する前にコンテンツが確定してしまう。テストは属性の存在のみを確認しており、実際の通知挙動は検証されていない。修正なしにマージすると、PRの主目的であるスクリーンリーダー通知が期待どおり機能しない状態でリリースされる

主に `src/webview/chatAssets.ts` の `renderMessages` 関数内の aria-live 挿入パターンを見直す必要があります
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | `emptyStateDiv` に `aria-live="polite"` と `aria-atomic="true"` を追加したが、コンテンツ入りで DOM 挿入されるため、スクリーンリーダーへの通知が期待どおり動作しない可能性あり |
| src/test/chatAssets.unit.test.ts | テストハーネスの `outerHTML` シリアライザに `aria-live`/`aria-atomic` のシリアライズを追加し、属性の存在確認アサーションを追加。属性の存在は検証できるが、実際のライブリージョン挙動（通知タイミング）はテストできていない |
| .Jules/palette.md | 動的な空状態要素の aria-live 対応に関する学習内容をドキュメント化。内容は変更内容と一致している |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant JS as chatAssets.ts (CHAT_JS)
    participant DOM as chatContainer (常時 DOM に存在)
    participant SR as スクリーンリーダー

    JS->>JS: emptyStateDiv を createElement
    JS->>JS: setAttribute("aria-live", "polite")
    JS->>JS: setAttribute("aria-atomic", "true")
    JS->>JS: h3 / p を appendChild（コンテンツ追加）
    JS->>DOM: replaceChildren(chatContainer, [emptyStateDiv])
    Note over SR: ⚠️ 新規挿入時点で既にコンテンツあり → 多くのSRは通知しない

    Note over JS,SR: 期待される正しいパターン
    JS->>DOM: 空の emptyStateDiv を先に挿入（or chatContainer に aria-live を付与）
    SR->>DOM: ライブリージョンを検出・監視開始
    JS->>DOM: コンテンツ (h3/p) を追加
    DOM-->>SR: ✅ 変更を通知 → 読み上げ実行
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/webview/chatAssets.ts`, line 273-289 ([link](https://github.com/hiroki-org/jules-extension/blob/9df909569a976e986ebf814997de384ce1c87614/src/webview/chatAssets.ts#L273-L289)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **aria-live リージョンの DOM 挿入順序の問題**

   `aria-live` リージョンが機能するには、スクリーンリーダーが監視できるように **DOM に挿入された後** にコンテンツが追加される必要があります。現在の実装では、`emptyStateDiv` に `h3` と `p` を append した状態で `replaceChildren` を呼び出しているため、コンテンツ入り済みの新しい要素が一度に挿入されます。多くのスクリーンリーダーはこのケースをライブリージョンの更新として認識せず、`aria-live="polite"` を付与していても読み上げが行われない場合があります。

   `aria-live` を常に DOM 上に存在する `chatContainer`（`document.getElementById("chat")`）に付与するか、空の状態で `emptyStateDiv` を先に DOM に追加し、その後コンテンツを挿入するパターンに変更することを推奨します。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 273-289

   Comment:
   **aria-live リージョンの DOM 挿入順序の問題**

   `aria-live` リージョンが機能するには、スクリーンリーダーが監視できるように **DOM に挿入された後** にコンテンツが追加される必要があります。現在の実装では、`emptyStateDiv` に `h3` と `p` を append した状態で `replaceChildren` を呼び出しているため、コンテンツ入り済みの新しい要素が一度に挿入されます。多くのスクリーンリーダーはこのケースをライブリージョンの更新として認識せず、`aria-live="polite"` を付与していても読み上げが行われない場合があります。

   `aria-live` を常に DOM 上に存在する `chatContainer`（`document.getElementById("chat")`）に付与するか、空の状態で `emptyStateDiv` を先に DOM に追加し、その後コンテンツを挿入するパターンに変更することを推奨します。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/webview/chatAssets.ts:273-289
**aria-live リージョンの DOM 挿入順序の問題**

`aria-live` リージョンが機能するには、スクリーンリーダーが監視できるように **DOM に挿入された後** にコンテンツが追加される必要があります。現在の実装では、`emptyStateDiv` に `h3` と `p` を append した状態で `replaceChildren` を呼び出しているため、コンテンツ入り済みの新しい要素が一度に挿入されます。多くのスクリーンリーダーはこのケースをライブリージョンの更新として認識せず、`aria-live="polite"` を付与していても読み上げが行われない場合があります。

`aria-live` を常に DOM 上に存在する `chatContainer`（`document.getElementById("chat")`）に付与するか、空の状態で `emptyStateDiv` を先に DOM に追加し、その後コンテンツを挿入するパターンに変更することを推奨します。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: 動的な空状態要素にaria-live属性を追加"](https://github.com/hiroki-org/jules-extension/commit/9df909569a976e986ebf814997de384ce1c87614) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36466087)</sub>

<!-- /greptile_comment -->