### PR TITLE
🎨 Palette: 動的Empty Stateコンテナのアクセシビリティ（ARIA属性）改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,6 +18,5 @@
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
 
 ## 2026-06-16 - 動的コンテナのアクセシビリティ強化
-
 **Learning:** 空の状態（Empty State）など、動的にDOMへ挿入されるコンテナに `aria-live="polite"` と `aria-atomic="true"` を付与することで、スクリーンリーダーが状態変化を即座に感知し、ユーザーに適切に通知できるようになります。
 **Action:** 今後、非同期処理や状態遷移に伴って新しいメッセージコンテナを動的生成する際は、必ず `aria-live` と `aria-atomic` 属性を付与してアクセシビリティを担保すること。

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,5 +18,6 @@
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
 
 ## 2026-06-16 - 動的コンテナのアクセシビリティ強化
+
 **Learning:** 空の状態（Empty State）など、動的にDOMへ挿入されるコンテナに `aria-live="polite"` と `aria-atomic="true"` を付与することで、スクリーンリーダーが状態変化を即座に感知し、ユーザーに適切に通知できるようになります。
 **Action:** 今後、非同期処理や状態遷移に伴って新しいメッセージコンテナを動的生成する際は、必ず `aria-live` と `aria-atomic` 属性を付与してアクセシビリティを担保すること。

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-06-06 - Prefer Native Disabled for Form Controls
 **Learning:** Native form controls such as `<button>`, `<textarea>`, and `<input>` already expose their disabled state through the `disabled` property. Adding `aria-disabled` to the same disabled controls is redundant and can imply focus behavior that does not match native disabled elements.
 **Action:** Use `disabled` and `:disabled` for native form controls. Reserve `aria-disabled` for custom widgets that must remain focusable while unavailable.
+
+## 2026-06-16 - 動的コンテナのアクセシビリティ強化
+**Learning:** 空の状態（Empty State）など、動的にDOMへ挿入されるコンテナに `aria-live="polite"` と `aria-atomic="true"` を付与することで、スクリーンリーダーが状態変化を即座に感知し、ユーザーに適切に通知できるようになります。
+**Action:** 今後、非同期処理や状態遷移に伴って新しいメッセージコンテナを動的生成する際は、必ず `aria-live` と `aria-atomic` 属性を付与してアクセシビリティを担保すること。

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,29 +1,6 @@
 import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
