### PR TITLE
🎨 Palette: コピーボタンのアクセシビリティ改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-06-11 - Dynamic Empty State Announcers
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.
+
+## 2026-06-19 - Dynamic Buttons and aria-live
+**Learning:** コピーボタンのようにクリック後に自身のテキストが「Copied」などに動的に変わるインタラクティブ要素には、ボタン自体に `aria-live="polite"` と `aria-atomic="true"` を設定することで、スクリーンリーダーが状態の変更を即座にユーザーへ通知できるようになります。
+**Action:** 次回、動的にテキストが変化するボタンを実装する際は、テキストとARIA属性の同期に加えて、要素自体に `aria-live="polite"` と `aria-atomic="true"` を含めること。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );


### PR DESCRIPTION
💡 What:
チャットビュー内のコードブロックの「Copy」ボタンに `aria-live="polite"` と `aria-atomic="true"` 属性を追加しました。

🎯 Why:
コピーボタンをクリックした際、テキストが「Copy」から「Copied」に動的に変更されますが、これまではスクリーンリーダーにその変更が通知されませんでした。この改善により、視覚障害のあるユーザーもコピーが成功したことを音声で確認できるようになります。

📸 Before/After:
Before: `<button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>`
After: `<button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>`

♿ Accessibility:
動的にテキストが変化するインタラクティブなボタンに `aria-live="polite"` と `aria-atomic="true"` を追加し、状態変更の読み上げをサポートしました。

---
*PR created automatically by Jules for task [7841765685421272681](https://jules.google.com/task/7841765685421272681) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コードブロックのコピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加し、テキストが「Copy」→「Copied」に変化した際にスクリーンリーダーへ通知するアクセシビリティ改善 PR です。

- `src/chatView.ts`: ボタンの HTML テンプレートに `aria-live="polite" aria-atomic="true"` を追加。ただし、ボタン本体に `aria-live` を置く実装では、コピー完了通知（「Copied」）だけでなく 1.2 秒後の元の状態への復元（「Copy」）も live region として発火するため、意図しないアナウンスが発生します。
- `.Jules/palette.md`: 今回の実装から得たラーニングを追記。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

アクセシビリティ向上を目的とした変更だが、既存の「元に戻す」ロジックとの組み合わせでスクリーンリーダーユーザーに意図しない読み上げを発生させる。

コピーボタン本体に `aria-live` を設定したことで、`restoreButtonState` がボタンテキストを「Copy」に戻すたびに live region が発火する。スクリーンリーダーユーザーはコピー後 1.2 秒で予期しない「Copy」の読み上げを聞くことになり、この変更が逆にアクセシビリティを損なうリスクがある。

src/chatView.ts — `aria-live` の配置方針を再検討する必要がある。`chatAssets.ts` の `restoreButtonState` との相互作用も確認してほしい。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | コピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加。意図は正しいが、既存の `restoreButtonState` が 1.2 秒後にボタンテキストを「Copy」に戻す際にも live region が発火し、意図しないアナウンスが発生する問題がある。 |
| .Jules/palette.md | 動的ボタンと `aria-live` に関するラーニングノートを追加。内容は変更されたコードと整合しており、問題なし。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/chatView.ts:60
**1.2秒後の元に戻す処理でもアナウンスが発生する**

`aria-live="polite"` をボタン自体に設定したことで、`chatAssets.ts` の `restoreButtonState` 関数（line 401）が `copyButton.textContent = originalText` で「Copy」に戻す際にも live region が発火します。スクリーンリーダーユーザーがコピーボタンをクリックすると、「Copied」が読み上げられた直後に、1.2秒後に予期せず「Copy」が再度アナウンスされ、混乱を招きます。

アナウンスをコピー完了通知のみに絞るには、ボタン本体に `aria-live` を置くのではなく、DOM 内に専用の非表示 live region（例: `<span class="sr-only" aria-live="polite" aria-atomic="true"></span>`）を用意し、コピー成功時のみそこを更新するパターンが推奨されます。あるいは、`restoreButtonState` 実行前に `aria-live` 属性を一時的に除去し、復元後に再付与する方法でも回避できます。

### Issue 2 of 2
src/chatView.ts:60
**インタラクティブ要素への `aria-live` 設定は二重読み上げを引き起こす可能性がある**

`<button>` 要素に `aria-live` を配置すると、スクリーンリーダーによっては「ボタンをアクティブにしたとき」と「live region の更新があったとき」の両タイミングでコンテンツを読み上げ、二重アナウンスが発生する場合があります（NVDA・JAWS・VoiceOver で挙動が異なります）。WAI-ARIA のベストプラクティスでは、`aria-live` はインタラクティブなロールを持つ要素ではなく、コンテナ要素に設定することを推奨しています。

`aria-label` の更新（`chatAssets.ts` 内の `setButtonState` で既に実施済み）を活用し、別途 visually-hidden な live region を使うパターンの方がより堅牢です。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: コピーボタンのアクセシビリティ改善"](https://github.com/hiroki-org/jules-extension/commit/4810082a3b07d4e9d3ed04904746cb09ec7575da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38671439)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->