### PR TITLE
🎨 Palette: コピーボタンのアクセシビリティ向上

### DIFF
--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,6 +63,8 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('aria-live="polite"'));
+    assert.ok(rendered.includes('aria-atomic="true"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {


### PR DESCRIPTION
💡 What: コードブロックのコピーボタンに `aria-live="polite"` および `aria-atomic="true"` を追加しました。
🎯 Why: コピー操作時にボタンテキストが「Copy」から「Copied」などに動的に変わる際、スクリーンリーダーに変更を即座に通知させるためです。
📸 Before/After: コード上の変更のみです。
♿ Accessibility: 動的テキストの読み上げに対応しました。

---
*PR created automatically by Jules for task [2495376983088469304](https://jules.google.com/task/2495376983088469304) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コードブロックのコピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加し、コピー操作時のボタンテキスト変化をスクリーンリーダーに通知するアクセシビリティ改善 PR です。対応するユニットテストも更新されています。

- `src/chatView.ts`: MarkdownIt のフェンスレンダラーで生成するボタン HTML に ARIA ライブリージョン属性を付与。
- `src/test/chatView.unit.test.ts`: 新たに付与した2属性が HTML に含まれることを検証するアサーションを追加。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更範囲は小さく、既存機能への破壊的影響はありません。アクセシビリティ属性の追加のみであり、マージ自体は安全です。

変更はコピーボタンへの ARIA 属性追加という局所的なものです。静的な `aria-label` との干渉や、ボタン自身への `aria-live` 付与によるスクリーンリーダー間の挙動差異が懸念されますが、機能的な後退はなく、テストも更新されているため大きなリスクはありません。

`src/chatView.ts` の `aria-live` 実装パターンと、JS 側（`CHAT_JS`）でのアクセシブル名更新ロジックについては確認を推奨します。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | コピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加。アクセシビリティ向上の意図は明確だが、静的な `aria-label` との干渉や、ボタン自身への `aria-live` 付与によるスクリーンリーダー間の挙動差異が懸念される。 |
| src/test/chatView.unit.test.ts | `aria-live="polite"` と `aria-atomic="true"` の存在確認アサーションを追加。実装変更に対応したテストが適切に追加されている。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/chatView.ts:60
**`aria-live` をインタラクティブ要素に直接付与することの信頼性**

`aria-live="polite"` をボタン自身に付与することは仕様上は許可されていますが、スクリーンリーダー（NVDA・JAWS・VoiceOver 等）によって挙動が一貫しない場合があります。また、同じボタンに `aria-label="Copy code"` が静的に設定されているため、ボタンのアクセシブル名はテキストコンテンツよりも `aria-label` が優先されます。その結果、テキストが「Copied!」等に変わっても、フォーカス時には依然として「Copy code」と読み上げられる可能性があります。

よりロバストな実装パターンとしては、ボタン外に `role="status"` または `aria-live="polite"` を持つ視覚的に非表示の要素（例: `<span class="sr-only" aria-live="polite" aria-atomic="true"></span>`）を別途設け、コピー完了時にその要素のテキストを JS 側で更新する方法が推奨されます。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add aria-live to copy button for accessi..."](https://github.com/hiroki-org/jules-extension/commit/9e142686062ab05ed854b0389918f99b5bd27c3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39057725)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->