### PR TITLE
⚡ Bolt: Set初期化時の無駄な配列割り当てを排除

### DIFF
--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -188,7 +188,11 @@ export async function recoverCorruptedActivities(
 
   // Optimize N+1 fetch by fetching activities in bulk via the paginated endpoint.
   // We process directly into a Map and shrink the search Set to avoid intermediate arrays.
-  const corruptedIds = new Set(corruptedActivities.map((a) => a.id));
+  // ⚡ Bolt: .map() による中間配列の割り当てを回避
+  const corruptedIds = new Set<string>();
+  for (const a of corruptedActivities) {
+    corruptedIds.add(a.id);
+  }
   const recoveredMap = new Map<string, Activity>();
   let pageToken: string | undefined;
   const MAX_PAGES = 10;


### PR DESCRIPTION
💡 What: `sessionUtils.ts` 内の `new Set(corruptedActivities.map((a) => a.id))` を `for...of` ループを使用した直接の要素追加にリファクタリングしました。
🎯 Why: `.map()` を使用すると一時的な配列が生成され、メモリ割り当てとガベージコレクションのオーバーヘッドが発生するためです。
📊 Impact: 中間配列の生成を防ぎ、メモリ使用量を削減することで処理を高速化します。
🔬 Measurement: 単体テスト (`pnpm run test:unit`) がすべて成功することを確認しました。

---
*PR created automatically by Jules for task [12811175607948958557](https://jules.google.com/task/12811175607948958557) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `sessionUtils.ts` 内の `new Set(corruptedActivities.map((a) => a.id))` を `for...of` ループによる直接追加に置き換えるマイクロ最適化です。ロジックの等価性は保たれており、機能的な問題はありません。

- `.map()` が生成する中間配列を排除し、不要なメモリアロケーションを削減する変更です。現代のJSエンジン（V8等）では最適化されるケースも多く、実際の効果は入力サイズに依存します。
- ツール帰属コメント（`// ⚡ Bolt: ...`）が本番コードに残っており、直上の既存コメントと重複しています。コミットメッセージやPR説明に記載すれば十分です。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

機能的に等価な変更であり、マージしても動作への影響はありません。

コードロジックは変更前後で完全に等価であり、バグのリスクはありません。唯一の指摘事項はツール帰属コメントが本番コードに残っていることで、コードの品質・可読性の観点からクリーンアップが望ましい状態です。

特に注意が必要なファイルはありません。`src/sessionUtils.ts` のコメント1行を削除すれば完璧な状態になります。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/sessionUtils.ts | `new Set(corruptedActivities.map(...))` を `for...of` ループに置き換えるマイクロ最適化。ロジックは等価で正しいが、ツール帰属コメント（⚡ Bolt）が本番コードに残っている。 |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[corruptedActivities 配列] --> B_old

    subgraph 変更前
        B_old[".map(a => a.id)"] --> C_old["中間配列 string[]"]
        C_old --> D_old["new Set(array)"]
        D_old --> E_old["corruptedIds: Set&lt;string&gt;"]
    end

    A --> B_new

    subgraph 変更後
        B_new["new Set&lt;string&gt;()"] --> C_new["for...of ループ"]
        C_new --> D_new[".add(a.id)"]
        D_new --> E_new["corruptedIds: Set&lt;string&gt;"]
    end

    style C_old fill:#ffdddd,stroke:#cc0000
    style B_new fill:#ddffdd,stroke:#00aa00
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[corruptedActivities 配列] --> B_old

    subgraph 変更前
        B_old[".map(a => a.id)"] --> C_old["中間配列 string[]"]
        C_old --> D_old["new Set(array)"]
        D_old --> E_old["corruptedIds: Set&lt;string&gt;"]
    end

    A --> B_new

    subgraph 変更後
        B_new["new Set&lt;string&gt;()"] --> C_new["for...of ループ"]
        C_new --> D_new[".add(a.id)"]
        D_new --> E_new["corruptedIds: Set&lt;string&gt;"]
    end

    style C_old fill:#ffdddd,stroke:#cc0000
    style B_new fill:#ddffdd,stroke:#00aa00
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/sessionUtils.ts:191-195
ツール帰属コメントを削除し、既存の説明コメントのみ残すことを推奨します。直上の行（「avoid intermediate arrays」）がすでに最適化の意図を説明しているため、このコメントは冗長です。

```suggestion
  const corruptedIds = new Set<string>();
  for (const a of corruptedActivities) {
    corruptedIds.add(a.id);
  }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: Set初期化時の無駄な配列割り当てを排除"](https://github.com/hiroki-org/jules-extension/commit/965abcd7f974faf943fca7794ff4d98c62a4b588) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39059137)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->