### PR TITLE
⚡ Bolt: 中間配列の削減によるパフォーマンス最適化

### DIFF
--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -175,20 +175,32 @@ export async function recoverCorruptedActivities(
   activities: Activity[],
   progress?: vscode.Progress<{ message?: string; increment?: number }>,
 ): Promise<void> {
-  const corruptedActivities = activities.filter(isActivityCorrupted);
-  if (corruptedActivities.length === 0) {
+  // ⚡ Bolt: パフォーマンス最適化
+  // activities.filter() と .map() の連鎖による中間配列の生成を避け、
+  // 1回のループで破損したアクティビティのIDを収集することで、
+  // メモリ割り当てとガベージコレクションのオーバーヘッドを削減します。
+  const corruptedIds = new Set<string>();
+  let corruptedCount = 0;
+
+  for (const act of activities) {
+    if (isActivityCorrupted(act)) {
+      corruptedIds.add(act.id);
+      corruptedCount++;
+    }
+  }
+
+  if (corruptedCount === 0) {
     return;
   }
 
   if (progress) {
     progress.report({
-      message: `Recovering ${corruptedActivities.length} corrupted activities...`,
+      message: `Recovering ${corruptedCount} corrupted activities...`,
     });
   }
 
   // Optimize N+1 fetch by fetching activities in bulk via the paginated endpoint.
   // We process directly into a Map and shrink the search Set to avoid intermediate arrays.
-  const corruptedIds = new Set(corruptedActivities.map((a) => a.id));
   const recoveredMap = new Map<string, Activity>();
   let pageToken: string | undefined;
   const MAX_PAGES = 10;


### PR DESCRIPTION
- 💡 What: `activities.filter()` と `.map()` を単一の `for...of` ループに統合し、中間配列の生成を削減しました。
- 🎯 Why: `recoverCorruptedActivities` 関数はセッションのアクティビティを復旧する際に呼び出され、大量のデータを処理する可能性があります。中間配列を削減することで、メモリ割り当てとGCのオーバーヘッドを減らすことができます。
- 📊 Impact: メモリ割り当ての削減
- 🔬 Measurement: 単体テストとE2Eテストがパスすることを確認します。

---
*PR created automatically by Jules for task [14916658697202911592](https://jules.google.com/task/14916658697202911592) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`recoverCorruptedActivities` 関数内の `activities.filter()` と `.map()` チェーンを単一の `for...of` ループに統合し、中間配列の生成を削減するパフォーマンス最適化です。ロジック的な正確性は保たれており、動作変更はありません。

- `corruptedActivities` 中間配列と `map((a) => a.id)` の中間配列を排除し、`corruptedIds` Set を直接構築するよう変更。
- `corruptedCount` カウンター変数を追加しているが、`corruptedIds.size` で代替可能なため冗長。
- \"⚡ Bolt:\" プレフィックス付きのエージェント帰属コメントがソースコード内に残っており、既存コーディングスタイルと不一致。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

ロジックの変更はなく、動作は元のコードと同等です。安全にマージできます。

変更は小さく、`filter()+map()` を単一ループに置き換えるだけで正確性は保たれています。`corruptedCount` が `corruptedIds.size` と冗長である点と、"⚡ Bolt:" プレフィックス付きのコメントがコーディングスタイルと不一致である点が気になりますが、いずれもマージを妨げるものではありません。

特に注意が必要なファイルはありません。`src/sessionUtils.ts` の変更は局所的で影響範囲が限定的です。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/sessionUtils.ts | `recoverCorruptedActivities` 関数の `filter()+map()` チェーンを単一の `for...of` ループに統合し、中間配列を削減。ロジックは正しく保たれているが、`corruptedCount` カウンター変数が `corruptedIds.size` と冗長で削除可能。また "⚡ Bolt:" プレフィックス付きコメントがコーディングスタイルと不一致。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["activities: Activity[]"] --> B["for...of ループ"]
    B -->|"isActivityCorrupted = true"| C["corruptedIds.add"]
    B -->|"isActivityCorrupted = false"| D["スキップ"]
    C --> E{"corruptedIds.size === 0?"}
    E -->|"Yes"| F["return 早期終了"]
    E -->|"No"| G["progress.report"]
    G --> H["ページネーション付き一括フェッチ"]
    H --> I{"corruptedIds に含まれる?"}
    I -->|"Yes"| J{"isActivityCorrupted?"}
    J -->|"No 復旧成功"| K["recoveredMap.set"]
    J -->|"Yes まだ破損"| L["スキップ"]
    K --> M["corruptedIds.delete"]
    L --> M
    M --> N{"corruptedIds.size === 0?"}
    N -->|"Yes"| O["早期ループ終了"]
    N -->|"No"| P{"nextPageToken?"}
    P -->|"Yes"| H
    P -->|"No"| Q["ループ終了"]
    Q --> R["activities 配列を後方走査して更新"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["activities: Activity[]"] --> B["for...of ループ"]
    B -->|"isActivityCorrupted = true"| C["corruptedIds.add"]
    B -->|"isActivityCorrupted = false"| D["スキップ"]
    C --> E{"corruptedIds.size === 0?"}
    E -->|"Yes"| F["return 早期終了"]
    E -->|"No"| G["progress.report"]
    G --> H["ページネーション付き一括フェッチ"]
    H --> I{"corruptedIds に含まれる?"}
    I -->|"Yes"| J{"isActivityCorrupted?"}
    J -->|"No 復旧成功"| K["recoveredMap.set"]
    J -->|"Yes まだ破損"| L["スキップ"]
    K --> M["corruptedIds.delete"]
    L --> M
    M --> N{"corruptedIds.size === 0?"}
    N -->|"Yes"| O["早期ループ終了"]
    N -->|"No"| P{"nextPageToken?"}
    P -->|"Yes"| H
    P -->|"No"| Q["ループ終了"]
    Q --> R["activities 配列を後方走査して更新"]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/sessionUtils.ts:182-200
`corruptedCount` は `corruptedIds.size` と常に等価です（アクティビティ ID が一意であれば）。`Set.size` は O(1) なので、追加のカウンター変数は不要です。変数を1つ削除することでコードがシンプルになります。

```suggestion
  const corruptedIds = new Set<string>();

  for (const act of activities) {
    if (isActivityCorrupted(act)) {
      corruptedIds.add(act.id);
    }
  }

  if (corruptedIds.size === 0) {
    return;
  }

  if (progress) {
    progress.report({
      message: `Recovering ${corruptedIds.size} corrupted activities...`,
    });
  }
```

### Issue 2 of 2
src/sessionUtils.ts:178-181
**ソースコード内の "⚡ Bolt:" プレフィックス付きコメント**

このコメントは Jules エージェントが自動生成した帰属情報に見えます。`AGENTS.md` には既存のコーディングスタイルに従うよう記載されており、リポジトリの他の箇所にこのような形式のコメントはありません。プロダクションコードにツール固有の帰属コメントを残すのは一般的でないため、PR の概要や Git コミットメッセージに移動させることを検討してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(sessionUtils): reduce intermediate ..."](https://github.com/hiroki-org/jules-extension/commit/a35c089157460c6423256c561ca5765832d7c0d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39853754)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->