### PR TITLE
🎨 Palette: 空の状態（Empty State）へのARIAライブリージョン追加によるアクセシビリティ向上

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,6 +19,5 @@
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
 
 ## 2026-06-11 - 空の状態（Empty State）へのARIAライブリージョンの追加
-
 **Learning:** 動的にDOMへ挿入される「空の状態（例：ウェルカムメッセージやプレースホルダー）」に対して、`aria-live="polite"` および `aria-atomic="true"` を追加することで、状態の変化がスクリーンリーダーによって即座に読み上げられるようになり、ユーザーが現在のアプリケーションの状況を正確に把握できるようになります。
 **Action:** 次回、チャットUIやリストなどで、コンテンツがない場合に表示される一時的なコンテナを動的に生成・挿入する際は、必ずそのコンテナに `aria-live="polite"` と `aria-atomic="true"` を設定すること。

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-06-06 - Prefer Native Disabled for Form Controls
 **Learning:** Native form controls such as `<button>`, `<textarea>`, and `<input>` already expose their disabled state through the `disabled` property. Adding `aria-disabled` to the same disabled controls is redundant and can imply focus behavior that does not match native disabled elements.
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
+
+## 2025-06-11 - 空の状態（Empty State）へのARIAライブリージョンの追加
+**Learning:** 動的にDOMへ挿入される「空の状態（例：ウェルカムメッセージやプレースホルダー）」に対して、`aria-live="polite"` および `aria-atomic="true"` を追加することで、状態の変化がスクリーンリーダーによって即座に読み上げられるようになり、ユーザーが現在のアプリケーションの状況を正確に把握できるようになります。
+**Action:** 次回、チャットUIやリストなどで、コンテンツがない場合に表示される一時的なコンテナを動的に生成・挿入する際は、必ずそのコンテナに `aria-live="polite"` と `aria-atomic="true"` を設定すること。

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,10 +13,12 @@
 ## 2026-05-26 - Title Tooltip Support for Truncated Text
 **Learning:** When applying CSS `text-overflow: ellipsis` to truncate long dynamically generated content (like a session ID), it is necessary to provide an accessible way for users to view the complete text. Mirroring the `textContent` into the `title` attribute creates a native browser tooltip, enabling hover-based discovery of the full content without requiring custom UI components.
 **Action:** Whenever using `text-overflow: ellipsis` to clip text in the DOM, synchronously update the element's `title` attribute to match the full `textContent`.
+
 ## 2026-06-06 - Prefer Native Disabled for Form Controls
 **Learning:** Native form controls such as `<button>`, `<textarea>`, and `<input>` already expose their disabled state through the `disabled` property. Adding `aria-disabled` to the same disabled controls is redundant and can imply focus behavior that does not match native disabled elements.
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
 
-## 2025-06-11 - 空の状態（Empty State）へのARIAライブリージョンの追加
+## 2026-06-11 - 空の状態（Empty State）へのARIAライブリージョンの追加
+
 **Learning:** 動的にDOMへ挿入される「空の状態（例：ウェルカムメッセージやプレースホルダー）」に対して、`aria-live="polite"` および `aria-atomic="true"` を追加することで、状態の変化がスクリーンリーダーによって即座に読み上げられるようになり、ユーザーが現在のアプリケーションの状況を正確に把握できるようになります。
 **Action:** 次回、チャットUIやリストなどで、コンテンツがない場合に表示される一時的なコンテナを動的に生成・挿入する際は、必ずそのコンテナに `aria-live="polite"` と `aria-atomic="true"` を設定すること。

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,6 +1,17 @@
 import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
