### PR TITLE
🎨 Palette: コピーボタンに aria-live と aria-atomic を追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-06-11 - Dynamic Empty State Announcers
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.
+
+## 2026-06-24 - Dynamic ARIA Labeling for Context-Aware Inputs
+**Learning:** コピーボタンのようなインタラクティブ要素の動的なテキスト変更（例：「Copy」から「Copied」への変更）を行う際、対応するARIA属性（aria-label、title）も同時に更新し、スクリーンリーダーが新しい状態をアナウンスできるようにすることが非常に重要です。また、セッションインジケーターやタイピング状態などの動的なテキスト領域にaria-live="polite"とaria-atomic="true"を追加することで、スクリーンリーダーが更新されたテキスト全体を正しく読み上げるようになります。
+**Action:** 次回、ボタンやインジケーターに一時的なテキスト変更を実装する際は、テキストと共にaria-labelとtitleを同期して更新し、aria-live領域には必ずaria-atomic="true"を設定すること。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );


### PR DESCRIPTION
💡 What: コピーボタンに `aria-live="polite"` と `aria-atomic="true"` の属性を追加しました。
🎯 Why: コピーボタンのテキストが動的に変更された際（例：「Copy」から「Copied」へ）、スクリーンリーダーが状態の変更を即座に読み上げられるようにするためです。
📸 Before/After: （視覚的な変更なし。HTMLの属性追加のみ）
♿ Accessibility: インタラクティブなボタンの動的なテキスト変更が、支援技術を使用するユーザーにも正しく伝わるように改善されました。

---
*PR created automatically by Jules for task [16099151880743172379](https://jules.google.com/task/16099151880743172379) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加し、スクリーンリーダーがボタンの動的テキスト変更（「Copy」→「Copied」）を認識できるようにする変更です。`.Jules/palette.md` に関連する学習メモも追記されています。

- `src/chatView.ts` のコードブロック用コピーボタン生成箇所に 2 つの ARIA 属性を追加。
- `src/webview/chatAssets.ts` の JS ハンドラーはすでに `aria-label` と `title` を動的に更新しており（`setButtonState` / `restoreButtonState`）、今回の追加はそれと干渉する。`aria-live` をボタン自身に設定しているため、1.2 秒後の復元処理でテキストが \"Copy\" に戻る際にも読み上げが発生し、スクリーンリーダーユーザーに不要なアナウンスが届く。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

アクセシビリティ改善を意図した変更だが、`aria-live` をボタン自身に置いたことで、既存の `restoreButtonState()` が 1.2 秒後にテキストを "Copy" へ戻す際にも読み上げが発生し、スクリーンリーダーユーザーへの体験を意図とは逆方向に悪化させるリスクがある。

既存の JS ハンドラー（`setButtonState` / `restoreButtonState`）と `aria-live` の組み合わせにより、コピー操作のたびにスクリーンリーダーが「Copied」→「Copy」と 2 回アナウンスする動作になる。アクセシビリティ改善 PR での不要な読み上げ追加は、修正前より体験を悪化させる可能性があるため、マージ前に対応が必要。

`src/chatView.ts` と `src/webview/chatAssets.ts` を合わせて確認することを推奨。ボタン側の ARIA 属性と JS ハンドラーの復元ロジックが干渉している。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | コードブロックのコピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加。ただし `aria-live` をボタン自身に設定すると、`restoreButtonState()` でテキストが "Copy" に戻る際にも余計なアナウンスが発生する問題がある。 |
| .Jules/palette.md | 動的な ARIA ラベリングに関する学習メモを追加。コーディングに直接影響しないドキュメント更新。 |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as ユーザー（コピーボタン）
    participant JS as chatAssets.ts (CHAT_JS)
    participant SR as スクリーンリーダー

    User->>JS: コピーボタンをクリック
    JS->>JS: "setButtonState("Copied")<br/>textContent = "Copied"<br/>aria-label = "Copied""
    JS-->>SR: "aria-live="polite" により「Copied」をアナウンス ✅"
    Note over JS: 1.2秒後...
    JS->>JS: "restoreButtonState()<br/>textContent = "Copy"（元に戻す）<br/>aria-label = "Copy code"（元に戻す）"
    JS-->>SR: "aria-live="polite" により「Copy」を再アナウンス ❌（不要なノイズ）"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as ユーザー（コピーボタン）
    participant JS as chatAssets.ts (CHAT_JS)
    participant SR as スクリーンリーダー

    User->>JS: コピーボタンをクリック
    JS->>JS: "setButtonState("Copied")<br/>textContent = "Copied"<br/>aria-label = "Copied""
    JS-->>SR: "aria-live="polite" により「Copied」をアナウンス ✅"
    Note over JS: 1.2秒後...
    JS->>JS: "restoreButtonState()<br/>textContent = "Copy"（元に戻す）<br/>aria-label = "Copy code"（元に戻す）"
    JS-->>SR: "aria-live="polite" により「Copy」を再アナウンス ❌（不要なノイズ）"
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/chatView.ts:60
**`aria-live` によるコピー復元時の不要なアナウンス**

`aria-live="polite"` をボタン自身に設定すると、`restoreButtonState()` が 1.2 秒後に `copyButton.textContent = originalText`（"Copy"）に戻した際にも、スクリーンリーダーが「Copy」とアナウンスしてしまいます。実際の動作: コピーをクリック → 「Copied」とアナウンス（意図通り）→ 1.2 秒後に「Copy」とアナウンス（不要なノイズ）。

`src/webview/chatAssets.ts` の `setButtonState()` がすでに `copyButton.setAttribute("aria-label", text)` を呼び出しており、アクセシブル名はこちらで正しく更新されています。`aria-live` はその更新に加えてテキストコンテンツの変化も読み上げるため、復元時にも余計なアナウンスが発生します。

より適切な実装としては、ボタンから `aria-live` を除き、別途 visually-hidden なライブリージョン（`<span class="sr-only" aria-live="polite">`）に「Copied!」とだけ書き込む方法が WAI-ARIA のベストプラクティスに沿っています。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: コピーボタンに aria-live と aria-ato..."](https://github.com/hiroki-org/jules-extension/commit/e6e4836ed8a2a262fe12c2e397ce3b983ea041f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39311848)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->