### PR TITLE
🎨 Palette: コピーボタンクリック時のスクリーンリーダー読み上げ改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-06-11 - Dynamic Empty State Announcers
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.
+
+## 2026-06-17 - コピーボタンのアクセシビリティ強化
+**Learning:** コピーボタンのように、クリック時に自身のテキストが動的かつ一時的に変更される要素に対しては、`aria-live="polite"`と`aria-atomic="true"`を追加することで、スクリーンリーダーが変更後のテキスト（「Copied」等）を即座に読み上げ、ユーザーが操作の成功を確認しやすくなります。
+**Action:** 今後、テキストが動的に変化するインタラクティブな要素を実装・修正する際は、`aria-live="polite"`と`aria-atomic="true"`を付与して状態変化が正しく伝わるようにすること。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,6 +63,8 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('aria-live="polite"'));
+    assert.ok(rendered.includes('aria-atomic="true"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {


### PR DESCRIPTION
💡 What: `chatView.ts`のマークダウンレンダラーによって生成されるコードブロックのコピーボタン(`.copy-code-button`)に、`aria-live="polite"` と `aria-atomic="true"` の属性を追加しました。さらに、対応するユニットテストにこれらの属性が存在することをアサートするチェックを追加しました。
🎯 Why: コピーボタンをクリックした際、ボタンのテキストが「Copy」から「Copied」へ一時的に変更されますが、既存の実装ではスクリーンリーダーがこの動的な変化を即座に読み上げませんでした。これら2つの属性を付与することで、アシスティブテクノロジーを使用しているユーザーでも、テキストの変更を通じて操作の成功（「Copied」状態になったこと）をフィードバックとして確実に受け取れるようになり、アクセシビリティとUXが大きく向上します。
📸 Before/After: （視覚的な変更はありませんが、スクリーンリーダーでの読み上げ動作が改善されています。確認用のPlaywrightスクリプトのスクリーンショットも取得済みです。）
♿ Accessibility: インタラクティブなボタンのテキストが動的に変わる際、そのステータス変更をユーザーへ確実に伝えるための堅牢な対応を追加しました。スクリーンリーダーユーザーに対する情報提供の非対称性を解消します。

---
*PR created automatically by Jules for task [8974190169048337218](https://jules.google.com/task/8974190169048337218) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コードブロックのコピーボタン（`.copy-code-button`）に `aria-live="polite"` と `aria-atomic="true"` を追加し、クリック時のテキスト変化（"Copy" → "Copied"）をスクリーンリーダーが読み上げられるようにしたアクセシビリティ改善 PR です。

- `src/chatView.ts`: マークダウンレンダラーが生成するボタンの HTML テンプレートに2つの ARIA 属性を追加。`sanitize-html` の `\"*\": [\"aria-*\"]` ルールにより、サニタイザーを通過した後も属性は保持される。
- `src/test/chatView.unit.test.ts`: 新属性の存在を確認するアサーションを2行追加。テスト構造は既存パターンと整合している。
- `.Jules/palette.md`: 動的テキスト変化要素への `aria-live` 付与に関する学習メモを追記。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージして問題ないが、リストア時に "Copy" が余分に読み上げられる点を今後改善できる。

変更は小規模で既存動作を壊すものではなく、サニタイザーも属性を正しく通過させる。ただし `restoreButtonState()` 実行時にも `aria-live` が反応し、1200ms 後に "Copy" と読み上げられるため、スクリーンリーダー体験として若干不自然な点が残る。

`src/webview/chatAssets.ts` の `restoreButtonState` 関数 ― ボタン自身に `aria-live` がついた状態でテキストを元に戻すと、意図しない読み上げが発生する。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | コピーボタンの HTML テンプレートに `aria-live="polite"` と `aria-atomic="true"` を追加。`sanitize-html` の `"*": ["aria-*"]` ルールにより属性はサニタイザーを通過する。 |
| src/test/chatView.unit.test.ts | 新たに追加した2属性（`aria-live="polite"`, `aria-atomic="true"`）の存在をアサートするテストを追加。既存のテスト構造と整合している。 |
| .Jules/palette.md | コピーボタンのアクセシビリティ対応に関する学習メモを追記。コードへの影響なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as ユーザー（スクリーンリーダー使用）
    participant Button as コピーボタン(aria-live="polite")
    participant Clipboard as クリップボード
    participant SR as スクリーンリーダー

    User->>Button: クリック
    Button->>Clipboard: writeText(code)
    Clipboard-->>Button: 成功
    Button->>Button: "textContent = "Copied", aria-label = "Copied""
    Button-->>SR: aria-live 変化を検知 → "Copied" を読み上げ
    Note over Button: 1200ms 後
    Button->>Button: "textContent = "Copy"（元に戻す）, aria-label = "Copy code""
    Button-->>SR: aria-live 変化を検知 → "Copy" を読み上げ（意図せぬ読み上げ）
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as ユーザー（スクリーンリーダー使用）
    participant Button as コピーボタン(aria-live="polite")
    participant Clipboard as クリップボード
    participant SR as スクリーンリーダー

    User->>Button: クリック
    Button->>Clipboard: writeText(code)
    Clipboard-->>Button: 成功
    Button->>Button: "textContent = "Copied", aria-label = "Copied""
    Button-->>SR: aria-live 変化を検知 → "Copied" を読み上げ
    Note over Button: 1200ms 後
    Button->>Button: "textContent = "Copy"（元に戻す）, aria-label = "Copy code""
    Button-->>SR: aria-live 変化を検知 → "Copy" を読み上げ（意図せぬ読み上げ）
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): add aria-live and aria-atomic ..."](https://github.com/hiroki-org/jules-extension/commit/f2aeedc7e9a129a01f6dff50f643612d4c1dddb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38156542)</sub>

<!-- /greptile_comment -->