### PR TITLE
⚡ Bolt: Set初期化時のパフォーマンス最適化

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -54,3 +54,7 @@
 ## 2026-06-04 - [Performance] Optimize string prefix removal
 **Learning:** Using regular expressions like `.replace(/^sessions\//, '')` introduces unnecessary compilation and execution overhead compared to basic string operations.
 **Action:** When conditionally removing a fixed string prefix, prefer using `.startsWith()` combined with `.slice()` for better execution speed and reduced memory allocation.
+
+## 2024-05-24 - Set初期化時のパフォーマンス最適化
+**Learning:** 配列からSetを初期化する際に array.map() を使用すると、不要な中間配列が生成され、メモリとGCのオーバーヘッドが増加する。
+**Action:** 空のコレクションを初期化し、for...ofループで追加することで中間配列の生成を避ける。

--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -188,7 +188,11 @@ export async function recoverCorruptedActivities(
 
   // Optimize N+1 fetch by fetching activities in bulk via the paginated endpoint.
   // We process directly into a Map and shrink the search Set to avoid intermediate arrays.
-  const corruptedIds = new Set(corruptedActivities.map((a) => a.id));
+  // 中間配列の生成を避けるため、array.map()を使用せずにループでSetを初期化します。
+  const corruptedIds = new Set<string>();
+  for (const a of corruptedActivities) {
+    corruptedIds.add(a.id);
+  }
   const recoveredMap = new Map<string, Activity>();
   let pageToken: string | undefined;
   const MAX_PAGES = 10;


### PR DESCRIPTION
💡 What: `src/sessionUtils.ts` 内で `Set` を初期化する際、`array.map()` で中間配列を生成する処理を、空の `Set` と `for...of` ループを使用して追加する処理に変更しました。
🎯 Why: `map()` によって生成される不要な中間配列を回避し、メモリ割り当てとガベージコレクションのオーバーヘッドを削減するため。
📊 Impact: 中間配列の生成がなくなり、メモリ効率が向上します。
🔬 Measurement: `pnpm run lint`、`pnpm run check-types`、および `xvfb-run -a pnpm test` を実行して、既存のテストがすべて通過し、機能が損なわれていないことを確認します。

---
*PR created automatically by Jules for task [14657911055551310259](https://jules.google.com/task/14657911055551310259) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`src/sessionUtils.ts` 内で `Set` を初期化する際、`array.map()` による中間配列の生成を避けるため、空の `Set` と `for...of` ループを使った実装に変更しています。変更自体は機能的に等価で安全です。

- `corruptedIds` の初期化方法を変更（`new Set(array.map(...))` → `new Set<string>()` + `for...of`）。メモリ効率は微改善されるが、対象配列が小規模であることを踏まえると実測上の差は軽微。
- `.jules/bolt.md` に学習エントリを追加。ただし日付が `2024-05-24` と誤っており、直上エントリ（2026-06-04）と時系列が逆転している。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

`src/sessionUtils.ts` の変更は機能的に等価であり、ロジックに影響はありません。`.jules/bolt.md` の日付ミスは記録上の問題にとどまります。

コアロジックの変更は安全で、既存の動作を壊すリスクはありません。指摘事項は冗長なコメントと `bolt.md` の日付誤りのみで、いずれもスタイル・記録上の問題です。

`.jules/bolt.md` の日付（`2024-05-24`）が誤っており、修正が望ましいです。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/sessionUtils.ts | Set初期化を`map()`から`for...of`ループに変更。機能的に同等で正確。冗長な日本語コメントが追加されている点のみ指摘。 |
| .jules/bolt.md | 新しい学習エントリを追加。日付が`2024-05-24`となっており、直上のエントリ（2026-06-04）と時系列が逆転している。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[corruptedActivities: Activity array] -->|変更前| B["array.map(a => a.id)\n中間配列を生成"]
    B --> C["new Set(中間配列)\nSetを初期化"]
    C --> D[corruptedIds: Set&lt;string&gt;]

    A -->|変更後| E["new Set&lt;string&gt;()\n空のSetを作成"]
    E --> F["for...of ループ\ncorruptedIds.add(a.id)"]
    F --> D

    style B fill:#f9c,stroke:#c66
    style E fill:#cfc,stroke:#696
    style F fill:#cfc,stroke:#696
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[corruptedActivities: Activity array] -->|変更前| B["array.map(a => a.id)\n中間配列を生成"]
    B --> C["new Set(中間配列)\nSetを初期化"]
    C --> D[corruptedIds: Set&lt;string&gt;]

    A -->|変更後| E["new Set&lt;string&gt;()\n空のSetを作成"]
    E --> F["for...of ループ\ncorruptedIds.add(a.id)"]
    F --> D

    style B fill:#f9c,stroke:#c66
    style E fill:#cfc,stroke:#696
    style F fill:#cfc,stroke:#696
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.jules/bolt.md:57-59
**bolt.md の日付が不正確**

新しく追加されたエントリの日付が `2024-05-24` になっていますが、直上のエントリが `2026-06-04` であり、時系列が逆転しています。このPRが作成された日付（2026年6月）と一致させるべきです。

### Issue 2 of 2
src/sessionUtils.ts:191-192
既存の英語コメント（`// We process directly into a Map and shrink the search Set to avoid intermediate arrays.`）がすでに「中間配列の回避」という同じ意図を説明しています。新たに追加された日本語コメントはその内容と重複しており、冗長です。コメントを削除するか、既存の英語コメントを更新する形に統合することをお勧めします。

```suggestion
  const corruptedIds = new Set<string>();
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: Set初期化時のパフォーマンス最適化"](https://github.com/hiroki-org/jules-extension/commit/5c192c6e05f3ce33055489092404913036666b3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40282236)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->