-function createMockElement(tag: string) {
-  return {
-    tagName: tag,
-    className: "",
-    textContent: "",
-    childNodes: [] as any[],
-    setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
-    appendChild(node: any) {
-        this.childNodes.push(node);
-    },
-    get outerHTML() {
-        const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-        const text = this.textContent ? this.textContent : childrenHtml;
-        const cls = this.className ? ` class="${this.className}"` : "";
-        const role = (this as any).role ? ` role="${(this as any).role}"` : "";
-        const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-        const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
-        const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
-        return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
-    }
-  };
-}
-
 function createChatScriptHarness(
   domPurify?: { sanitize: (html: string, config: any) => any },
   computedStyle = { borderTopWidth: "1px", borderBottomWidth: "1px" },
@@ -78,7 +55,26 @@ function createChatScriptHarness(
   const messageListeners: Array<(event: { data: any }) => void> = [];
   const mockDocument = {
     getElementById: (id: string) => elements[id],
-    createElement: createMockElement,
+    createElement: (tag: string) => ({
+        tagName: tag,
+        className: "",
+        textContent: "",
+        childNodes: [] as any[],
+        setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
+        appendChild(node: any) {
+            this.childNodes.push(node);
+        },
+        get outerHTML() {
+            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+            const text = this.textContent ? this.textContent : childrenHtml;
+            const cls = this.className ? ` class="${this.className}"` : "";
+            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
+            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
+        }
+    }),
     createDocumentFragment: () => ({
         childNodes: [] as any[],
         appendChild(node: any) {
@@ -552,9 +548,6 @@ suite("chatAssets unit tests", () => {
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Welcome to Jules"));
     assert.ok(harness.elements.chat.innerHTML.includes("Select a session or create a new one"));
-    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
-    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
-
   });
 
   test("CHAT_JS should render ready empty state when a session has no messages", () => {
@@ -568,9 +561,6 @@ suite("chatAssets unit tests", () => {
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Ready to assist"));
     assert.ok(harness.elements.chat.innerHTML.includes("Type a message to start interacting"));
-    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
-    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
-
   });
 
   test("CHAT_JS should not reinsert the same empty state repeatedly", () => {
@@ -693,7 +683,26 @@ suite("chatAssets unit tests", () => {
 
     const mockDocument = {
       getElementById: (id: string) => elements[id],
-      createElement: createMockElement,
+      createElement: (tag: string) => ({
+        tagName: tag,
+        className: "",
+        textContent: "",
+        childNodes: [] as any[],
+        setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
+        appendChild(node: any) {
+            this.childNodes.push(node);
+        },
+        get outerHTML() {
+            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+            const text = this.textContent ? this.textContent : childrenHtml;
+            const cls = this.className ? ` class="${this.className}"` : "";
+            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
+            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
+        }
+      }),
       createDocumentFragment: () => ({
         childNodes: [] as any[],
         appendChild(node: any) {

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -1,6 +1,29 @@
 import * as assert from "assert";
 import { CHAT_CSS, CHAT_JS } from "../webview/chatAssets";
 
+function createMockElement(tag: string) {
+  return {
+    tagName: tag,
+    className: "",
+    textContent: "",
+    childNodes: [] as any[],
+    setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
+    appendChild(node: any) {
+        this.childNodes.push(node);
+    },
+    get outerHTML() {
+        const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
+        const text = this.textContent ? this.textContent : childrenHtml;
+        const cls = this.className ? ` class="${this.className}"` : "";
+        const role = (this as any).role ? ` role="${(this as any).role}"` : "";
+        const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
+        const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+        const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+        return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
+    }
+  };
+}
+
 function createChatScriptHarness(
   domPurify?: { sanitize: (html: string, config: any) => any },
   computedStyle = { borderTopWidth: "1px", borderBottomWidth: "1px" },
@@ -55,26 +78,7 @@ function createChatScriptHarness(
   const messageListeners: Array<(event: { data: any }) => void> = [];
   const mockDocument = {
     getElementById: (id: string) => elements[id],
-    createElement: (tag: string) => ({
-        tagName: tag,
-        className: "",
-        textContent: "",
-        childNodes: [] as any[],
-        setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
-        appendChild(node: any) {
-            this.childNodes.push(node);
-        },
-        get outerHTML() {
-            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-            const text = this.textContent ? this.textContent : childrenHtml;
-            const cls = this.className ? ` class="${this.className}"` : "";
-            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
-            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
-            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
-        }
-    }),
+    createElement: createMockElement,
     createDocumentFragment: () => ({
         childNodes: [] as any[],
         appendChild(node: any) {
@@ -548,6 +552,9 @@ suite("chatAssets unit tests", () => {
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Welcome to Jules"));
     assert.ok(harness.elements.chat.innerHTML.includes("Select a session or create a new one"));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
+
   });
 
   test("CHAT_JS should render ready empty state when a session has no messages", () => {
@@ -561,6 +568,9 @@ suite("chatAssets unit tests", () => {
     assert.ok(harness.elements.chat.innerHTML.includes('class="empty-state"'));
     assert.ok(harness.elements.chat.innerHTML.includes("Ready to assist"));
     assert.ok(harness.elements.chat.innerHTML.includes("Type a message to start interacting"));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-live="polite"'));
+    assert.ok(harness.elements.chat.innerHTML.includes('aria-atomic="true"'));
+
   });
 
   test("CHAT_JS should not reinsert the same empty state repeatedly", () => {
@@ -683,26 +693,7 @@ suite("chatAssets unit tests", () => {
 
     const mockDocument = {
       getElementById: (id: string) => elements[id],
-      createElement: (tag: string) => ({
-        tagName: tag,
-        className: "",
-        textContent: "",
-        childNodes: [] as any[],
-        setAttribute: function(k: string, v: string) { (this as any)[k] = v; },
-        appendChild(node: any) {
-            this.childNodes.push(node);
-        },
-        get outerHTML() {
-            const childrenHtml = this.childNodes.map((n: any) => n.outerHTML ?? n.textContent ?? "").join("");
-            const text = this.textContent ? this.textContent : childrenHtml;
-            const cls = this.className ? ` class="${this.className}"` : "";
-            const role = (this as any).role ? ` role="${(this as any).role}"` : "";
-            const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
-            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
-        }
-      }),
+      createElement: createMockElement,
       createDocumentFragment: () => ({
         childNodes: [] as any[],
         appendChild(node: any) {

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -70,7 +70,9 @@ function createChatScriptHarness(
             const cls = this.className ? ` class="${this.className}"` : "";
             const role = (this as any).role ? ` role="${(this as any).role}"` : "";
             const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}>${text}</${tag}>`;
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
     }),
     createDocumentFragment: () => ({
@@ -696,7 +698,9 @@ suite("chatAssets unit tests", () => {
             const cls = this.className ? ` class="${this.className}"` : "";
             const role = (this as any).role ? ` role="${(this as any).role}"` : "";
             const ariaLabel = (this as any)["aria-label"] ? ` aria-label="${(this as any)["aria-label"]}"` : "";
-            return `<${tag}${cls}${role}${ariaLabel}>${text}</${tag}>`;
+            const ariaLive = (this as any)["aria-live"] ? ` aria-live="${(this as any)["aria-live"]}"` : "";
+            const ariaAtomic = (this as any)["aria-atomic"] ? ` aria-atomic="${(this as any)["aria-atomic"]}"` : "";
+            return `<${tag}${cls}${role}${ariaLabel}${ariaLive}${ariaAtomic}>${text}</${tag}>`;
         }
       }),
       createDocumentFragment: () => ({

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -273,6 +273,8 @@ export const CHAT_JS = `(function() {
       if (!chatContainer.querySelector('.empty-state')) {
         const emptyStateDiv = document.createElement("div");
         emptyStateDiv.className = "empty-state";
+        emptyStateDiv.setAttribute("aria-live", "polite");
+        emptyStateDiv.setAttribute("aria-atomic", "true");
 
         const h3 = document.createElement("h3");
         h3.textContent = state.sessionId ? "Ready to assist" : "Welcome to Jules";


### PR DESCRIPTION
💡 What: 動的に生成される「Empty State（空の状態）」コンテナ（ウェルカムメッセージ等）に対して、`aria-live="polite"` と `aria-atomic="true"` の属性を付与しました。さらに、テスト環境でのDOMモック（`outerHTML`）もこれらをシリアライズできるように修正しました。

🎯 Why: 空の状態はチャットセッション等がない初期段階に動的に挿入されますが、これまではスクリーンリーダーにその状態変化が即座に伝わりませんでした。この修正により、ユーザーがインターフェースの状態をより正確に把握できるようになります。

📸 Before/After: （視覚的な変更はありません）

♿ Accessibility: `aria-live="polite"` により、進行中の読み上げを妨げずに新しいテキストの出現をスクリーンリーダーが感知し、`aria-atomic="true"` により、追加されたテキスト全体がひとつの意味の塊として適切にアナウンスされるようになります。

---
*PR created automatically by Jules for task [4694465445280336061](https://jules.google.com/task/4694465445280336061) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

動的に挿入される Empty State コンテナ（ウェルカムメッセージ）に `aria-live=\"polite\"` と `aria-atomic=\"true\"` を付与し、スクリーンリーダーへの状態変化通知を改善する変更です。テスト用 DOM モックも新属性をシリアライズできるよう更新されています。

- **`src/webview/chatAssets.ts`**: `renderMessages()` 内の Empty State 生成時に `setAttribute` で2つの ARIA 属性を追加。
- **`src/test/chatAssets.unit.test.ts`**: 重複している2つの `outerHTML` モックゲッターへ `aria-live` / `aria-atomic` のシリアライズを追加。ただし既存の空ステートテストに新属性の存在を検証するアサーションは追加されていない。
- **`.Jules/palette.md`**: 今回の変更内容を動的コンテナの ARIA 実装ベストプラクティスとして記録。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

テスト側の更新が不完全で、新 ARIA 属性の付与を確認するアサーションが欠落しているためマージ前に補完が必要。

実装コード自体は小さく明快ですが、テスト側の更新が不完全で `aria-live` / `aria-atomic` の付与を確認するアサーションが欠落しています。将来の誤削除や属性名ミスを自動検知できない状態です。また、コンテンツを追加済みの要素をまとめて DOM へ挿入するパターンは一部スクリーンリーダーで初期テキストがアナウンスされないという既知の動作差異があります。

src/test/chatAssets.unit.test.ts — 既存の空ステートテストに ARIA 属性のアサーションを追加する必要があります。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | `renderMessages()` の空ステート生成に `aria-live="polite"` と `aria-atomic="true"` を追加。実装自体は正しいが、挿入タイミングの問題で一部スクリーンリーダーが初期コンテンツをアナウンスしない可能性あり。 |
| src/test/chatAssets.unit.test.ts | モックの `outerHTML` に `aria-live` / `aria-atomic` のシリアライズを追加したが、空ステートの既存テストに新 ARIA 属性の検証アサーションが追加されていないため、実装が壊れてもテストは通過し続ける。 |
| .Jules/palette.md | 今回の変更内容をドキュメント化した学習ノートの追記。問題なし。 |

</details>


</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["renderMessages() 呼び出し"] --> B{messages.length === 0 かつ !isTyping?}
    B -- No --> C["メッセージノードを生成してchatContainerへ挿入"]
    B -- Yes --> D{chatContainerに.empty-stateが存在?}
    D -- Yes --> E["何もしない（重複挿入防止）"]
    D -- No --> F["div.empty-stateを生成"]
    F --> G["aria-live=politeを設定 / aria-atomic=trueを設定"]
    G --> H["h3/pを生成してテキストをセット"]
    H --> I["子要素をemptyStateDivに追加"]
    I --> J["replaceChildrenでchatContainerへ挿入"]
    J --> K["スクリーンリーダーがaria-liveを検知（初期コンテンツのアナウンスは保証されない場合あり）"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["renderMessages() 呼び出し"] --> B{messages.length === 0 かつ !isTyping?}
    B -- No --> C["メッセージノードを生成してchatContainerへ挿入"]
    B -- Yes --> D{chatContainerに.empty-stateが存在?}
    D -- Yes --> E["何もしない（重複挿入防止）"]
    D -- No --> F["div.empty-stateを生成"]
    F --> G["aria-live=politeを設定 / aria-atomic=trueを設定"]
    G --> H["h3/pを生成してテキストをセット"]
    H --> I["子要素をemptyStateDivに追加"]
    I --> J["replaceChildrenでchatContainerへ挿入"]
    J --> K["スクリーンリーダーがaria-liveを検知（初期コンテンツのアナウンスは保証されない場合あり）"]
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/test/chatAssets.unit.test.ts`, line 548-551 ([link](https://github.com/hiroki-org/jules-extension/blob/bf7c0f7cb615d7176c77aea6d25fbf13abbbd5ad/src/test/chatAssets.unit.test.ts#L548-L551)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **ARIA属性の検証アサーションが不足**

   モックの `outerHTML` ゲッターが `aria-live` と `aria-atomic` をシリアライズできるよう更新されましたが、空のステートに関する既存テスト（2件）に新属性の存在を確認するアサーションが追加されていません。`AGENTS.md` には「新しい機能を追加した場合は、対応するテストも追加してください」と定められており、この修正では実装が将来削除または変更されてもテストが通過し続けます。`aria-live="polite"` と `aria-atomic="true"` が実際にレンダリングされた `innerHTML` に含まれることを明示的に検証するアサーションをこれらのテストケース、および `session-1` を使ったテスト（553–564行）に追加してください。

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 548-551
   
   Comment:
   **ARIA属性の検証アサーションが不足**
   
   モックの `outerHTML` ゲッターが `aria-live` と `aria-atomic` をシリアライズできるよう更新されましたが、空のステートに関する既存テスト（2件）に新属性の存在を確認するアサーションが追加されていません。`AGENTS.md` には「新しい機能を追加した場合は、対応するテストも追加してください」と定められており、この修正では実装が将来削除または変更されてもテストが通過し続けます。`aria-live="polite"` と `aria-atomic="true"` が実際にレンダリングされた `innerHTML` に含まれることを明示的に検証するアサーションをこれらのテストケース、および `session-1` を使ったテスト（553–564行）に追加してください。
   
   **Context Used:** AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/webview/chatAssets.ts`, line 273-289 ([link](https://github.com/hiroki-org/jules-extension/blob/bf7c0f7cb615d7176c77aea6d25fbf13abbbd5ad/src/webview/chatAssets.ts#L273-L289)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`aria-live` リージョンの挿入タイミング**

   現在の実装では、子要素（`h3`・`p`）を追加した後に `emptyStateDiv` を DOM へ挿入しています。ARIA のベストプラクティスでは、ライブリージョンはコンテンツ変更より先に DOM 上に存在していることが推奨されており、挿入時点でコンテンツが既にそろっている場合、一部のスクリーンリーダー（特に古い JAWS や NVDA+Chrome 組み合わせ）は初期テキストをアナウンスしません。ウェルカムメッセージの確実な読み上げを保証するには、空のライブリージョンを先に挿入してから `h3`・`p` を追加する手順、またはコンテナを静的な初期 HTML に含めてコンテンツのみ動的に更新する方法の採用を検討してください。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 273-289

   Comment:
   **`aria-live` リージョンの挿入タイミング**

   現在の実装では、子要素（`h3`・`p`）を追加した後に `emptyStateDiv` を DOM へ挿入しています。ARIA のベストプラクティスでは、ライブリージョンはコンテンツ変更より先に DOM 上に存在していることが推奨されており、挿入時点でコンテンツが既にそろっている場合、一部のスクリーンリーダー（特に古い JAWS や NVDA+Chrome 組み合わせ）は初期テキストをアナウンスしません。ウェルカムメッセージの確実な読み上げを保証するには、空のライブリージョンを先に挿入してから `h3`・`p` を追加する手順、またはコンテナを静的な初期 HTML に含めてコンテンツのみ動的に更新する方法の採用を検討してください。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/test/chatAssets.unit.test.ts:548-551
**ARIA属性の検証アサーションが不足**

モックの `outerHTML` ゲッターが `aria-live` と `aria-atomic` をシリアライズできるよう更新されましたが、空のステートに関する既存テスト（2件）に新属性の存在を確認するアサーションが追加されていません。`AGENTS.md` には「新しい機能を追加した場合は、対応するテストも追加してください」と定められており、この修正では実装が将来削除または変更されてもテストが通過し続けます。`aria-live="polite"` と `aria-atomic="true"` が実際にレンダリングされた `innerHTML` に含まれることを明示的に検証するアサーションをこれらのテストケース、および `session-1` を使ったテスト（553–564行）に追加してください。

### Issue 2 of 3
src/webview/chatAssets.ts:273-289
**`aria-live` リージョンの挿入タイミング**

現在の実装では、子要素（`h3`・`p`）を追加した後に `emptyStateDiv` を DOM へ挿入しています。ARIA のベストプラクティスでは、ライブリージョンはコンテンツ変更より先に DOM 上に存在していることが推奨されており、挿入時点でコンテンツが既にそろっている場合、一部のスクリーンリーダー（特に古い JAWS や NVDA+Chrome 組み合わせ）は初期テキストをアナウンスしません。ウェルカムメッセージの確実な読み上げを保証するには、空のライブリージョンを先に挿入してから `h3`・`p` を追加する手順、またはコンテナを静的な初期 HTML に含めてコンテンツのみ動的に更新する方法の採用を検討してください。

### Issue 3 of 3
src/test/chatAssets.unit.test.ts:70-75
**`outerHTML` モックが2箇所で重複定義**

この `outerHTML` ゲッターのロジックはファイル内の 70 行目付近と 695 行目付近の2箇所に同一コードとして存在しており、今回もその両方に同じ変更を加えています。片方の更新を忘れるリスクがあります（既存の技術的負債ですが、今回変更の機会に共通ヘルパー関数への抽出を検討してください）。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(a11y): add aria-live and aria-atomi..."](https://github.com/hiroki-org/jules-extension/commit/bf7c0f7cb615d7176c77aea6d25fbf13abbbd5ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37911010)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->