### PR TITLE
🛡️ Sentinel: [MEDIUM] パストラバーサルチェックの修正

### DIFF
--- a/src/sessionContextMenuArtifacts.ts
+++ b/src/sessionContextMenuArtifacts.ts
@@ -52,7 +52,7 @@ async function resolveWorkspaceFileAsync(targetPath: string): Promise<vscode.Uri
 
         // Security Check: Ensure resolved path is still inside the workspace folder
         const relative = path.relative(folderPath, candidatePath);
-        const isSafe = !relative.startsWith('..') && !path.isAbsolute(relative);
+        const isSafe = (!relative.startsWith('..' + path.sep) && relative !== '..') && !path.isAbsolute(relative);
 
         if (!isSafe) {
             console.warn(`[Security] Rejected path traversal attempt: ${targetPath} -> ${candidatePath}`);

--- a/src/test/sessionContextMenuArtifacts.unit.test.ts
+++ b/src/test/sessionContextMenuArtifacts.unit.test.ts
@@ -75,6 +75,28 @@ suite("Session Context Menu Artifacts Security Suite", () => {
         assert.strictEqual(fsStatStub.called, false, "Should not attempt to stat traversed path");
     });
 
+    test("should allow valid paths that start with '..'", async () => {
+        const rootPath = path.resolve("/workspace");
+        const folder = {
+            uri: vscode.Uri.file(rootPath),
+            name: "root",
+            index: 0
+        };
+        workspaceFoldersStub.value([folder]);
+
+        const targetPath = "..config";
+        const resolvedPath = path.resolve(rootPath, targetPath);
+        const resolvedUri = vscode.Uri.file(resolvedPath);
+
+        // Simulate file exists
+        fsStatStub.withArgs(sinon.match((uri: vscode.Uri) => uri.fsPath === resolvedUri.fsPath)).resolves({ type: vscode.FileType.File });
+
+        const result = await resolveWorkspaceFile(targetPath);
+
+        assert.ok(result, "Should resolve valid path");
+        assert.strictEqual(result.fsPath, resolvedUri.fsPath);
+    });
+
     test("should allow valid paths within workspace", async () => {
         const rootPath = path.resolve("/workspace");
         const folder = {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: パストラバーサルチェックにおいて、`!relative.startsWith('..')`という条件を使用しているため、`..config`のようにファイル名が`..`から始まる正当なファイルが誤って拒否されるという問題がありました。
🎯 Impact: ユーザーが、`..config`などの有効なファイルを変更セットとして開こうとすると失敗し、正常な機能が損なわれる可能性があります。
🔧 Fix: チェックを`(!relative.startsWith('..' + path.sep) && relative !== '..') && !path.isAbsolute(relative)`に修正し、ディレクトリトラバーサルのみをブロックし、ファイル名としての`..`は許可するようにしました。
✅ Verification: `pnpm run test:unit` を実行し、新しいテストケースがパスすることを確認。

---
*PR created automatically by Jules for task [17958967944497337864](https://jules.google.com/task/17958967944497337864) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

パストラバーサル検出ロジックの false positive を修正するPRです。`..config` のように `..` で始まる正当なファイル名が誤って拒否されていた問題を、より精密な条件式へ変更することで解消しています。

- `!relative.startsWith('..')` という過剰な条件を `(!relative.startsWith('..' + path.sep) && relative !== '..')` に置き換え、ディレクトリトラバーサル（`../`、`..` 単体）のみをブロックし、`..config` 等の正当なファイル名を通過させるように変更。
- 対応するテストケースを追加し、`..config` が正しく解決されることを検証。ただし `relative === '..'` になるパス（`targetPath = ".."` 単体）を拒否することを確認するテストは未整備。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

セキュリティ上の意図は正しく実装されており、マージは概ね安全です。

修正ロジック自体は正しく、`../foo` や `..` 単体のトラバーサルは引き続き適切にブロックされます。一方、`relative === ".."` の条件に対応するテストが存在しないため、将来の変更でこのブランチがリグレッションしても気付きにくい状態です。

テストファイル `src/test/sessionContextMenuArtifacts.unit.test.ts` に `..` 単独パスを拒否することを確認するテストケースの追加を検討してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/sessionContextMenuArtifacts.ts | パストラバーサルチェックの条件を修正。`..config` 等の正当なファイル名を誤拒否していた false positive を解消。ロジック自体は正しいが、`relative === '..'` のみでブロックされるケース（`targetPath = '..'`）のテストが未整備。 |
| src/test/sessionContextMenuArtifacts.unit.test.ts | `..config` を許可する新テストを追加。ただし `..`（単独）のトラバーサル・ケースに対応するテストが存在しない。 |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[targetPath を受け取る] --> B{絶対パス?}
    B -- Yes --> C[null を返す]
    B -- No --> D[path.resolve でcandidatePath を算出]
    D --> E[path.relative でrelative を算出]
    E --> F{relative が dotdot+sep で始まる?}
    F -- Yes --> G[isSafe = false, 拒否]
    F -- No --> H{relative が dotdot に等しい?}
    H -- Yes --> G
    H -- No --> I{relative が絶対パス?}
    I -- Yes --> G
    I -- No --> J[isSafe = true, stat 確認]
    J --> K{ファイルが存在?}
    K -- Yes --> L[Uri を返す]
    K -- No --> M[null を返す]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[targetPath を受け取る] --> B{絶対パス?}
    B -- Yes --> C[null を返す]
    B -- No --> D[path.resolve でcandidatePath を算出]
    D --> E[path.relative でrelative を算出]
    E --> F{relative が dotdot+sep で始まる?}
    F -- Yes --> G[isSafe = false, 拒否]
    F -- No --> H{relative が dotdot に等しい?}
    H -- Yes --> G
    H -- No --> I{relative が絶対パス?}
    I -- Yes --> G
    I -- No --> J[isSafe = true, stat 確認]
    J --> K{ファイルが存在?}
    K -- Yes --> L[Uri を返す]
    K -- No --> M[null を返す]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/test/sessionContextMenuArtifacts.unit.test.ts:78-98
**`relative === '..'` ブランチのテストが未整備**

新しい条件 `relative !== '..'` は、`targetPath = ".."` を渡した場合（`path.resolve("/workspace", "..")` → `/`、`path.relative("/workspace", "/")` → `".."` ）のトラバーサルをブロックするために追加されましたが、このパスを検証するテストが存在しません。既存の `"../secret.txt"` テストは `startsWith('..' + path.sep)` ブランチをカバーしますが、`relative === ".."` になるケースはカバーされていないため、将来的なリグレッションの検知が困難です。`".."`（セパレータなし）を `targetPath` として渡し、`null` が返ることを確認するテストを追加することを推奨します。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix path traversal false positive for fi..."](https://github.com/hiroki-org/jules-extension/commit/2045cbb73529a0d982aa4796c6c22ddc41d26481) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38902705)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->