### PR TITLE
⚡ Bolt: Optimize cache clearing performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -54,6 +54,6 @@
 ## 2026-06-04 - [Performance] Optimize string prefix removal
 **Learning:** Using regular expressions like `.replace(/^sessions\//, '')` introduces unnecessary compilation and execution overhead compared to basic string operations.
 **Action:** When conditionally removing a fixed string prefix, prefer using `.startsWith()` combined with `.slice()` for better execution speed and reduced memory allocation.
-## 2025-02-18 - Optimize bulk cache clearing by avoiding array chaining
+## 2026-06-13 - Optimize bulk cache clearing by avoiding array chaining
 **Learning:** Combining `.filter()`, array spreads, and `.map()` when processing state keys creates unnecessary intermediate arrays and memory overhead.
 **Action:** Use a single `for...of` loop to iterate keys and push to a promise array to reduce allocations when performing bulk state updates.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -54,3 +54,6 @@
 ## 2026-06-04 - [Performance] Optimize string prefix removal
 **Learning:** Using regular expressions like `.replace(/^sessions\//, '')` introduces unnecessary compilation and execution overhead compared to basic string operations.
 **Action:** When conditionally removing a fixed string prefix, prefer using `.startsWith()` combined with `.slice()` for better execution speed and reduced memory allocation.
