### PR TITLE
🎨 Palette: コピーボタンの状態変化のアクセシビリティ改善

### DIFF
--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,6 +63,8 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('aria-live="polite"'));
+    assert.ok(rendered.includes('aria-atomic="true"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {


### PR DESCRIPTION
💡 What: コードブロックのコピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加し、ボタンクリック時の状態変化（「Copy」→「Copied」）がスクリーンリーダーで自動的に読み上げられるようにしました。
🎯 Why: コピーボタンはクリックすると一時的にテキストが「Copied」や「Failed」に変化しますが、視覚的にはフィードバックがあってもスクリーンリーダーのユーザーには変化が伝わりませんでした。`aria-live`領域を設定することで、スクリーンリーダーユーザーにも操作結果が確実に伝わるようになり、アクセシビリティが向上します。
📸 Before/After: 視覚的な変更はありません。（HTML属性の追加のみ）
♿ Accessibility: 動的なテキスト変化を持つインタラクティブ要素に対するアクセシビリティ（スクリーンリーダー対応）の向上。

---
*PR created automatically by Jules for task [14967971906556247187](https://jules.google.com/task/14967971906556247187) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コードブロックのコピーボタンに `aria-live=\"polite\"` と `aria-atomic=\"true\"` を追加し、クリック時の状態変化をスクリーンリーダーで読み上げられるようにするアクセシビリティ改善 PR です。対応するユニットテストのアサーションも追加されています。

- `src/chatView.ts`: markdown-it のフェンスレンダラーでボタン HTML に2つの ARIA 属性を追加。既存の `sanitize-html` の `aria-*` ワイルドカード許可により属性はサニタイズ後も保持されます。
- `src/test/chatView.unit.test.ts`: `renderChatMarkdown` の出力に新属性が含まれることを検証するアサーションを2行追加。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

既存機能を壊す変更はなく、視覚的な差分もないためマージは安全です。ただし、ボタン要素への `aria-live` 直接付与は意図した効果が得られない可能性があります。

コピーボタンへの `aria-live` 付与はアクセシビリティを改善しようとする変更ですが、テキストが「Copied」から「Copy」へ戻る際にも不要な読み上げが発生します。また、インタラクティブ要素への `aria-live` 適用はスクリーンリーダーによってサポートが一貫しておらず、実際に期待通り動作しないケースがあります。変更は既存動作を破壊せず、テストも追加されていますが、アクセシビリティ改善の実効性に疑問が残ります。

コピーボタンの状態変化をスクリーンリーダーへ通知する実装方針（`src/chatView.ts` の60行目付近）を再検討することを推奨します。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | `aria-live="polite"` と `aria-atomic="true"` をコピーボタンに追加。技術的には機能するが、テキストが元に戻る際にも読み上げが発生するため、インタラクティブ要素への直接付与より専用ライブリージョンの使用が望ましい。 |
| src/test/chatView.unit.test.ts | 新しい `aria-live` / `aria-atomic` 属性がサニタイズ後のレンダリング出力に含まれることを確認するアサーションを追加。 |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as ユーザー
    participant B as コピーボタン(aria-live)
    participant SR as スクリーンリーダー
    participant JS as CHAT_JS

    U->>B: クリック
    B->>JS: click イベント
    JS->>B: "textContent = "Copied""
    B-->>SR: ライブリージョン変化を検知
    SR-->>U: "Copied" を読み上げ ✅

    Note over JS: 2秒後にリセット
    JS->>B: "textContent = "Copy""
    B-->>SR: ライブリージョン変化を検知
    SR-->>U: "Copy" を読み上げ ⚠️ (意図しない読み上げ)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as ユーザー
    participant B as コピーボタン(aria-live)
    participant SR as スクリーンリーダー
    participant JS as CHAT_JS

    U->>B: クリック
    B->>JS: click イベント
    JS->>B: "textContent = "Copied""
    B-->>SR: ライブリージョン変化を検知
    SR-->>U: "Copied" を読み上げ ✅

    Note over JS: 2秒後にリセット
    JS->>B: "textContent = "Copy""
    B-->>SR: ライブリージョン変化を検知
    SR-->>U: "Copy" を読み上げ ⚠️ (意図しない読み上げ)
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/chatView.ts:60
**`<button>` への `aria-live` 付与による意図しない二重アナウンス**

`aria-live="polite"` を `<button>` 要素に直接付与すると、テキストが変化するたびにスクリーンリーダーがアナウンスします。「Copy」→「Copied」の変化だけでなく、タイムアウト後に「Copied」→「Copy」へ戻る際にも「Copy」と読み上げられてしまい、不要なノイズになります。

また、インタラクティブ要素への `aria-live` 適用はスクリーンリーダーによってサポートが一貫していません。より信頼性の高い実装として、ページ初期化時から DOM に存在する静的な専用ライブリージョン（`getChatWebviewHtml` 内に `<div role="status" aria-live="polite" aria-atomic="true"></div>` を追加するなど）を設け、コピー成功時のみその中身を JS で更新する方法が推奨されます。あるいは、ボタンの `aria-label` を JS でコピー時に `"Copied!"` へ動的変更する方法も一般的かつ確実です。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: \[UX improvement\] コピーボタンの状態変化..."](https://github.com/hiroki-org/jules-extension/commit/9521bb66b05d1baab221d527abb20c1e2ab66dc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38426518)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->