### PR TITLE
🎨 Palette: [UX improvement] Accessible Empty States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-06-06 - Prefer Native Disabled for Form Controls
 **Learning:** Native form controls such as `<button>`, `<textarea>`, and `<input>` already expose their disabled state through the `disabled` property. Adding `aria-disabled` to the same disabled controls is redundant and can imply focus behavior that does not match native disabled elements.
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
+
+## 2026-06-12 - Accessible Empty States
+**Learning:** When dynamically inserting an empty state container (e.g., when a user selects a session or no messages exist), screen readers won't announce it unless the container uses `aria-live`.
+**Action:** Always add `aria-live="polite"` and `aria-atomic="true"` when dynamically creating empty state containers in the DOM so that screen readers promptly announce the context change to the user.

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,18 +1,17 @@
 import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
-function createMockElementOuterHTML(element: any): string {
-  const { tagName, className, textContent, childNodes } = element;
-  const childrenHtml = (childNodes || []).map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-  const text = textContent || childrenHtml;
-  const attrs = [];
-  if (className) attrs.push(`class="${className}"`);
-  if (element.role) attrs.push(`role="${element.role}"`);
-  if (element["aria-label"]) attrs.push(`aria-label="${element["aria-label"]}"`);
-  if (element["aria-live"]) attrs.push(`aria-live="${element["aria-live"]}"`);
-  if (element["aria-atomic"]) attrs.push(`aria-atomic="${element["aria-atomic"]}"`);
-  const attrsStr = attrs.length ? " " + attrs.join(" ") : "";
-  return `<${tagName}${attrsStr}>${text}</${tagName}>`;
+function createMockElementOuterHTML(element: any, tag: string): string {
+  const childrenHtml = element.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+  const text = element.textContent ? element.textContent : childrenHtml;
+  const cls = element.className ? `class="${element.className}"` : "";
+  const role = element.role ? `role="${element.role}"` : "";
+  const ariaLabel = element["aria-label"] ? `aria-label="${element["aria-label"]}"` : "";
+  const ariaLive = element["aria-live"] ? `aria-live="${element["aria-live"]}"` : "";
+  const ariaAtomic = element["aria-atomic"] ? `aria-atomic="${element["aria-atomic"]}"` : "";
+  const attrs = [cls, role, ariaLabel, ariaLive, ariaAtomic].filter(Boolean).join(" ");
+  const attrStr = attrs.length > 0 ? ` ${attrs}` : "";
+  return `<${tag}${attrStr}>${text}</${tag}>`;
 }
 
 function createChatScriptHarness(
@@ -28,26 +27,19 @@ function createChatScriptHarness(
   };
   const elements: Record<string, any> = {
     chat: {
-        _childNodes: [] as any[],
-        get innerHTML() {
-          if (this._childNodes.length > 0) {
-            return this._childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-          }
-          return chatInnerHTML;
-        },
-        set innerHTML(value: string) {
-          chatInnerHTMLSetCount += 1;
-          chatInnerHTML = value;
-          this._childNodes = [];
-        },
-        get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
-        replaceChildren(...nodes: any[]) {
-          chatInnerHTMLSetCount += 1;
-          this._childNodes = nodes;
-        },
-        appendChild(node: any) {
-          this._childNodes.push(node);
-        },
+      get innerHTML() { return chatInnerHTML; },
+      set innerHTML(value: string) {
+        chatInnerHTMLSetCount += 1;
+        chatInnerHTML = value;
+      },
+      get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
+      replaceChildren(...nodes: any[]) {
+        chatInnerHTMLSetCount += 1;
+        chatInnerHTML = nodes.map(n => n.outerHTML ?? n.textContent ?? "").join("");
+      },
+      appendChild(node: any) {
+        chatInnerHTML += (node.outerHTML ?? node.textContent ?? "");
+      },
       querySelector: () => null,
       scrollTop: 0,
       scrollHeight: 0,
@@ -86,7 +78,7 @@ function createChatScriptHarness(
             this.childNodes.push(node);
         },
         get outerHTML() {
-            return createMockElementOuterHTML(this);
+            return createMockElementOuterHTML(this, tag);
         }
     }),
     createDocumentFragment: () => ({
@@ -583,7 +575,7 @@ suite("chatAssets unit tests", () => {
 
     harness.elements.chat.querySelector = (sel: string) => {
       if (sel === '.empty-state' && harness.elements.chat.innerHTML.includes('empty-state')) {
-        return { querySelector: () => null };
+        return {};
       }
       return null;
     };
@@ -707,7 +699,7 @@ suite("chatAssets unit tests", () => {
             this.childNodes.push(node);
         },
         get outerHTML() {
-            return createMockElementOuterHTML(this);
+            return createMockElementOuterHTML(this, tag);
         }
       }),
       createDocumentFragment: () => ({

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -70,7 +70,9 @@ function createChatScriptHarness(
             const cls = this.className ? ` class="${this.className}"` : "";
             const role = (this as any).role ? ` role="${(this as any).role}"` : "";
             const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}>${text}</${tag}>`;
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
     }),
     createDocumentFragment: () => ({
@@ -696,7 +698,9 @@ suite("chatAssets unit tests", () => {
             const cls = this.className ? ` class="${this.className}"` : "";
             const role = (this as any).role ? ` role="${(this as any).role}"` : "";
             const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}>${text}</${tag}>`;
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
       }),
       createDocumentFragment: () => ({

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,6 +1,20 @@
 import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
+function createMockElementOuterHTML(element: any): string {
+  const { tagName, className, textContent, childNodes } = element;
+  const childrenHtml = (childNodes || []).map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+  const text = textContent || childrenHtml;
+  const attrs = [];
+  if (className) attrs.push(`class="${className}"`);
+  if (element.role) attrs.push(`role="${element.role}"`);
+  if (element["aria-label"]) attrs.push(`aria-label="${element["aria-label"]}"`);
+  if (element["aria-live"]) attrs.push(`aria-live="${element["aria-live"]}"`);
+  if (element["aria-atomic"]) attrs.push(`aria-atomic="${element["aria-atomic"]}"`);
+  const attrsStr = attrs.length ? " " + attrs.join(" ") : "";
+  return `<${tagName}${attrsStr}>${text}</${tagName}>`;
+}
+
 function createChatScriptHarness(
   domPurify?: { sanitize: (html: string, config: any) => any },
   computedStyle = { borderTopWidth: "1px", borderBottomWidth: "1px" },
@@ -14,19 +28,26 @@ function createChatScriptHarness(
   };
   const elements: Record<string, any> = {
     chat: {
-      get innerHTML() { return chatInnerHTML; },
-      set innerHTML(value: string) {
-        chatInnerHTMLSetCount += 1;
-        chatInnerHTML = value;
-      },
-      get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
-      replaceChildren(...nodes: any[]) {
-        chatInnerHTMLSetCount += 1;
-        chatInnerHTML = nodes.map(n => n.outerHTML ?? n.textContent ?? "").join("");
-      },
-      appendChild(node: any) {
-        chatInnerHTML += (node.outerHTML ?? node.textContent ?? "");
-      },
+        _childNodes: [] as any[],
+        get innerHTML() {
+          if (this._childNodes.length > 0) {
+            return this._childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+          }
+          return chatInnerHTML;
+        },
+        set innerHTML(value: string) {
+          chatInnerHTMLSetCount += 1;
+          chatInnerHTML = value;
+          this._childNodes = [];
+        },
+        get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
+        replaceChildren(...nodes: any[]) {
+          chatInnerHTMLSetCount += 1;
+          this._childNodes = nodes;
+        },
+        appendChild(node: any) {
+          this._childNodes.push(node);
+        },
       querySelector: () => null,
       scrollTop: 0,
       scrollHeight: 0,
@@ -65,14 +86,7 @@ function createChatScriptHarness(
             this.childNodes.push(node);
         },
         get outerHTML() {
-            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-            const text = this.textContent ? this.textContent : childrenHtml;
-            const cls = this.className ? ` class="${this.className}"` : "";
-            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
-            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
-            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
+            return createMockElementOuterHTML(this);
         }
     }),
     createDocumentFragment: () => ({
@@ -569,7 +583,7 @@ suite("chatAssets unit tests", () => {
 
     harness.elements.chat.querySelector = (sel: string) => {
       if (sel === '.empty-state' && harness.elements.chat.innerHTML.includes('empty-state')) {
-        return {};
+        return { querySelector: () => null };
       }
       return null;
     };
@@ -693,14 +707,7 @@ suite("chatAssets unit tests", () => {
             this.childNodes.push(node);
         },
         get outerHTML() {
-            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-            const text = this.textContent ? this.textContent : childrenHtml;
-            const cls = this.className ? ` class="${this.className}"` : "";
-            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
-            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
-            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
+            return createMockElementOuterHTML(this);
         }
       }),
       createDocumentFragment: () => ({

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -270,23 +270,31 @@ export const CHAT_JS = `(function() {
 
   function renderMessages() {
     if (state.messages.length === 0 && !state.isTyping) {
-      if (!chatContainer.querySelector('.empty-state')) {
+      const existingEmptyState = chatContainer.querySelector('.empty-state');
+      if (existingEmptyState) {
+        const h3 = existingEmptyState.querySelector("h3");
+        const p = existingEmptyState.querySelector("p");
+        if (h3) h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";
+        if (p) p.textContent = state.sessionId
+          ? "Type a message to start interacting with Jules."
+          : "Select a session or create a new one to begin.";
+      } else {
         const emptyStateDiv = document.createElement("div");
         emptyStateDiv.className = "empty-state";
         emptyStateDiv.setAttribute("aria-live", "polite");
         emptyStateDiv.setAttribute("aria-atomic", "true");
 
         const h3 = document.createElement("h3");
-        h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";
-
+        emptyStateDiv.appendChild(h3);
         const p = document.createElement("p");
+        emptyStateDiv.appendChild(p);
+
+        replaceChildren(chatContainer, [emptyStateDiv]);
+
+        h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";
         p.textContent = state.sessionId
           ? "Type a message to start interacting with Jules."
           : "Select a session or create a new one to begin.";
-
-        emptyStateDiv.appendChild(h3);
-        emptyStateDiv.appendChild(p);
-        replaceChildren(chatContainer, [emptyStateDiv]);
       }
     } else {
       const nodes = state.messages.map(m => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -270,31 +270,23 @@ export const CHAT_JS = `(function() {
 
   function renderMessages() {
     if (state.messages.length === 0 && !state.isTyping) {
-      const existingEmptyState = chatContainer.querySelector('.empty-state');
-      if (existingEmptyState) {
-        const h3 = existingEmptyState.querySelector("h3");
-        const p = existingEmptyState.querySelector("p");
-        if (h3) h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";
-        if (p) p.textContent = state.sessionId
-          ? "Type a message to start interacting with Jules."
-          : "Select a session or create a new one to begin.";
-      } else {
+      if (!chatContainer.querySelector('.empty-state')) {
         const emptyStateDiv = document.createElement("div");
         emptyStateDiv.className = "empty-state";
         emptyStateDiv.setAttribute("aria-live", "polite");
         emptyStateDiv.setAttribute("aria-atomic", "true");
 
         const h3 = document.createElement("h3");
-        emptyStateDiv.appendChild(h3);
-        const p = document.createElement("p");
-        emptyStateDiv.appendChild(p);
-
-        replaceChildren(chatContainer, [emptyStateDiv]);
-
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";
+
+        const p = document.createElement("p");
         p.textContent = state.sessionId
           ? "Type a message to start interacting with Jules."
           : "Select a session or create a new one to begin.";
+
+        emptyStateDiv.appendChild(h3);
+        emptyStateDiv.appendChild(p);
+        replaceChildren(chatContainer, [emptyStateDiv]);
       }
     } else {
       const nodes = state.messages.map(m => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -273,6 +273,8 @@ export const CHAT_JS = `(function() {
       if (!chatContainer.querySelector('.empty-state')) {
         const emptyStateDiv = document.createElement("div");
         emptyStateDiv.className = "empty-state";
+        emptyStateDiv.setAttribute("aria-live", "polite");
+        emptyStateDiv.setAttribute("aria-atomic", "true");
 
         const h3 = document.createElement("h3");
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";


### PR DESCRIPTION
💡 What: チャットビューの Empty State（空の状態）を動的に生成する際、コンテナに `aria-live="polite"` と `aria-atomic="true"` 属性を追加しました。

🎯 Why: ユーザーがセッションを選択した際や、まだメッセージがない場合に動的に挿入される「Welcome to Jules」などのテキストが、スクリーンリーダーによって読み上げられない問題がありました。この対応により、コンテキストの変更が即座にユーザーに伝わるようになります。

📸 Before/After: （視覚的な変更はありません。アクセシビリティレイヤーのみの改善です。）

♿ Accessibility: 動的に生成される Empty State コンテナに `aria-live` 領域を設定し、スクリーンリーダーが新しいテキストを確実にアナウンスするように改善しました。これにより視覚障害を持つユーザーのナビゲーション体験が向上します。

---
*PR created automatically by Jules for task [8485104776601507064](https://jules.google.com/task/8485104776601507064) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

チャットビューの Empty State コンテナに `aria-live=\"polite\"` と `aria-atomic=\"true\"` を付与し、スクリーンリーダーへの動的コンテンツ通知を改善する変更です。テストハーネスの `outerHTML` モックも新属性をシリアライズできるよう更新されています。

- **`src/webview/chatAssets.ts`**: `renderMessages()` 内で生成される `empty-state` div に `aria-live=\"polite\"` と `aria-atomic=\"true\"` を追加。ただし、コンテンツを追加した状態で DOM に一括挿入しているため、ライブリージョンの検知タイミングに課題があります。
- **`src/test/chatAssets.unit.test.ts`**: ハーネスの `outerHTML` ゲッターを更新して新属性を出力対応にしたが、`aria-live`・`aria-atomic` を直接検証するアサーションは追加されていない。
- **`.Jules/palette.md`**: 動的 Empty State へのアクセシビリティ対応に関する学習ログを追記。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

アクセシビリティ改善を意図した変更ですが、`aria-live` の配置タイミングに問題があり、目的を達成できない可能性があります。

`aria-live` 領域はコンテンツが追加される前に DOM に存在している必要がありますが、現在の実装では子要素をすべて追加してから `replaceChildren` で一括挿入しているため、主要なスクリーンリーダーでアナウンスがスキップされるリスクがあります。意図したアクセシビリティ改善が実際には機能しない可能性があるため、修正が望まれます。

`src/webview/chatAssets.ts` の `renderMessages()` 関数における `aria-live` 領域の挿入順序を要確認。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | 空の状態コンテナに `aria-live="polite"` と `aria-atomic="true"` を追加。ただし、コンテンツを含む要素を一度に DOM に挿入するため、スクリーンリーダーへのアナウンスが確実でない可能性あり。 |
| src/test/chatAssets.unit.test.ts | テストハーネスの `outerHTML` モックを更新して `aria-live`・`aria-atomic` をシリアライズ対応。ただし新属性を検証するアサーションは追加されていない。 |
| .Jules/palette.md | アクセシブルな空の状態に関する学習ログを追記。コード変更なし。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SR as スクリーンリーダー
    participant DOM as chatContainer (DOM)
    participant JS as renderMessages()

    Note over JS: メッセージなし & isTyping=false

    JS->>JS: createElement("div") → emptyStateDiv
    JS->>JS: setAttribute("aria-live", "polite")
    JS->>JS: setAttribute("aria-atomic", "true")
    JS->>JS: appendChild(h3), appendChild(p)
    JS->>DOM: replaceChildren([emptyStateDiv]) ← コンテンツ込みで一括挿入

    Note over SR,DOM: ⚠️ aria-live 領域がコンテンツ付きで一度に挿入されるため、一部のスクリーンリーダーはアナウンスをスキップする可能性

    Note over JS,DOM: 推奨パターン
    JS->>DOM: replaceChildren([emptyStateDiv]) ← 空のまま挿入
    DOM-->>SR: ライブリージョンを認識
    JS->>DOM: emptyStateDiv.appendChild(h3)
    JS->>DOM: emptyStateDiv.appendChild(p)
    DOM-->>SR: ✅ コンテンツ変更を検知してアナウンス
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/webview/chatAssets.ts`, line 274-289 ([link](https://github.com/hiroki-org/jules-extension/blob/a50822d545aafd2a167e89cae5be578f39edcbaf/src/webview/chatAssets.ts#L274-L289)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **aria-live 領域の事前配置が必要**

   `aria-live` 属性を持つ要素にコンテンツを追加してから DOM に挿入しているため、スクリーンリーダーがアナウンスを行わない可能性があります。WAI-ARIA の仕様および主要スクリーンリーダー（NVDA、JAWS など）の実装では、ライブリージョンは **DOM に存在している状態でコンテンツが変更されたとき** にのみ確実にアナウンスされます。現在のコードでは `emptyStateDiv` にすべての子要素を追加してから `replaceChildren` で DOM に挿入するため、コンテンツを含む要素が一度に挿入されたとみなされ、アナウンスがスキップされるリスクがあります。

   推奨される修正パターンは、空の `aria-live` コンテナを先に `chatContainer` に挿入し、その後に子要素を追加することです（例: `replaceChildren(chatContainer, [emptyStateDiv])` を先に呼び出し、続いて `h3`・`p` を `emptyStateDiv.appendChild` で追加）。あるいは、常に DOM に存在する永続的なライブリージョンコンテナを HTML テンプレートに含めておき、その中身だけを更新する方法もあります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 274-289

   Comment:
   **aria-live 領域の事前配置が必要**

   `aria-live` 属性を持つ要素にコンテンツを追加してから DOM に挿入しているため、スクリーンリーダーがアナウンスを行わない可能性があります。WAI-ARIA の仕様および主要スクリーンリーダー（NVDA、JAWS など）の実装では、ライブリージョンは **DOM に存在している状態でコンテンツが変更されたとき** にのみ確実にアナウンスされます。現在のコードでは `emptyStateDiv` にすべての子要素を追加してから `replaceChildren` で DOM に挿入するため、コンテンツを含む要素が一度に挿入されたとみなされ、アナウンスがスキップされるリスクがあります。

   推奨される修正パターンは、空の `aria-live` コンテナを先に `chatContainer` に挿入し、その後に子要素を追加することです（例: `replaceChildren(chatContainer, [emptyStateDiv])` を先に呼び出し、続いて `h3`・`p` を `emptyStateDiv.appendChild` で追加）。あるいは、常に DOM に存在する永続的なライブリージョンコンテナを HTML テンプレートに含めておき、その中身だけを更新する方法もあります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/test/chatAssets.unit.test.ts`, line 548-563 ([link](https://github.com/hiroki-org/jules-extension/blob/a50822d545aafd2a167e89cae5be578f39edcbaf/src/test/chatAssets.unit.test.ts#L548-L563)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **新しい aria 属性のアサーションが欠落**

   テストハーネスの `outerHTML` ゲッターは `aria-live` と `aria-atomic` を正しくシリアライズするように更新されましたが、それらの値を検証するアサーションが追加されていません。現在のテストは `class="empty-state"` やテキストコンテンツの存在のみをチェックしています。`aria-live="polite"` や `aria-atomic="true"` を直接検証するアサーションを追加することで、将来の誤った削除を防ぐことができます。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 548-563

   Comment:
   **新しい aria 属性のアサーションが欠落**

   テストハーネスの `outerHTML` ゲッターは `aria-live` と `aria-atomic` を正しくシリアライズするように更新されましたが、それらの値を検証するアサーションが追加されていません。現在のテストは `class="empty-state"` やテキストコンテンツの存在のみをチェックしています。`aria-live="polite"` や `aria-atomic="true"` を直接検証するアサーションを追加することで、将来の誤った削除を防ぐことができます。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/webview/chatAssets.ts:274-289
**aria-live 領域の事前配置が必要**

`aria-live` 属性を持つ要素にコンテンツを追加してから DOM に挿入しているため、スクリーンリーダーがアナウンスを行わない可能性があります。WAI-ARIA の仕様および主要スクリーンリーダー（NVDA、JAWS など）の実装では、ライブリージョンは **DOM に存在している状態でコンテンツが変更されたとき** にのみ確実にアナウンスされます。現在のコードでは `emptyStateDiv` にすべての子要素を追加してから `replaceChildren` で DOM に挿入するため、コンテンツを含む要素が一度に挿入されたとみなされ、アナウンスがスキップされるリスクがあります。

推奨される修正パターンは、空の `aria-live` コンテナを先に `chatContainer` に挿入し、その後に子要素を追加することです（例: `replaceChildren(chatContainer, [emptyStateDiv])` を先に呼び出し、続いて `h3`・`p` を `emptyStateDiv.appendChild` で追加）。あるいは、常に DOM に存在する永続的なライブリージョンコンテナを HTML テンプレートに含めておき、その中身だけを更新する方法もあります。

### Issue 2 of 2
src/test/chatAssets.unit.test.ts:548-563
**新しい aria 属性のアサーションが欠落**

テストハーネスの `outerHTML` ゲッターは `aria-live` と `aria-atomic` を正しくシリアライズするように更新されましたが、それらの値を検証するアサーションが追加されていません。現在のテストは `class="empty-state"` やテキストコンテンツの存在のみをチェックしています。`aria-live="polite"` や `aria-atomic="true"` を直接検証するアサーションを追加することで、将来の誤った削除を防ぐことができます。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: \[UX improvement\] Add aria-li..."](https://github.com/hiroki-org/jules-extension/commit/a50822d545aafd2a167e89cae5be578f39edcbaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37243671)</sub>

<!-- /greptile_comment -->