+export function createMockElementOuterHTML(element: any, tag: string): string {
+    const childrenHtml = element.childNodes ? element.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("") : "";
+    const text = element.textContent ? element.textContent : childrenHtml;
+    const cls = element.className ? ` class="${element.className}"` : "";
+    const role = element.role ? ` role="${element.role}"` : "";
+    const ariaLabel = element["aria-label"] ? ` aria-label="${element["aria-label"]}"` : "";
+    const ariaLive = element["aria-live"] ? ` aria-live="${element["aria-live"]}"` : "";
+    const ariaAtomic = element["aria-atomic"] ? ` aria-atomic="${element["aria-atomic"]}"` : "";
+    return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
+}
+
 function createChatScriptHarness(
   domPurify?: { sanitize: (html: string, config: any) => any },
   computedStyle = { borderTopWidth: "1px", borderBottomWidth: "1px" },
@@ -14,20 +25,32 @@ function createChatScriptHarness(
   };
   const elements: Record<string, any> = {
     chat: {
-      get innerHTML() { return chatInnerHTML; },
+      childNodes: [] as any[],
+      get innerHTML() {
+        if (this.childNodes && this.childNodes.length > 0) {
+            return this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+        }
+        return chatInnerHTML;
+      },
       set innerHTML(value: string) {
         chatInnerHTMLSetCount += 1;
         chatInnerHTML = value;
+        this.childNodes = [];
       },
       get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
       replaceChildren(...nodes: any[]) {
         chatInnerHTMLSetCount += 1;
-        chatInnerHTML = nodes.map(n => n.outerHTML ?? n.textContent ?? "").join("");
+        this.childNodes = [...nodes];
       },
       appendChild(node: any) {
-        chatInnerHTML += (node.outerHTML ?? node.textContent ?? "");
+        this.childNodes.push(node);
       },
-      querySelector: () => null,
+      querySelector: (sel: string) => {
+        if (sel === '.empty-state') {
+          return elements.chat.childNodes.find((n: any) => n.className === 'empty-state') || null;
+        }
+        return null;
+      },
       scrollTop: 0,
       scrollHeight: 0,
       addEventListener: (evt: string, cb: any) => { listeners.chat[evt] = cb; },
@@ -65,14 +88,7 @@ function createChatScriptHarness(
             this.childNodes.push(node);
         },
         get outerHTML() {
-            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-            const text = this.textContent ? this.textContent : childrenHtml;
-            const cls = this.className ? ` class="${this.className}"` : "";
-            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
-            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
-            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
+            return createMockElementOuterHTML(this, tag);
         }
     }),
     createDocumentFragment: () => ({
@@ -697,14 +713,7 @@ suite("chatAssets unit tests", () => {
             this.childNodes.push(node);
         },
         get outerHTML() {
-            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-            const text = this.textContent ? this.textContent : childrenHtml;
-            const cls = this.className ? ` class="${this.className}"` : "";
-            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
-            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
-            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
+            return createMockElementOuterHTML(this, tag);
         }
       }),
       createDocumentFragment: () => ({

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,17 +1,6 @@
 import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
-export function createMockElementOuterHTML(element: any, tag: string): string {
-    const childrenHtml = element.childNodes ? element.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("") : "";
-    const text = element.textContent ? element.textContent : childrenHtml;
-    const cls = element.className ? ` class="${element.className}"` : "";
-    const role = element.role ? ` role="${element.role}"` : "";
-    const ariaLabel = element["aria-label"] ? ` aria-label="${element["aria-label"]}"` : "";
-    const ariaLive = element["aria-live"] ? ` aria-live="${element["aria-live"]}"` : "";
-    const ariaAtomic = element["aria-atomic"] ? ` aria-atomic="${element["aria-atomic"]}"` : "";
-    return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
-}
-
 function createChatScriptHarness(
   domPurify?: { sanitize: (html: string, config: any) => any },
   computedStyle = { borderTopWidth: "1px", borderBottomWidth: "1px" },
@@ -25,32 +14,32 @@ function createChatScriptHarness(
   };
   const elements: Record<string, any> = {
     chat: {
-      childNodes: [] as any[],
-      get innerHTML() {
-        if (this.childNodes && this.childNodes.length > 0) {
-            return this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-        }
-        return chatInnerHTML;
-      },
+      get innerHTML() { return chatInnerHTML; },
       set innerHTML(value: string) {
         chatInnerHTMLSetCount += 1;
         chatInnerHTML = value;
-        this.childNodes = [];
       },
       get innerHTMLSetCount() { return chatInnerHTMLSetCount; },
       replaceChildren(...nodes: any[]) {
         chatInnerHTMLSetCount += 1;
-        this.childNodes = [...nodes];
+        chatInnerHTML = nodes.map(n => {
+            if (n.childNodes && n.childNodes.length === 0) {
+              const childrenHtml = n.childNodes.map((child: any) => child.outerHTML ?? child.textContent ?? "").join("");
+              const text = n.textContent ? n.textContent : childrenHtml;
+              const cls = n.className ? ` class="${n.className}"` : "";
+              const role = (n as any).role ? ` role="${(n as any).role}"` : "";
+              const ariaLabel = (n as any)["aria-label"] ? ` aria-label="${(n as any)["aria-label"]}"` : "";
+              const ariaLive = (n as any)["aria-live"] ? ` aria-live="${(n as any)["aria-live"]}"` : "";
+              const ariaAtomic = (n as any)["aria-atomic"] ? ` aria-atomic="${(n as any)["aria-atomic"]}"` : "";
+              return `<${n.tagName}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${n.tagName}>`;
+            }
+            return n.outerHTML ?? n.textContent ?? "";
+        }).join("");
       },
       appendChild(node: any) {
-        this.childNodes.push(node);
+        chatInnerHTML += (node.outerHTML ?? node.textContent ?? "");
       },
-      querySelector: (sel: string) => {
-        if (sel === '.empty-state') {
-          return elements.chat.childNodes.find((n: any) => n.className === 'empty-state') || null;
-        }
-        return null;
-      },
+      querySelector: () => null,
       scrollTop: 0,
       scrollHeight: 0,
       addEventListener: (evt: string, cb: any) => { listeners.chat[evt] = cb; },
@@ -88,7 +77,14 @@ function createChatScriptHarness(
             this.childNodes.push(node);
         },
         get outerHTML() {
-            return createMockElementOuterHTML(this, tag);
+            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+            const text = this.textContent ? this.textContent : childrenHtml;
+            const cls = this.className ? ` class="${this.className}"` : "";
+            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
+            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
     }),
     createDocumentFragment: () => ({
@@ -713,7 +709,14 @@ suite("chatAssets unit tests", () => {
             this.childNodes.push(node);
         },
         get outerHTML() {
-            return createMockElementOuterHTML(this, tag);
+            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+            const text = this.textContent ? this.textContent : childrenHtml;
+            const cls = this.className ? ` class="${this.className}"` : "";
+            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
+            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
       }),
       createDocumentFragment: () => ({

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -70,7 +70,9 @@ function createChatScriptHarness(
             const cls = this.className ? ` class="${this.className}"` : "";
             const role = (this as any).role ? ` role="${(this as any).role}"` : "";
             const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}>${text}</${tag}>`;
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
     }),
     createDocumentFragment: () => ({
@@ -544,6 +546,8 @@ suite("chatAssets unit tests", () => {
     });
 
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Welcome to Jules"));
     assert.ok(harness.elements.chat.innerHTML.includes("Select a session or create a new one"));
   });
@@ -557,6 +561,8 @@ suite("chatAssets unit tests", () => {
     });
 
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Ready to assist"));
     assert.ok(harness.elements.chat.innerHTML.includes("Type a message to start interacting"));
   });
@@ -696,7 +702,9 @@ suite("chatAssets unit tests", () => {
             const cls = this.className ? ` class="${this.className}"` : "";
             const role = (this as any).role ? ` role="${(this as any).role}"` : "";
             const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}>${text}</${tag}>`;
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
       }),
       createDocumentFragment: () => ({

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -276,9 +276,6 @@ export const CHAT_JS = `(function() {
         emptyStateDiv.setAttribute("aria-live", "polite");
         emptyStateDiv.setAttribute("aria-atomic", "true");
 
-        // 先に空のコンテナをDOMに挿入する
-        replaceChildren(chatContainer, [emptyStateDiv]);
-
         const h3 = document.createElement("h3");
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";
 
@@ -287,7 +284,7 @@ export const CHAT_JS = `(function() {
           ? "Type a message to start interacting with Jules."
           : "Select a session or create a new one to begin.";
 
-        // DOM挿入後に子要素を追加することで、スクリーンリーダーがテキストの変更を検知できるようにする
+        replaceChildren(chatContainer, [emptyStateDiv]);
         emptyStateDiv.appendChild(h3);
         emptyStateDiv.appendChild(p);
       }

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -276,6 +276,9 @@ export const CHAT_JS = `(function() {
         emptyStateDiv.setAttribute("aria-live", "polite");
         emptyStateDiv.setAttribute("aria-atomic", "true");
 
+        // 先に空のコンテナをDOMに挿入する
+        replaceChildren(chatContainer, [emptyStateDiv]);
+
         const h3 = document.createElement("h3");
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";
 
@@ -284,9 +287,9 @@ export const CHAT_JS = `(function() {
           ? "Type a message to start interacting with Jules."
           : "Select a session or create a new one to begin.";
 
+        // DOM挿入後に子要素を追加することで、スクリーンリーダーがテキストの変更を検知できるようにする
         emptyStateDiv.appendChild(h3);
         emptyStateDiv.appendChild(p);
-        replaceChildren(chatContainer, [emptyStateDiv]);
       }
     } else {
       const nodes = state.messages.map(m => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -273,6 +273,8 @@ export const CHAT_JS = `(function() {
       if (!chatContainer.querySelector('.empty-state')) {
         const emptyStateDiv = document.createElement("div");
         emptyStateDiv.className = "empty-state";
+        emptyStateDiv.setAttribute("aria-live", "polite");
+        emptyStateDiv.setAttribute("aria-atomic", "true");
 
         const h3 = document.createElement("h3");
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";


### PR DESCRIPTION
💡 **What:** チャットUI等でセッションが未選択またはメッセージがない場合に表示される「空の状態（Empty State）」のコンテナ（`emptyStateDiv`）に、`aria-live="polite"` および `aria-atomic="true"` 属性を追加しました。また、これに対応して単体テスト（`src/test/chatAssets.unit.test.ts`）内のDOMモックも更新し、新属性の直列化と検証ロジックを追加しました。

🎯 **Why:** コンテンツが動的に画面へ挿入・更新された際、視覚的な変化だけでなく、スクリーンリーダーを使用しているユーザーに対しても「現在どのような状態であるか（例：Ready to assist）」を即座に伝える必要があるためです。これにより、ユーザーが迷うことなく次のアクションを理解できるようになります。

📸 **Before/After:**
視覚的なUIの変更はありません（スクリーンリーダー向けの見えない改善です）。

♿ **Accessibility:** `aria-live="polite"` により、進行中の読み上げを中断することなく、適切なタイミングで新しい状態がアナウンスされます。また、`aria-atomic="true"` によって、コンテナ内の一部のテキストだけでなく、全体の文脈（h3とpタグの内容）がまとめて読み上げられるようになり、正確な情報伝達が保証されます。

---
*PR created automatically by Jules for task [3571031716162851578](https://jules.google.com/task/3571031716162851578) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

チャットUIの空の状態コンテナ（`emptyStateDiv`）に `aria-live="polite"` と `aria-atomic="true"` を追加し、セッション未選択・メッセージゼロ時の状態をスクリーンリーダーへ通知することを目的としたPRです。対応してテストのDOMモックと属性アサーションも更新されています。

- **`src/webview/chatAssets.ts`**: `emptyStateDiv` 生成時に2つのARIA属性を `setAttribute` で設定。ただし子要素を追加した後にDOMへ挿入する順序のため、主要スクリーンリーダー（NVDA・JAWS）ではライブリージョンのアナウンスが発火しない可能性があります。
- **`src/test/chatAssets.unit.test.ts`**: モックの `outerHTML` ゲッターに `aria-live` / `aria-atomic` のシリアライズを追加し、両属性の存在をアサーション。テスト構造は正しいが、ブラウザのMutation Observerを模倣していないため、タイミング問題は静的チェックでは検出できません。
- **`.Jules/palette.md`**: 学習ログのエントリ日付が \"2025-06-11\" と1年ずれています。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

UIの見た目には影響なく既存機能を壊すリスクは低いが、このPRが達成しようとしているスクリーンリーダーへの読み上げ通知がNVDA・JAWSで動作しない可能性があり、アクセシビリティ改善の主目的が実現されないままマージされる恐れがあります。

`aria-live` コンテナにコンテンツを追加した後にDOMへ挿入しているため、NVDA+Firefox や JAWS+Chrome といった広く使われているスクリーンリーダーの組み合わせで読み上げが発火しないことが知られています。テストのDOMモックはこのタイミング問題を検出できないため、テストがパスしていても実際のアクセシビリティ要件を満たしているかどうかが保証されません。

主に `src/webview/chatAssets.ts` の `renderMessages` 関数内、`replaceChildren` 呼び出し前後の処理順序が要確認です。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | `emptyStateDiv` に `aria-live="polite"` と `aria-atomic="true"` を追加したが、コンテンツを追加してからDOMへ挿入しているため、主要スクリーンリーダーで読み上げが発火しない可能性がある |
| src/test/chatAssets.unit.test.ts | DOMモックに `aria-live` / `aria-atomic` のシリアライズを追加し、両属性の存在チェックをアサーションとして追加。テスト自体は正しく記述されているが、モックが実ブラウザのMutation Observerを再現していないため、ライブリージョンのタイミング問題を検出できない |
| .Jules/palette.md | ARIAライブリージョンに関する学習ログを追加。日付が "2025-06-11" と1年ずれており時系列が逆転している |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant VS as VS Code Extension
    participant WV as Webview (chatAssets.ts)
    participant DOM as DOM
    participant SR as スクリーンリーダー

    VS->>WV: "postMessage({ type: chatState, messages: [] })"
    WV->>WV: renderMessages() 呼び出し
    WV->>DOM: createElement(div) emptyStateDiv
    WV->>WV: setAttribute(aria-live, polite)
    WV->>WV: setAttribute(aria-atomic, true)
    WV->>WV: h3 / p を emptyStateDiv.appendChild()
    Note over WV,DOM: コンテンツ入りの状態でDOMへ挿入
    WV->>DOM: replaceChildren(chatContainer, [emptyStateDiv])
    DOM-->>SR: Mutation Observer 通知
    Note over SR: NVDA/JAWS は挿入時点でコンテンツが既にある場合読み上げをスキップすることがある

    Note over WV,DOM: 推奨フロー
    WV->>DOM: replaceChildren(chatContainer, [emptyStateDiv]) 空で挿入
    WV->>DOM: emptyStateDiv.appendChild(h3)
    WV->>DOM: emptyStateDiv.appendChild(p)
    DOM-->>SR: Mutation Observer 通知（コンテンツ変化）
    SR->>SR: Ready to assist を読み上げ
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/webview/chatAssets.ts`, line 274-289 ([link](https://github.com/hiroki-org/jules-extension/blob/8911b2cf7d17924c7a81c66d2729cbd153c059ce/src/webview/chatAssets.ts#L274-L289)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **aria-live リージョンへのコンテンツ追加タイミング問題**

   `aria-live` の有効な動作には、コンテナが先にDOMに存在し、その後コンテンツが追加されることが必要です。現在の実装では `emptyStateDiv` に `h3` と `p` を追加してから `replaceChildren` でDOMへ挿入しているため、コンテナが「コンテンツ入り」の状態でDOMに挿入されます。NVDA+Firefox や JAWS+Chrome など主要なスクリーンリーダーの組み合わせは、既にコンテンツが入った状態でDOMに挿入されたライブリージョンの内容を読み上げないことが多いため、このPRの主目的である読み上げアナウンスが期待通りに動作しない可能性があります。`replaceChildren(chatContainer, [emptyStateDiv])` を `h3` / `p` の `appendChild` より**前**に移動することで対応できます。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 274-289

   Comment:
   **aria-live リージョンへのコンテンツ追加タイミング問題**

   `aria-live` の有効な動作には、コンテナが先にDOMに存在し、その後コンテンツが追加されることが必要です。現在の実装では `emptyStateDiv` に `h3` と `p` を追加してから `replaceChildren` でDOMへ挿入しているため、コンテナが「コンテンツ入り」の状態でDOMに挿入されます。NVDA+Firefox や JAWS+Chrome など主要なスクリーンリーダーの組み合わせは、既にコンテンツが入った状態でDOMに挿入されたライブリージョンの内容を読み上げないことが多いため、このPRの主目的である読み上げアナウンスが期待通りに動作しない可能性があります。`replaceChildren(chatContainer, [emptyStateDiv])` を `h3` / `p` の `appendChild` より**前**に移動することで対応できます。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/webview/chatAssets.ts:274-289
**aria-live リージョンへのコンテンツ追加タイミング問題**

`aria-live` の有効な動作には、コンテナが先にDOMに存在し、その後コンテンツが追加されることが必要です。現在の実装では `emptyStateDiv` に `h3` と `p` を追加してから `replaceChildren` でDOMへ挿入しているため、コンテナが「コンテンツ入り」の状態でDOMに挿入されます。NVDA+Firefox や JAWS+Chrome など主要なスクリーンリーダーの組み合わせは、既にコンテンツが入った状態でDOMに挿入されたライブリージョンの内容を読み上げないことが多いため、このPRの主目的である読み上げアナウンスが期待通りに動作しない可能性があります。`replaceChildren(chatContainer, [emptyStateDiv])` を `h3` / `p` の `appendChild` より**前**に移動することで対応できます。

### Issue 2 of 2
.Jules/palette.md:20
この学習エントリの日付が "2025-06-11" になっていますが、直前のエントリが "2026-06-06" であるため、時系列が逆転しています。おそらく "2026-06-11" の誤りです。

```suggestion
## 2026-06-11 - 空の状態（Empty State）へのARIAライブリージョンの追加
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: 空の状態（Empty State）にARIAライブリージ..."](https://github.com/hiroki-org/jules-extension/commit/8911b2cf7d17924c7a81c66d2729cbd153c059ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37638856)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->