### PR TITLE
⚡ Bolt: 中間配列の生成を排除しSetの初期化のメモリ効率を改善

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,9 +134,11 @@ export async function handleFilterActivitiesCommand(
   });
 
   if (selected !== undefined) {
-    const newFilter = new Set<ActivityCategory>(
-      selected.map((item) => item.label as ActivityCategory),
-    );
+    // Performance optimization: mapによる中間配列の生成を避け、for...ofループで直接Setを構築します
+    const newFilter = new Set<ActivityCategory>();
+    for (const item of selected) {
+      newFilter.add(item.label as ActivityCategory);
+    }
     sessionsProvider.setActivityCategoryFilter(newFilter);
   }
 }

--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -188,7 +188,11 @@ export async function recoverCorruptedActivities(
 
   // Optimize N+1 fetch by fetching activities in bulk via the paginated endpoint.
   // We process directly into a Map and shrink the search Set to avoid intermediate arrays.
-  const corruptedIds = new Set(corruptedActivities.map((a) => a.id));
+  // Performance optimization: mapによる中間配列の生成を避け、for...ofループで直接Setを構築します
+  const corruptedIds = new Set<string>();
+  for (const a of corruptedActivities) {
+    corruptedIds.add(a.id);
+  }
   const recoveredMap = new Map<string, Activity>();
   let pageToken: string | undefined;
   const MAX_PAGES = 10;


### PR DESCRIPTION
💡 What: `map()`メソッドを使用して作成された中間配列を`new Set()`に渡す代わりに、空の`Set`を初期化し`for...of`ループで直接要素を追加するようにリファクタリングしました。
🎯 Why: `Array.prototype.map()`を伴う`Set`の初期化は不要な中間配列をメモリ上に生成するため、メモリ割り当てとガベージコレクションのオーバーヘッドが増加します。これを排除することでパフォーマンスを最適化します。
📊 Impact: 中間配列の生成が不要になるため、メモリ割り当てが削減され、特に要素数が多い場合や頻繁に実行されるパスでの実行速度とメモリ効率が向上します。
🔬 Measurement: ユニットテストおよびE2Eテストがすべて正常に通過することを確認します（`xvfb-run -a pnpm test`）。メモリプロファイラを使用し、配列割り当ての減少を確認できます。

---
*PR created automatically by Jules for task [7825381830246067442](https://jules.google.com/task/7825381830246067442) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、`new Set(arr.map(fn))` パターンを空の `Set` + `for...of` ループに置き換え、中間配列の生成を排除するマイクロ最適化です。変更は2箇所に限定され、機能的な振る舞いに差異はありません。

- **`src/extension.ts`**: QuickPickの選択結果からActivityCategoryのSetを構築する処理を `for...of` ループに変更。ただし、このコードパスは少数のUI選択肢を対象とするため、実運用での効果は測定困難なレベルです。
- **`src/sessionUtils.ts`**: `corruptedActivities` からIDのSetを構築する処理を同様に変更。既存コメントと新規コメントが同じ内容を重複して説明しています。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

両ファイルの変更は機能的に同等で、バグや破壊的変更は導入されていないため、安全にマージできます。

`sessionUtils.ts` では既存コメント（189〜190行目）と新規追加コメント（191行目）が同じ最適化意図を重複して説明しており、コードの可読性を若干損なっています。ロジックの正確性に問題はなく、スタイル上の軽微な改善点のみ存在します。

src/sessionUtils.ts の重複コメントを整理すると、より読みやすくなります。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | QuickPickの選択結果からSetを構築する方法を `map()` + コンストラクタから `for...of` ループに変更。機能的に同等で、バグの導入なし。 |
| src/sessionUtils.ts | `corruptedIds` Setの構築方法を `map()` から `for...of` ループに変更。機能的に同等だが、既存の「avoid intermediate arrays」コメントと新規追加コメントが重複している。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["変更前: new Set(arr.map(fn))"] --> B["map() 実行"]
    B --> C["中間配列を生成"]
    C --> D["Set コンストラクタに渡す"]
    D --> E["中間配列をGC"]
    E --> F["Set 完成"]

    G["変更後: for...of ループ"] --> H["空の Set を初期化"]
    H --> I["要素を1件ずつ add()"]
    I --> J["Set 完成"]

    style C fill:#f9a,stroke:#c33
    style E fill:#fcc,stroke:#c33
    style J fill:#9f9,stroke:#393
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["変更前: new Set(arr.map(fn))"] --> B["map() 実行"]
    B --> C["中間配列を生成"]
    C --> D["Set コンストラクタに渡す"]
    D --> E["中間配列をGC"]
    E --> F["Set 完成"]

    G["変更後: for...of ループ"] --> H["空の Set を初期化"]
    H --> I["要素を1件ずつ add()"]
    I --> J["Set 完成"]

    style C fill:#f9a,stroke:#c33
    style E fill:#fcc,stroke:#c33
    style J fill:#9f9,stroke:#393
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/sessionUtils.ts:189-195
**重複コメントによる情報の冗長性**

191行目に追加されたコメントと、189〜190行目の既存コメント（"We process directly into a Map and shrink the search Set to avoid intermediate arrays."）が同じ最適化意図を説明しており、冗長です。どちらか一方（既存の英語コメントかプロジェクトの言語方針に合わせた日本語コメント）に統一するか、191行目の新しいコメントを削除することを検討してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 中間配列の生成を排除しSetの初期化のメモリ効率を改善"](https://github.com/hiroki-org/jules-extension/commit/de54f72f349be31e529c6afae6b89a84bfbfc752) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40538532)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->