### PR TITLE
🎨 Palette: コピーボタンのアクセシビリティ向上

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+## 2024-05-14 - Empty state
+**Learning:** Adding empty states helps users.
+**Action:** Always add them.
+## 2026-06-20 - 動的ボタンテキストのアクセシビリティ
+**Learning:** コピーボタンのようにテキストが動的に変更される要素は、明示的な属性がないとスクリーンリーダーで状態変化が読み上げられない。
+**Action:** テキストが動的に変更されるインタラクティブな要素には、常に `aria-live="polite"` と `aria-atomic="true"` を追加する。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,6 +63,8 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('aria-live="polite"'));
+    assert.ok(rendered.includes('aria-atomic="true"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {


### PR DESCRIPTION
💡 What: コードブロックのコピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加しました。
🎯 Why: コピー完了時にボタンのテキストが「Copied」に変更される際、スクリーンリーダーがその状態変更を適切に読み上げるようにするためです。
📸 Before/After: （視覚的な変更はありません）
♿ Accessibility: 動的にテキストが変更されるボタンにaria-live属性を付与することで、視覚障害を持つユーザーに対するフィードバックを改善しました。

---
*PR created automatically by Jules for task [14314094367238684580](https://jules.google.com/task/14314094367238684580) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コードブロックのコピーボタンに `aria-live=\"polite\"` と `aria-atomic=\"true\"` を追加し、コピー完了時のテキスト変化をスクリーンリーダーが読み上げられるようにしたアクセシビリティ改善PRです。対応するユニットテストも更新されています。

- `src/chatView.ts`: ボタンの HTML テンプレートに `aria-live=\"polite\" aria-atomic=\"true\"` を追加。
- `src/test/chatView.unit.test.ts`: 両属性の存在を検証するアサーションを2件追加。
- `.jules/palette.md`: 今回の変更に関する学習ログを追記。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージしても視覚的・機能的な破壊はなく安全です。

変更はHTMLテンプレートへの属性追加のみで、既存の動作を壊すリスクはありません。ただし、`aria-live` をインタラクティブな `<button>` に直接付与するパターンはスクリーンリーダーによってサポートが異なり、`setButtonState` での `aria-label` 更新と組み合わさることで一部のATで二重読み上げが発生しうるため、アクセシビリティ改善としての効果が想定通りにならない場合があります。

コピーボタンのARIA実装を行っている `src/chatView.ts` と、`setButtonState` のロジックを持つ `src/webview/chatAssets.ts` の連携を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | コピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加。WAI-ARIAとしてはボタン要素への直接付与より別途ライブリージョンを使う方が推奨されるが、機能的な破壊はない。 |
| src/test/chatView.unit.test.ts | 追加された `aria-live` と `aria-atomic` 属性の存在を確認するアサーションが適切に追加されている。 |
| .jules/palette.md | Julesエージェント向けの学習ログ。今回のアクセシビリティ対応の知見が追記されている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as ユーザー（マウス/キーボード）
    participant Button as コピーボタン(aria-live="polite")
    participant Clipboard as クリップボード
    participant AT as スクリーンリーダー

    User->>Button: クリック
    Button->>Clipboard: navigator.clipboard.writeText(code)
    Clipboard-->>Button: 成功
    Button->>Button: "textContent = "Copied""
    Button->>Button: "aria-label = "Copied""
    Button-->>AT: aria-live により "Copied" を通知（polite）
    Note over AT: フォーカスが離れていても読み上げ
    Note over Button: 1200ms後 → "Copy" に戻す
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as ユーザー（マウス/キーボード）
    participant Button as コピーボタン(aria-live="polite")
    participant Clipboard as クリップボード
    participant AT as スクリーンリーダー

    User->>Button: クリック
    Button->>Clipboard: navigator.clipboard.writeText(code)
    Clipboard-->>Button: 成功
    Button->>Button: "textContent = "Copied""
    Button->>Button: "aria-label = "Copied""
    Button-->>AT: aria-live により "Copied" を通知（polite）
    Note over AT: フォーカスが離れていても読み上げ
    Note over Button: 1200ms後 → "Copy" に戻す
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/chatView.ts:60
**ボタン要素への `aria-live` 付与は AT サポートが不安定**

`aria-live` をインタラクティブな `<button>` 要素に直接付与するパターンは WAI-ARIA の推奨ではなく、スクリーンリーダー（特に NVDA+Firefox、JAWS）でのサポートが不安定です。加えて、`setButtonState` 内で `aria-label` も同時に更新されているため、キーボード操作でボタンにフォーカスが残っているユーザーには「Copied」が二重に読み上げられる可能性があります。

より確実なアクセシビリティパターンとしては、ボタンの隣にvisually-hiddenの `<span role="status" aria-live="polite" aria-atomic="true">` を別途配置し、`setButtonState` 呼び出し時にそのspan内のテキストを更新するアプローチが推奨されます。この場合、ボタン自体の `aria-live`/`aria-atomic` 属性は不要になります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add aria-live and aria-atomic to c..."](https://github.com/hiroki-org/jules-extension/commit/9cec12a23887f2f843728a506e367fce283c584d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38814950)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->