### PR TITLE
🎨 Palette: コピーボタンのアクセシビリティ向上

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,6 @@
 ## 2026-06-11 - Dynamic Empty State Announcers
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.
+## 2026-06-21 - 🎨 Palette: コピーボタンのアクセシビリティ向上
+**Learning:** 動的にテキストが変わるインタラクティブなボタン（例：「Copy」から「Copied」へ変更）には、スクリーンリーダーが状態の変更を読み上げるように `aria-live="polite"` と `aria-atomic="true"` 属性を追加する必要がある。
+**Action:** 今後、テキストが動的に変化するボタンを実装する際は、必ず `aria-live` と `aria-atomic` 属性を含める。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,6 +63,8 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('aria-live="polite"'));
+    assert.ok(rendered.includes('aria-atomic="true"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {


### PR DESCRIPTION
💡 What: コードブロックの「Copy」ボタンに `aria-live="polite"` と `aria-atomic="true"` 属性を追加しました。
🎯 Why: コピーボタンをクリックした際、テキストが「Copied」に動的に変更されますが、これまではスクリーンリーダーにその変更が通知されていませんでした。これらの属性を追加することで、視覚に障害のあるユーザーもコピーが成功したことを音声で確認できるようになります。
📸 Before/After: （視覚的な変更はありません）
♿ Accessibility: 動的に内容が変更されるボタンにARAIライブリージョンを追加し、スクリーンリーダー対応を強化しました。

---
*PR created automatically by Jules for task [8297306603030952456](https://jules.google.com/task/8297306603030952456) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コードブロックの「Copy」ボタンに `aria-live="polite"` と `aria-atomic="true"` を追加し、クリック時に「Copied」へ変わるテキスト変更をスクリーンリーダーへ通知するアクセシビリティ改善です。

- **`src/chatView.ts`**: Markdown のコードブロックレンダリング時に生成されるコピーボタンの HTML 属性に `aria-live` と `aria-atomic` を追加。
- **`src/test/chatView.unit.test.ts`**: 上記属性が出力 HTML に含まれることを検証するアサーションを追加。
- **`.Jules/palette.md`**: 動的テキスト変更ボタンへのライブリージョン適用パターンをエージェント向けナレッジとして記録。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

アクセシビリティの改善意図は明確で、機能的な破壊的変更はありません。ただし `<button>` へ `aria-live` を直接付与する実装パターンについて、AT間の互換性を確認してからマージするとより安心です。

変更はHTML属性の追加のみで既存機能に影響しません。懸念点は `<button>` 要素へのライブリージョン付与が一部のスクリーンリーダー（JAWS、VoiceOver）で確実に動作しない可能性があること。実害が出るとすれば「改善効果が得られないままになる」ケースで、既存の動作を壊すものではありません。

`src/chatView.ts` のボタン実装パターンを確認してください。`src/webview/chatAssets.ts` の `setButtonState` 関数と合わせて、ライブリージョンの配置を再検討する余地があります。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | `<button>` 要素に `aria-live="polite"` と `aria-atomic="true"` を追加。意図は正しいがインタラクティブ要素へのライブリージョン付与はAT間で対応が不安定。 |
| src/test/chatView.unit.test.ts | `aria-live="polite"` と `aria-atomic="true"` の属性が出力HTMLに含まれることを検証するアサーションを2行追加。ロジックに問題なし。 |
| .Jules/palette.md | 今回の変更から得た学習内容をエージェント向けのナレッジとして追記。ドキュメントのみの変更で問題なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as ユーザー
    participant Button as Copy ボタン(aria-live="polite")
    participant JS as chatAssets.ts setButtonState()
    participant AT as スクリーンリーダー

    User->>Button: クリック
    Button->>JS: click イベント
    JS->>Button: "textContent = "Copied", aria-label = "Copied""
    Note over Button,AT: aria-live="polite" によりDOM変更を検知（AT依存）
    AT-->>User: "Copied" を読み上げ（期待動作）
    Note over AT: ⚠️ button要素上の aria-live はAT・ブラウザの組み合わせ次第で発火しない場合あり
    JS->>Button: "setTimeout後: textContent = "Copy", aria-label = "Copy code" に復元"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as ユーザー
    participant Button as Copy ボタン(aria-live="polite")
    participant JS as chatAssets.ts setButtonState()
    participant AT as スクリーンリーダー

    User->>Button: クリック
    Button->>JS: click イベント
    JS->>Button: "textContent = "Copied", aria-label = "Copied""
    Note over Button,AT: aria-live="polite" によりDOM変更を検知（AT依存）
    AT-->>User: "Copied" を読み上げ（期待動作）
    Note over AT: ⚠️ button要素上の aria-live はAT・ブラウザの組み合わせ次第で発火しない場合あり
    JS->>Button: "setTimeout後: textContent = "Copy", aria-label = "Copy code" に復元"
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/chatView.ts:60
**`<button>` へ `aria-live` を直接付与するとスクリーンリーダーの対応が不安定**

`aria-live` はコンテナ要素（`<div>`, `<span>` など）に付与するのがWAI-ARIAの推奨パターンです。`<button>` などのインタラクティブ要素に付与した場合、JAWS・VoiceOver・NVDA の組み合わせによってライブリージョンの変更通知が発火しない、または二重に読み上げられるケースが報告されています。

より信頼性の高い実装としては、`<button>` の外に非表示のライブリージョンを置く方法があります。`chatAssets.ts` の `setButtonState` 関数でそのリージョンのテキストも一緒に更新すれば、現行の `aria-label` による accessible name の更新と組み合わせて確実に通知できます。例：
- `<span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>` を `.code-block` 内に追加し、コピー成功時にテキストを書き込む。
- あるいはボタン内のテキストを `<span aria-live="polite" aria-atomic="true">Copy</span>` でラップし、`textContent` の変更はそのスパンに対して行う（`setButtonState` 側も変更が必要）。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: コピーボタンのアクセシビリティ向上"](https://github.com/hiroki-org/jules-extension/commit/b1a94ef31ef4ad08d1bdfca1d8de48cc080ccc69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38901180)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->