### PR TITLE
⚡ Bolt: [パフォーマンス改善] Set初期化時の無駄な配列生成を削減

### DIFF
--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -188,7 +188,11 @@ export async function recoverCorruptedActivities(
 
   // Optimize N+1 fetch by fetching activities in bulk via the paginated endpoint.
   // We process directly into a Map and shrink the search Set to avoid intermediate arrays.
-  const corruptedIds = new Set(corruptedActivities.map((a) => a.id));
+  // Performance optimization: Avoid intermediate array allocation by directly adding to Set.
+  const corruptedIds = new Set<string>();
+  for (const a of corruptedActivities) {
+    corruptedIds.add(a.id);
+  }
   const recoveredMap = new Map<string, Activity>();
   let pageToken: string | undefined;
   const MAX_PAGES = 10;


### PR DESCRIPTION
💡 What: `sessionUtils.ts`の`corruptedIds`初期化において、`array.map()`を用いた中間配列の生成を避け、`for...of`ループと`.add()`を直接使用するように変更しました。
🎯 Why: `new Set(array.map(...))`は不要な中間配列をメモリに確保するため、パフォーマンス低下を招く恐れがあるためです。
📊 Impact: ガベージコレクションへの負荷軽減とメモリ使用量の削減が期待できます。
🔬 Measurement: ユニットテストおよびE2Eテストが正常に通過することを確認しました。

---
*PR created automatically by Jules for task [8270693855345893716](https://jules.google.com/task/8270693855345893716) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`sessionUtils.ts` の `recoverCorruptedActivities` 関数における `corruptedIds` の初期化方法を、`new Set(array.map(...))` による中間配列生成から `for...of` ループを使った直接追加へと変更しました。変更は機能的に等価であり、既存のロジックに影響はありません。

- `new Set<string>()` に明示的な型パラメータが追加されており、型安全性は向上しています。
- ただし、同じ内容を説明するコメントが重複して存在するようになったため、整理が望ましいです。
- 直後の paginated API 呼び出し（最大 10 ページ × 1000 件）のネットワークコストと比較すると、この最適化が体感パフォーマンスに与える影響はごくわずかです。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

機能的には等価な変更であり、既存のロジックを壊すリスクはありません。

変更箇所は1行の初期化コードのみで、動作の正確性に問題はありません。重複コメントの追加と、実際のボトルネック（API I/O）に対して効果が限定的なマイクロ最適化という点が気になりますが、バグは存在しません。

特に注意が必要なファイルはありません。`src/sessionUtils.ts` の変更は局所的かつ安全です。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/sessionUtils.ts | `corruptedIds` の初期化を `new Set(array.map(...))` から `for...of` + `.add()` に変更。機能的には等価だが、重複コメントの追加と、API I/O に比べて効果が限定的なマイクロ最適化が含まれる。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/sessionUtils.ts:189-191
**コメントの重複**

既存のコメント（`// We process directly into a Map and shrink the search Set to avoid intermediate arrays.`）が既に中間配列の削減について説明しており、追加された `// Performance optimization: Avoid intermediate array allocation by directly adding to Set.` は同じ内容を繰り返しています。冗長なコメントは可読性を下げるため、削除するか既存コメントに統合することを推奨します。

### Issue 2 of 2
src/sessionUtils.ts:192-195
**最適化の実際的な効果について**

この変更は `new Set(corruptedActivities.map(a => a.id))` の中間配列を避けることを目的としていますが、直後の `do...while` ループで最大 `MAX_PAGES × 1000` 件の API 呼び出し（`client.listActivities`）が行われます。そのネットワーク I/O コストに比べると、中間配列の確保・GC にかかるコストは実質的に無視できる水準です。また、`corruptedActivities` は `activities.filter(isActivityCorrupted)` の結果であり、配列サイズが極端に大きくなるケースは想定しにくいです。コードの可読性が低下した分の恩恵が得られるかどうか、再検討の余地があります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Performance: Avoid intermediate array al..."](https://github.com/hiroki-org/jules-extension/commit/b9b38a770cdf9d791510c21f9e43b648a986d2fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39306738)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->