+## 2025-02-18 - Optimize bulk cache clearing by avoiding array chaining
+**Learning:** Combining `.filter()`, array spreads, and `.map()` when processing state keys creates unnecessary intermediate arrays and memory overhead.
+**Action:** Use a single `for...of` loop to iterate keys and push to a promise array to reduce allocations when performing bulk state updates.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3837,22 +3837,31 @@ export function activate(context: vscode.ExtensionContext) {
         // すべてのキーを取得
         const allKeys = context.globalState.keys();
 
-        // Sources & Branches キャッシュをフィルタ
-        const branchCacheKeys = allKeys.filter((key) =>
-          key.startsWith("jules.branches."),
-        );
-        const cacheKeys = ["jules.sources", ...branchCacheKeys];
+        // ⚡ Bolt: Performance optimization
+        // Avoid chained .filter().map() and array spreads to reduce intermediate array allocations.
+        // We combine the filtering and mapping into a single pass using a for...of loop.
+        const promises: Thenable<void>[] = [
+          context.globalState.update("jules.sources", undefined),
+        ];
+        let branchCacheCount = 0;
+
+        for (const key of allKeys) {
+          if (key.startsWith("jules.branches.")) {
+            promises.push(context.globalState.update(key, undefined));
+            branchCacheCount++;
+          }
+        }
 
         // すべてのキャッシュをクリア
-        await Promise.all(
-          cacheKeys.map((key) => context.globalState.update(key, undefined)),
-        );
+        await Promise.all(promises);
+
+        const totalCleared = branchCacheCount + 1;
 
         vscode.window.showInformationMessage(
-          `Jules cache cleared: ${cacheKeys.length} entries removed`,
+          `Jules cache cleared: ${totalCleared} entries removed`,
         );
         logChannel.appendLine(
-          `[Jules] Cache cleared: ${cacheKeys.length} entries (1 sources + ${branchCacheKeys.length} branches)`,
+          `[Jules] Cache cleared: ${totalCleared} entries (1 sources + ${branchCacheCount} branches)`,
         );
       } catch (error: any) {
         logChannel.appendLine(`[Jules] Error clearing cache: ${error.message}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3838,17 +3838,18 @@ export function activate(context: vscode.ExtensionContext) {
         const allKeys = context.globalState.keys();
 
         // ⚡ Bolt: パフォーマンス最適化
-        // filter() と map() のチェーンやスプレッド構文を避け、中間配列の割り当てを減らします。
-        // for...of ループを使用して、フィルタリングとマッピングを1回のパスで組み合わせます。
+        // 不要な中間配列の生成を避けるため、chained な .filter().map() や array spread を避け、
+        // 1回の for...of ループでフィルタとマッピングを統合して処理します。
         const promises: Thenable<void>[] = [];
         let branchCacheCount = 0;
-        let hasSources = false;
+
+        // "jules.sources" キーが存在する場合のみアップデートに追加
+        if (allKeys.includes("jules.sources")) {
+          promises.push(context.globalState.update("jules.sources", undefined));
+        }
 
         for (const key of allKeys) {
-          if (key === "jules.sources") {
-            promises.push(context.globalState.update(key, undefined));
-            hasSources = true;
-          } else if (key.startsWith("jules.branches.")) {
+          if (key.startsWith("jules.branches.")) {
             promises.push(context.globalState.update(key, undefined));
             branchCacheCount++;
           }
@@ -3857,13 +3858,13 @@ export function activate(context: vscode.ExtensionContext) {
         // すべてのキャッシュをクリア
         await Promise.all(promises);
 
-        const totalCleared = branchCacheCount + (hasSources ? 1 : 0);
+        const totalCleared = branchCacheCount + 1;
 
         vscode.window.showInformationMessage(
           `Jules cache cleared: ${totalCleared} entries removed`,
         );
         logChannel.appendLine(
-          `[Jules] Cache cleared: ${totalCleared} entries (${hasSources ? 1 : 0} sources + ${branchCacheCount} branches)`,
+          `[Jules] Cache cleared: ${totalCleared} entries (1 sources + ${branchCacheCount} branches)`,
         );
       } catch (error: any) {
         logChannel.appendLine(`[Jules] Error clearing cache: ${error.message}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3837,16 +3837,18 @@ export function activate(context: vscode.ExtensionContext) {
         // すべてのキーを取得
         const allKeys = context.globalState.keys();
 
-        // ⚡ Bolt: Performance optimization
-        // Avoid chained .filter().map() and array spreads to reduce intermediate array allocations.
-        // We combine the filtering and mapping into a single pass using a for...of loop.
-        const promises: Thenable<void>[] = [
-          context.globalState.update("jules.sources", undefined),
-        ];
+        // ⚡ Bolt: パフォーマンス最適化
+        // filter() と map() のチェーンやスプレッド構文を避け、中間配列の割り当てを減らします。
+        // for...of ループを使用して、フィルタリングとマッピングを1回のパスで組み合わせます。
+        const promises: Thenable<void>[] = [];
         let branchCacheCount = 0;
+        let hasSources = false;
 
         for (const key of allKeys) {
-          if (key.startsWith("jules.branches.")) {
+          if (key === "jules.sources") {
+            promises.push(context.globalState.update(key, undefined));
+            hasSources = true;
+          } else if (key.startsWith("jules.branches.")) {
             promises.push(context.globalState.update(key, undefined));
             branchCacheCount++;
           }
@@ -3855,13 +3857,13 @@ export function activate(context: vscode.ExtensionContext) {
         // すべてのキャッシュをクリア
         await Promise.all(promises);
 
-        const totalCleared = branchCacheCount + 1;
+        const totalCleared = branchCacheCount + (hasSources ? 1 : 0);
 
         vscode.window.showInformationMessage(
           `Jules cache cleared: ${totalCleared} entries removed`,
         );
         logChannel.appendLine(
-          `[Jules] Cache cleared: ${totalCleared} entries (1 sources + ${branchCacheCount} branches)`,
+          `[Jules] Cache cleared: ${totalCleared} entries (${hasSources ? 1 : 0} sources + ${branchCacheCount} branches)`,
         );
       } catch (error: any) {
         logChannel.appendLine(`[Jules] Error clearing cache: ${error.message}`);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -754,16 +754,25 @@ suite("Extension Test Suite", () => {
       (mockContext.globalState.keys as sinon.SinonStub).returns(allKeys);
 
       // キャッシュクリア処理をシミュレート
-      const branchCacheKeys = allKeys.filter(key => key.startsWith('jules.branches.'));
-      const cacheKeys = ['jules.sources', ...branchCacheKeys];
+      const promises: any[] = [
+        "jules.sources"
+      ];
+      let branchCacheCount = 0;
+
+      for (const key of allKeys) {
+        if (key.startsWith("jules.branches.")) {
+          promises.push(key);
+          branchCacheCount++;
+        }
+      }
 
       // 検証：正しいキーがフィルタされることを確認
-      assert.strictEqual(cacheKeys.length, 4); // 1 sources + 3 branches
-      assert.strictEqual(branchCacheKeys.length, 3);
-      assert.ok(cacheKeys.includes('jules.sources'));
-      assert.ok(cacheKeys.includes('jules.branches.source1'));
-      assert.ok(cacheKeys.includes('jules.branches.source2'));
-      assert.ok(cacheKeys.includes('jules.branches.source3'));
+      assert.strictEqual(promises.length, 4); // 1 sources + 3 branches
+      assert.strictEqual(branchCacheCount, 3);
+      assert.ok(promises.includes('jules.sources'));
+      assert.ok(promises.includes('jules.branches.source1'));
+      assert.ok(promises.includes('jules.branches.source2'));
+      assert.ok(promises.includes('jules.branches.source3'));
     });
 
     test("cache should expire after TTL", () => {

--- a/src/test/extensionHelpers.unit.test.ts
+++ b/src/test/extensionHelpers.unit.test.ts
@@ -1039,17 +1039,7 @@ suite("Extension helper unit tests", () => {
       assert.ok(registeredCommands['jules-extension.clearCache']);
       const showInfoStub = localSandbox.stub(vscode.window, 'showInformationMessage').resolves();
 
-      // Override the mock to return an array of keys including branch caches
-      const mockKeys = [
-        "jules.sources",
-        "jules.branches.source1",
-        "jules.branches.source2",
-        "other.key"
-      ];
-      // mockContext is not directly accessible here, but the active extension has it via activate
-      // We know globalState.keys is stubbed in setup, we can find it
-      const keysStub = (extensionModule as any)._test_mockContext_keys_stub || localSandbox.stub(); // Just overriding the first return if we can't find it easily
-      // Let's rely on sinon's ability to find the stub
+
 
       await registeredCommands['jules-extension.clearCache']();
       assert.strictEqual(showInfoStub.calledOnce, true);

--- a/src/test/extensionHelpers.unit.test.ts
+++ b/src/test/extensionHelpers.unit.test.ts
@@ -1038,9 +1038,6 @@ suite("Extension helper unit tests", () => {
     test("jules-extension.clearCache executes successfully", async () => {
       assert.ok(registeredCommands['jules-extension.clearCache']);
       const showInfoStub = localSandbox.stub(vscode.window, 'showInformationMessage').resolves();
-
-
-
       await registeredCommands['jules-extension.clearCache']();
       assert.strictEqual(showInfoStub.calledOnce, true);
     });

--- a/src/test/extensionHelpers.unit.test.ts
+++ b/src/test/extensionHelpers.unit.test.ts
@@ -943,7 +943,12 @@ suite("Extension helper unit tests", () => {
             return {};
           }),
           update: localSandbox.stub().resolves(),
-          keys: localSandbox.stub().returns([]),
+          keys: localSandbox.stub().returns([
+            "jules.sources",
+            "jules.branches.source1",
+            "jules.branches.source2",
+            "other.key"
+          ]),
         },
         subscriptions: [],
         secrets: { get: getSecretStub, store: localSandbox.stub().resolves() }
@@ -1033,6 +1038,19 @@ suite("Extension helper unit tests", () => {
     test("jules-extension.clearCache executes successfully", async () => {
       assert.ok(registeredCommands['jules-extension.clearCache']);
       const showInfoStub = localSandbox.stub(vscode.window, 'showInformationMessage').resolves();
+
+      // Override the mock to return an array of keys including branch caches
+      const mockKeys = [
+        "jules.sources",
+        "jules.branches.source1",
+        "jules.branches.source2",
+        "other.key"
+      ];
+      // mockContext is not directly accessible here, but the active extension has it via activate
+      // We know globalState.keys is stubbed in setup, we can find it
+      const keysStub = (extensionModule as any)._test_mockContext_keys_stub || localSandbox.stub(); // Just overriding the first return if we can't find it easily
+      // Let's rely on sinon's ability to find the stub
+
       await registeredCommands['jules-extension.clearCache']();
       assert.strictEqual(showInfoStub.calledOnce, true);
     });


### PR DESCRIPTION
💡 What: Replaced a chained `.filter().map()` and an array spread with a single `for...of` loop when iterating over extension global keys in `clearCache`.
🎯 Why: Chaining functional operations causes intermediate array creations. This micro-optimization reduces memory allocations and unnecessary array traversals on a bulk cache invalidation path.
📊 Impact: Eliminates an intermediate filtered array and a mapped promise array.
🔬 Measurement: Run the `pnpm run test:unit` extension test suite to verify clearing branches caches still behaves correctly.

---
*PR created automatically by Jules for task [12754787858213815112](https://jules.google.com/task/12754787858213815112) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `clearCache` コマンド内で `.filter().map()` チェーンと配列スプレッドを `for...of` ループに置き換えるマイクロ最適化です。動作の等価性は保たれており、ロジックに問題はありません。

- `jules.sources` のクリアとブランチキャッシュのフィルタリング・クリアを1パスに統合し、中間配列の生成を削減している。
- `branchCacheCount` 変数でエントリ数を追跡し、ログメッセージの内容は変更前と同等の情報を出力する。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

キャッシュクリアのロジックは変更前と等価で、動作に問題はない。指摘は日本語コメント規約違反と bolt.md の日付ミスのみ。

変更されたロジックは clearCache コマンドのみで、動作の等価性は確認できている。context.globalState.update が配列構築時に即時呼び出される点は元のコードと実質的に同じ挙動であり、機能上の問題はない。ただし追加されたインラインコメントが AGENTS.md の日本語規約に違反しており、.jules/bolt.md の日付も他エントリと時系列が合わない。

src/extension.ts の新規インラインコメント（英語で記述されており、日本語に修正が必要）と .jules/bolt.md の日付フィールドを確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | clearCache コマンドで .filter().map() チェーンを for...of ループに置き換え。ロジックの等価性は確認できているが、追加されたコメントが英語でAGENTS.mdの日本語規約に違反している。 |
| .jules/bolt.md | 新しいラーニングエントリを追加。日付が 2025-02-18 になっており、他のエントリ（2026年）と時系列が合わない。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Command as clearCache Command
    participant GlobalState as context.globalState
    participant UI as vscode.window

    User->>Command: jules-extension.clearCache 実行
    Command->>GlobalState: keys() で全キー取得
    Command->>GlobalState: update("jules.sources", undefined) ← 即時呼び出し
    loop allKeys の各キー
        alt key.startsWith("jules.branches.")
            Command->>GlobalState: update(key, undefined)
        end
    end
    Command->>GlobalState: Promise.all(promises) await
    GlobalState-->>Command: すべての更新完了
    Command->>UI: showInformationMessage(totalCleared entries removed)
    Command->>UI: logChannel.appendLine(Cache cleared)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/extension.ts:3840-3842
**コメントが英語で記述されている**

`AGENTS.md` の規約では「特に指定がない限り、すべての出力、コメント、ドキュメントは**日本語**で行うこと」と定められています。変更前のコード（`// Sources & Branches キャッシュをフィルタ`）は日本語でしたが、今回の変更で追加された3行のインラインコメントがすべて英語になっています。リポジトリ規約に合わせて日本語に直す必要があります。

### Issue 2 of 2
.jules/bolt.md:57
**日付が誤っている可能性**

他のエントリは `2026-06-04` などと 2026 年になっているのに対し、この新しいエントリは `2025-02-18` となっており、時系列が逆転しています。記録日が正しいか確認してください。

```suggestion
## 2026-06-13 - Optimize bulk cache clearing by avoiding array chaining
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Optimize globalState cache clearing to a..."](https://github.com/hiroki-org/jules-extension/commit/33fa5e4b83c8ce1d7c801b2fa0c16b00c7f00b04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37406635)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->