### PR TITLE
🎨 Palette: コピーボタンのアクセシビリティ改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-06-11 - Dynamic Empty State Announcers
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.
+
+## 2026-06-29 - コピーボタンの動的なアクセシビリティ改善
+**Learning:** コピーボタンのようにテキストが動的に変わる要素（「Copy」から「Copied」へ）では、単にaria-labelを変えるだけでなく、要素自体にaria-live="polite"とaria-atomic="true"を設定し、スクリーンリーダーが変更を直ちに読み上げるようにすることが重要である。
+**Action:** 今後、動的に状態テキストが変わるボタンを実装する際は、テンプレートでaria-live属性を追加し、JS側で意味のあるaria-label（例：「Copied code」）を同期して更新する。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -587,7 +587,7 @@ suite("chatAssets unit tests", () => {
   });
 
   test("CHAT_JS should reset copy button text after failure", () => {
-    assert.ok(CHAT_JS.includes('setButtonState("Failed")'));
+    assert.ok(CHAT_JS.includes('setButtonState("Failed", "Failed to copy code")'));
     const resetCount = (
       CHAT_JS.match(
         /setTimeout\(restoreButtonState, 1200\)/g,

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,6 +63,8 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('aria-live="polite"'));
+    assert.ok(rendered.includes('aria-atomic="true"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -391,10 +391,10 @@ export const CHAT_JS = `(function() {
     const originalTitle = copyButton.title;
     const originalAriaLabel = copyButton.getAttribute("aria-label");
 
-    function setButtonState(text) {
+    function setButtonState(text, ariaLabel) {
       copyButton.textContent = text;
       copyButton.title = text;
-      copyButton.setAttribute("aria-label", text);
+      copyButton.setAttribute("aria-label", ariaLabel || text);
     }
 
     function restoreButtonState() {
@@ -406,10 +406,10 @@ export const CHAT_JS = `(function() {
 
     try {
       await navigator.clipboard.writeText(code);
-      setButtonState("Copied");
+      setButtonState("Copied", "Copied code");
       setTimeout(restoreButtonState, 1200);
     } catch {
-      setButtonState("Failed");
+      setButtonState("Failed", "Failed to copy code");
       setTimeout(restoreButtonState, 1200);
     }
   });


### PR DESCRIPTION
💡 What:
コードブロックのコピーボタン（.copy-code-button）に `aria-live="polite"` と `aria-atomic="true"` を追加し、コピーステータス（Copied, Failed）に応じてスクリーンリーダー向けのより詳細なラベル（"Copied code", "Failed to copy code"）を設定するようにしました。

🎯 Why:
ボタンのテキストが動的に変更された際（「Copy」→「Copied」など）、スクリーンリーダーユーザーに変更が伝わらない問題を解決し、変更内容がより具体的な文脈を伴って読み上げられるようにするためです。

📸 Before/After:
UIの見た目上の変更はありません（アクセシビリティの向上のみ）。

♿ Accessibility:
・スクリーンリーダーが動的な状態変更を認識できるようになりました。
・「Copied」だけでなく「Copied code」と読み上げられることで、何の操作が成功したか文脈がより明確になりました。

---
*PR created automatically by Jules for task [18107617071590995811](https://jules.google.com/task/18107617071590995811) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コードブロックのコピーボタン（`.copy-code-button`）に `aria-live=\"polite\"` / `aria-atomic=\"true\"` を追加し、成功・失敗時の `aria-label` をより文脈が明確な文字列（\"Copied code\" / \"Failed to copy code\"）に更新するアクセシビリティ改善PRです。

- `src/chatView.ts` のHTMLテンプレートにライブリージョン属性を追加し、`src/webview/chatAssets.ts` の `setButtonState` 関数を拡張して文脈付き `aria-label` をサポート。
- 状態復元時（`restoreButtonState`）にも `aria-live` が発火して \"Copy code\" が再アナウンスされる副作用があり、意図しないスクリーンリーダー読み上げが発生する可能性がある。また、`<button>` 要素への `aria-live` 付与は一部のスクリーンリーダー（NVDA, JAWS）で無視されるケースがあり、専用のライブリージョン要素を分離することがより確実なパターンとして推奨される。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

ボタン自体へのライブリージョン設定と、状態復元時の意図しない再アナウンスの2点が、この変更が目指すアクセシビリティ向上を損なうリスクを持っている。

コピーボタンの `<button>` 要素に直接 `aria-live="polite"` を付与しているため、NVDA や JAWS などの主要スクリーンリーダーでライブリージョンが無視されると、このPRのアクセシビリティ改善が実際には効果を持たない可能性がある。さらに、1.2秒後の `restoreButtonState` でも `aria-label` が変化するため、スクリーンリーダーが "Copy code" を予期せず読み上げるという副作用が生じる。

`src/chatView.ts` のボタンテンプレートと `src/webview/chatAssets.ts` の `setButtonState` / `restoreButtonState` の連携部分を重点的に確認してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/chatView.ts | コピーボタンのHTML テンプレートに `aria-live="polite"` と `aria-atomic="true"` を追加。ただし `<button>` 要素へのライブリージョン設定はスクリーンリーダー間の動作が不安定なリスクがある。 |
| src/webview/chatAssets.ts | `setButtonState` に `ariaLabel` 引数を追加し、成功/失敗時に文脈付きの aria-label を設定する変更。ただし状態復元時にも live region がアナウンスされる副作用がある。 |
| src/test/chatAssets.unit.test.ts | 失敗パスの `setButtonState` 呼び出し文字列アサーションを更新。成功パスの aria-label に対する明示的なアサーションが欠落している。 |
| src/test/chatView.unit.test.ts | `aria-live="polite"` と `aria-atomic="true"` の存在チェックを追加。適切に更新されている。 |
| .Jules/palette.md | コピーボタンの動的アクセシビリティ改善に関するラーニングエントリを追加。コード変更なし。 |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as ユーザー（クリック）
    participant Button as .copy-code-button
    participant Clipboard as navigator.clipboard
    participant SR as スクリーンリーダー

    User->>Button: クリック
    Button->>Clipboard: writeText(code)
    alt 成功
        Clipboard-->>Button: 解決
        Button->>Button: "textContent=Copied / aria-label=Copied code"
        SR-->>User: Copied code を読み上げ
        Note over Button,SR: 1200ms後
        Button->>Button: "textContent=Copy / aria-label=Copy code"
        SR-->>User: Copy code を再度読み上げ（意図しない副作用）
    else 失敗
        Clipboard-->>Button: 例外
        Button->>Button: "textContent=Failed / aria-label=Failed to copy code"
        SR-->>User: Failed to copy code を読み上げ
        Note over Button,SR: 1200ms後
        Button->>Button: "textContent=Copy / aria-label=Copy code"
        SR-->>User: Copy code を再度読み上げ（意図しない副作用）
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as ユーザー（クリック）
    participant Button as .copy-code-button
    participant Clipboard as navigator.clipboard
    participant SR as スクリーンリーダー

    User->>Button: クリック
    Button->>Clipboard: writeText(code)
    alt 成功
        Clipboard-->>Button: 解決
        Button->>Button: "textContent=Copied / aria-label=Copied code"
        SR-->>User: Copied code を読み上げ
        Note over Button,SR: 1200ms後
        Button->>Button: "textContent=Copy / aria-label=Copy code"
        SR-->>User: Copy code を再度読み上げ（意図しない副作用）
    else 失敗
        Clipboard-->>Button: 例外
        Button->>Button: "textContent=Failed / aria-label=Failed to copy code"
        SR-->>User: Failed to copy code を読み上げ
        Note over Button,SR: 1200ms後
        Button->>Button: "textContent=Copy / aria-label=Copy code"
        SR-->>User: Copy code を再度読み上げ（意図しない副作用）
    end
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/webview/chatAssets.ts`, line 400-404 ([link](https://github.com/hiroki-org/jules-extension/blob/1b2d0689550a1b23fad7c951bb6e0e9cbf27a55d/src/webview/chatAssets.ts#L400-L404)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **ボタン状態復元時にも aria-live がアナウンスされる問題**

   `restoreButtonState` によって `aria-label` が "Copied code" → "Copy code" に戻る際、ボタン自体に `aria-live="polite"` が設定されているため、スクリーンリーダーが復元後に再度 "Copy code" を読み上げてしまいます。コピー操作の完了から 1.2 秒後に唐突に "Copy code" と読み上げられることは、ユーザーにとって混乱を招く可能性があります。ライブリージョンの対象を限定する（ボタン外に専用の `aria-live` 要素を置く）か、復元時だけ一時的にライブリージョンの機能を抑制することを検討してください。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 400-404

   Comment:
   **ボタン状態復元時にも aria-live がアナウンスされる問題**

   `restoreButtonState` によって `aria-label` が "Copied code" → "Copy code" に戻る際、ボタン自体に `aria-live="polite"` が設定されているため、スクリーンリーダーが復元後に再度 "Copy code" を読み上げてしまいます。コピー操作の完了から 1.2 秒後に唐突に "Copy code" と読み上げられることは、ユーザーにとって混乱を招く可能性があります。ライブリージョンの対象を限定する（ボタン外に専用の `aria-live` 要素を置く）か、復元時だけ一時的にライブリージョンの機能を抑制することを検討してください。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `src/test/chatAssets.unit.test.ts`, line 589-601 ([link](https://github.com/hiroki-org/jules-extension/blob/1b2d0689550a1b23fad7c951bb6e0e9cbf27a55d/src/test/chatAssets.unit.test.ts#L589-L601)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **成功パスの aria-label に対するアサーションが欠落**

   テストは失敗パス (`"Failed to copy code"`) の文字列が含まれることを明示的に確認していますが、成功パスの `setButtonState("Copied", "Copied code")` に対応する `includes` チェックが追加されていません。この PR の主要な変更内容（aria-label に文脈を付加すること）が成功パスでも正しく機能していることを保証するアサーションが必要です。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/test/chatAssets.unit.test.ts
   Line: 589-601

   Comment:
   **成功パスの aria-label に対するアサーションが欠落**

   テストは失敗パス (`"Failed to copy code"`) の文字列が含まれることを明示的に確認していますが、成功パスの `setButtonState("Copied", "Copied code")` に対応する `includes` チェックが追加されていません。この PR の主要な変更内容（aria-label に文脈を付加すること）が成功パスでも正しく機能していることを保証するアサーションが必要です。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/webview/chatAssets.ts:400-404
**ボタン状態復元時にも aria-live がアナウンスされる問題**

`restoreButtonState` によって `aria-label` が "Copied code" → "Copy code" に戻る際、ボタン自体に `aria-live="polite"` が設定されているため、スクリーンリーダーが復元後に再度 "Copy code" を読み上げてしまいます。コピー操作の完了から 1.2 秒後に唐突に "Copy code" と読み上げられることは、ユーザーにとって混乱を招く可能性があります。ライブリージョンの対象を限定する（ボタン外に専用の `aria-live` 要素を置く）か、復元時だけ一時的にライブリージョンの機能を抑制することを検討してください。

### Issue 2 of 3
src/chatView.ts:60
**インタラクティブ要素への `aria-live` の適用はスクリーンリーダー間で動作が不安定**

`<button>` 要素そのものに `aria-live="polite"` を付与する方法は ARIA 仕様上は禁止されていませんが、NVDA や JAWS などの主要スクリーンリーダーはフォーカスを持つインタラクティブ要素のライブリージョン変化を無視するケースがあります。より確実なパターンは、ボタン外に `class="sr-only"` の `<span aria-live="polite" aria-atomic="true">` を別途置き、そこだけを JS で更新することです。現実装では目的のアナウンスがスクリーンリーダーによっては一切読み上げられない可能性があります。

### Issue 3 of 3
src/test/chatAssets.unit.test.ts:589-601
**成功パスの aria-label に対するアサーションが欠落**

テストは失敗パス (`"Failed to copy code"`) の文字列が含まれることを明示的に確認していますが、成功パスの `setButtonState("Copied", "Copied code")` に対応する `includes` チェックが追加されていません。この PR の主要な変更内容（aria-label に文脈を付加すること）が成功パスでも正しく機能していることを保証するアサーションが必要です。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(a11y): improve screen reader announ..."](https://github.com/hiroki-org/jules-extension/commit/1b2d0689550a1b23fad7c951bb6e0e9cbf27a55d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40538235)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->