### PR TITLE
🎨 Palette: 空状態コンテナへのスクリーンリーダー対応強化（aria-live追加）

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,5 +18,6 @@
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
 
 ## 2026-06-11 - Dynamic Empty State Announcers
+
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,6 +18,5 @@
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
 
 ## 2026-06-11 - Dynamic Empty State Announcers
-
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-06-06 - Prefer Native Disabled for Form Controls
 **Learning:** Native form controls such as `<button>`, `<textarea>`, and `<input>` already expose their disabled state through the `disabled` property. Adding `aria-disabled` to the same disabled controls is redundant and can imply focus behavior that does not match native disabled elements.
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
+
+## 2026-06-11 - Dynamic Empty State Announcers
+**Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
+**Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,18 +1,6 @@
 import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
-function createMockElementOuterHTML(element: any): string {
-  const { tagName, className, textContent, childNodes } = element;
-  const childrenHtml = (childNodes || []).map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-  const text = textContent || childrenHtml;
-  const cls = className ? ` class="${className}"` : "";
-  const role = element.role ? ` role="${element.role}"` : "";
-  const ariaLabel = element["aria-label"] ? ` aria-label="${element["aria-label"]}"` : "";
-  const ariaLive = element["aria-live"] ? ` aria-live="${element["aria-live"]}"` : "";
-  const ariaAtomic = element["aria-atomic"] ? ` aria-atomic="${element["aria-atomic"]}"` : "";
-  return `<${tagName}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tagName}>`;
-}
-
 function createChatScriptHarness(
   domPurify?: { sanitize: (html: string, config: any) => any },
   computedStyle = { borderTopWidth: "1px", borderBottomWidth: "1px" },
@@ -26,26 +14,19 @@ function createChatScriptHarness(
   };
   const elements: Record<string, any> = {
     chat: {
-        _childNodes: [] as any[],
-        get innerHTML() {
-          if (this._childNodes.length > 0) {
-            return this._childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-          }
-          return chatInnerHTML;
-        },
-        set innerHTML(value: string) {
-          chatInnerHTMLSetCount += 1;
-          chatInnerHTML = value;
-          this._childNodes = [];
-        },
-        get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
-        replaceChildren(...nodes: any[]) {
-          chatInnerHTMLSetCount += 1;
-          this._childNodes = nodes;
-        },
-        appendChild(node: any) {
-          this._childNodes.push(node);
-        },
+      get innerHTML() { return chatInnerHTML; },
+      set innerHTML(value: string) {
+        chatInnerHTMLSetCount += 1;
+        chatInnerHTML = value;
+      },
+      get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
+      replaceChildren(...nodes: any[]) {
+        chatInnerHTMLSetCount += 1;
+        chatInnerHTML = nodes.map(n => n.outerHTML ?? n.textContent ?? "").join("");
+      },
+      appendChild(node: any) {
+        chatInnerHTML += (node.outerHTML ?? node.textContent ?? "");
+      },
       querySelector: () => null,
       scrollTop: 0,
       scrollHeight: 0,
@@ -84,7 +65,14 @@ function createChatScriptHarness(
             this.childNodes.push(node);
         },
         get outerHTML() {
-            return createMockElementOuterHTML(this);
+            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+            const text = this.textContent ? this.textContent : childrenHtml;
+            const cls = this.className ? ` class="${this.className}"` : "";
+            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
+            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
     }),
     createDocumentFragment: () => ({
@@ -709,7 +697,14 @@ suite("chatAssets unit tests", () => {
             this.childNodes.push(node);
         },
         get outerHTML() {
-            return createMockElementOuterHTML(this);
+            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+            const text = this.textContent ? this.textContent : childrenHtml;
+            const cls = this.className ? ` class="${this.className}"` : "";
+            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
+            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
       }),
       createDocumentFragment: () => ({

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,6 +1,18 @@
 import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
+function createMockElementOuterHTML(element: any): string {
+  const { tagName, className, textContent, childNodes } = element;
+  const childrenHtml = (childNodes || []).map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+  const text = textContent || childrenHtml;
+  const cls = className ? ` class="${className}"` : "";
+  const role = element.role ? ` role="${element.role}"` : "";
+  const ariaLabel = element["aria-label"] ? ` aria-label="${element["aria-label"]}"` : "";
+  const ariaLive = element["aria-live"] ? ` aria-live="${element["aria-live"]}"` : "";
+  const ariaAtomic = element["aria-atomic"] ? ` aria-atomic="${element["aria-atomic"]}"` : "";
+  return `<${tagName}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tagName}>`;
+}
+
 function createChatScriptHarness(
   domPurify?: { sanitize: (html: string, config: any) => any },
   computedStyle = { borderTopWidth: "1px", borderBottomWidth: "1px" },
@@ -14,19 +26,26 @@ function createChatScriptHarness(
   };
   const elements: Record<string, any> = {
     chat: {
-      get innerHTML() { return chatInnerHTML; },
-      set innerHTML(value: string) {
-        chatInnerHTMLSetCount += 1;
-        chatInnerHTML = value;
-      },
-      get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
-      replaceChildren(...nodes: any[]) {
-        chatInnerHTMLSetCount += 1;
-        chatInnerHTML = nodes.map(n => n.outerHTML ?? n.textContent ?? "").join("");
-      },
-      appendChild(node: any) {
-        chatInnerHTML += (node.outerHTML ?? node.textContent ?? "");
-      },
+        _childNodes: [] as any[],
+        get innerHTML() {
+          if (this._childNodes.length > 0) {
+            return this._childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+          }
+          return chatInnerHTML;
+        },
+        set innerHTML(value: string) {
+          chatInnerHTMLSetCount += 1;
+          chatInnerHTML = value;
+          this._childNodes = [];
+        },
+        get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
+        replaceChildren(...nodes: any[]) {
+          chatInnerHTMLSetCount += 1;
+          this._childNodes = nodes;
+        },
+        appendChild(node: any) {
+          this._childNodes.push(node);
+        },
       querySelector: () => null,
       scrollTop: 0,
       scrollHeight: 0,
@@ -65,14 +84,7 @@ function createChatScriptHarness(
             this.childNodes.push(node);
         },
         get outerHTML() {
-            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-            const text = this.textContent ? this.textContent : childrenHtml;
-            const cls = this.className ? ` class="${this.className}"` : "";
-            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
-            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
-            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
+            return createMockElementOuterHTML(this);
         }
     }),
     createDocumentFragment: () => ({
@@ -697,14 +709,7 @@ suite("chatAssets unit tests", () => {
             this.childNodes.push(node);
         },
         get outerHTML() {
-            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-            const text = this.textContent ? this.textContent : childrenHtml;
-            const cls = this.className ? ` class="${this.className}"` : "";
-            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
-            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
-            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
+            return createMockElementOuterHTML(this);
         }
       }),
       createDocumentFragment: () => ({

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -70,7 +70,9 @@ function createChatScriptHarness(
             const cls = this.className ? ` class="${this.className}"` : "";
             const role = (this as any).role ? ` role="${(this as any).role}"` : "";
             const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}>${text}</${tag}>`;
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
     }),
     createDocumentFragment: () => ({
@@ -546,6 +548,8 @@ suite("chatAssets unit tests", () => {
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Welcome to Jules"));
     assert.ok(harness.elements.chat.innerHTML.includes("Select a session or create a new one"));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
   });
 
   test("CHAT_JS should render ready empty state when a session has no messages", () => {
@@ -559,6 +563,8 @@ suite("chatAssets unit tests", () => {
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Ready to assist"));
     assert.ok(harness.elements.chat.innerHTML.includes("Type a message to start interacting"));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
   });
 
   test("CHAT_JS should not reinsert the same empty state repeatedly", () => {
@@ -696,7 +702,9 @@ suite("chatAssets unit tests", () => {
             const cls = this.className ? ` class="${this.className}"` : "";
             const role = (this as any).role ? ` role="${(this as any).role}"` : "";
             const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}>${text}</${tag}>`;
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
       }),
       createDocumentFragment: () => ({

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -276,6 +276,8 @@ export const CHAT_JS = `(function() {
         emptyStateDiv.setAttribute("aria-live", "polite");
         emptyStateDiv.setAttribute("aria-atomic", "true");
 
+        replaceChildren(chatContainer, [emptyStateDiv]);
+
         const h3 = document.createElement("h3");
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";
 
@@ -286,7 +288,6 @@ export const CHAT_JS = `(function() {
 
         emptyStateDiv.appendChild(h3);
         emptyStateDiv.appendChild(p);
-        replaceChildren(chatContainer, [emptyStateDiv]);
       }
     } else {
       const nodes = state.messages.map(m => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -276,8 +276,6 @@ export const CHAT_JS = `(function() {
         emptyStateDiv.setAttribute("aria-live", "polite");
         emptyStateDiv.setAttribute("aria-atomic", "true");
 
-        replaceChildren(chatContainer, [emptyStateDiv]);
-
         const h3 = document.createElement("h3");
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";
 
@@ -288,6 +286,7 @@ export const CHAT_JS = `(function() {
 
         emptyStateDiv.appendChild(h3);
         emptyStateDiv.appendChild(p);
+        replaceChildren(chatContainer, [emptyStateDiv]);
       }
     } else {
       const nodes = state.messages.map(m => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -273,6 +273,8 @@ export const CHAT_JS = `(function() {
       if (!chatContainer.querySelector('.empty-state')) {
         const emptyStateDiv = document.createElement("div");
         emptyStateDiv.className = "empty-state";
+        emptyStateDiv.setAttribute("aria-live", "polite");
+        emptyStateDiv.setAttribute("aria-atomic", "true");
 
         const h3 = document.createElement("h3");
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";


### PR DESCRIPTION
💡 What: チャットコンテナに動的に追加される「空状態（Empty State）」のDOM要素に `aria-live="polite"` および `aria-atomic="true"` 属性を追加しました。さらに、テスト環境のDOMモックもこれらの新しい属性を正しくシリアライズするように更新し、テストケースを追加しました。

🎯 Why: チャット履歴が空になった際、または新しいセッションが開始された際に、画面上にメッセージ（「Welcome to Jules」や「Ready to assist」など）が表示されますが、これまではスクリーンリーダーにその変更が通知されていませんでした。これらのARIA属性を追加することで、視覚に障害のあるユーザーもチャットの状態が変わったことを直感的に把握できるようになります。

📸 Before/After: （視覚的な変更はありません）

♿ Accessibility: 動的に生成されるプレースホルダーメッセージ（空状態）に対して `aria-live` を設定することで、スクリーンリーダーによる自動読み上げサポートを追加しました。

---
*PR created automatically by Jules for task [14741185434075336632](https://jules.google.com/task/14741185434075336632) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、チャットが空の状態で動的に挿入されるプレースホルダーコンテナ（`.empty-state`）に `aria-live="polite"` と `aria-atomic="true"` を追加し、スクリーンリーダーが状態変化を通知できるようにするアクセシビリティ改善です。テストモックも新属性に対応するよう更新されています。

- `chatAssets.ts` の `renderMessages()` 関数内で、空状態のdivに2つのARIA属性を追加
- テストハーネスの `outerHTML` ゲッターと2つのテストケースの検証アサーションを更新
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

空のaria-live領域をDOMに挿入してからコンテンツを追加するという正しい順序になっておらず、アクセシビリティ改善の目的が達成されない可能性がある

コンテンツが揃った状態でDOM挿入しているため、スクリーンリーダーがaria-liveの変化を検知できず、PRの主目的であるアクセシビリティ改善が多くの支援技術で機能しない可能性があります。テストは属性の存在を確認するだけで、挿入順序の正しさを検証していません。

src/webview/chatAssets.ts の renderMessages 関数（aria-live 領域の DOM 挿入順序）
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | aria-live領域に内容を追加してからDOMに挿入しており、スクリーンリーダーが変化を検知しない可能性がある |
| src/test/chatAssets.unit.test.ts | outerHTMLモックのaria属性シリアライズを2箇所で更新（重複コード）し、2つのテストアサーションを追加 |
| .Jules/palette.md | 今回の変更内容をAIエージェント向けのラーニングとして記録 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WV as Webview (chatAssets.ts)
    participant DOM as DOM (chatContainer)
    participant SR as スクリーンリーダー

    WV->>WV: "emptyStateDiv = createElement(div)"
    WV->>WV: setAttribute aria-live polite
    WV->>WV: setAttribute aria-atomic true
    WV->>WV: emptyStateDiv.appendChild(h3)
    WV->>WV: emptyStateDiv.appendChild(p)
    WV->>DOM: replaceChildren(chatContainer, [emptyStateDiv])
    Note over SR: コンテンツ挿入済みの状態でDOMに追加されるため aria-live の変化を検知できない場合がある

    Note over WV,SR: 推奨パターン
    WV->>DOM: replaceChildren(chatContainer, [emptyStateDiv]) まず空コンテナを追加
    WV->>DOM: emptyStateDiv.appendChild(h3) 後からコンテンツを注入
    WV->>DOM: emptyStateDiv.appendChild(p)
    DOM-->>SR: aria-live 領域の変化を検知しアナウンス
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/webview/chatAssets.ts`, line 273-289 ([link](https://github.com/hiroki-org/jules-extension/blob/025aa087d0731d8006809cfa0e85582ed59c70c3/src/webview/chatAssets.ts#L273-L289)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **aria-live 領域のアナウンスが発火しない可能性がある**

   WAI-ARIA の仕様上、`aria-live` 領域は**DOMに挿入される前に空の状態で存在している**必要があります。現在のコードでは `h3` と `p` を追加済みの状態で `replaceChildren` により DOM に挿入しているため、スクリーンリーダーが変更を観測する前にコンテンツが揃ってしまい、読み上げが発火しないケースがあります（NVDA・JAWS・VoiceOverで確認報告あり）。`replaceChildren(chatContainer, [emptyStateDiv])` を `appendChild` 呼び出しの前に移動し、空コンテナをDOMに先に挿入してからコンテンツを注入してください。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 273-289

   Comment:
   **aria-live 領域のアナウンスが発火しない可能性がある**

   WAI-ARIA の仕様上、`aria-live` 領域は**DOMに挿入される前に空の状態で存在している**必要があります。現在のコードでは `h3` と `p` を追加済みの状態で `replaceChildren` により DOM に挿入しているため、スクリーンリーダーが変更を観測する前にコンテンツが揃ってしまい、読み上げが発火しないケースがあります（NVDA・JAWS・VoiceOverで確認報告あり）。`replaceChildren(chatContainer, [emptyStateDiv])` を `appendChild` 呼び出しの前に移動し、空コンテナをDOMに先に挿入してからコンテンツを注入してください。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/test/chatAssets.unit.test.ts`, line 696-710 ([link](https://github.com/hiroki-org/jules-extension/blob/025aa087d0731d8006809cfa0e85582ed59c70c3/src/test/chatAssets.unit.test.ts#L696-L710)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **outerHTML モックのシリアライズロジックが重複している**

   `aria-live` / `aria-atomic` の処理を含む `outerHTML` ゲッターの実装が、テストファイル内の2箇所（行70付近と行702付近）に重複しています。将来的に ARIA 属性を追加する際に片方の更新が漏れるリスクがあります。共通のファクトリ関数やヘルパーに切り出すことを検討してください。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 696-710

   Comment:
   **outerHTML モックのシリアライズロジックが重複している**

   `aria-live` / `aria-atomic` の処理を含む `outerHTML` ゲッターの実装が、テストファイル内の2箇所（行70付近と行702付近）に重複しています。将来的に ARIA 属性を追加する際に片方の更新が漏れるリスクがあります。共通のファクトリ関数やヘルパーに切り出すことを検討してください。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/webview/chatAssets.ts:273-289
**aria-live 領域のアナウンスが発火しない可能性がある**

WAI-ARIA の仕様上、`aria-live` 領域は**DOMに挿入される前に空の状態で存在している**必要があります。現在のコードでは `h3` と `p` を追加済みの状態で `replaceChildren` により DOM に挿入しているため、スクリーンリーダーが変更を観測する前にコンテンツが揃ってしまい、読み上げが発火しないケースがあります（NVDA・JAWS・VoiceOverで確認報告あり）。`replaceChildren(chatContainer, [emptyStateDiv])` を `appendChild` 呼び出しの前に移動し、空コンテナをDOMに先に挿入してからコンテンツを注入してください。

### Issue 2 of 2
src/test/chatAssets.unit.test.ts:696-710
**outerHTML モックのシリアライズロジックが重複している**

`aria-live` / `aria-atomic` の処理を含む `outerHTML` ゲッターの実装が、テストファイル内の2箇所（行70付近と行702付近）に重複しています。将来的に ARIA 属性を追加する際に片方の更新が漏れるリスクがあります。共通のファクトリ関数やヘルパーに切り出すことを検討してください。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: 空状態コンテナへのaria-liveとaria-atom..."](https://github.com/hiroki-org/jules-extension/commit/025aa087d0731d8006809cfa0e85582ed59c70c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36992656)</sub>

<!-- /greptile_comment -->