### PR TITLE
🎨 Palette: コピーボタンのアクセシビリティ向上

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-06-11 - Dynamic Empty State Announcers
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.
+
+## 2026-06-30 - コピーボタンの動的なアクセシビリティ対応
+**Learning:** コピーボタンのようなインタラクティブ要素の動的なテキスト変更（例：「Copy」から「Copied」への変更）を行う際、対応するARIA属性（aria-label、title）も同時に更新し、スクリーンリーダーが新しい状態をアナウンスできるようにすることが非常に重要です。また、セッションインジケーターやタイピング状態などの動的なテキスト領域にaria-live="polite"とaria-atomic="true"を追加することで、スクリーンリーダーが更新されたテキスト全体を正しく読み上げるようになります。
+**Action:** 次回、ボタンやインジケーターに一時的なテキスト変更を実装する際は、テキストと共にaria-labelとtitleを同期して更新し、aria-live領域には必ずaria-atomic="true"を設定すること。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,6 +63,8 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('aria-live="polite"'));
+    assert.ok(rendered.includes('aria-atomic="true"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -393,8 +393,9 @@ export const CHAT_JS = `(function() {
 
     function setButtonState(text) {
       copyButton.textContent = text;
-      copyButton.title = text;
-      copyButton.setAttribute("aria-label", text);
+      const desc = text === "Copied" ? "Copied code" : (text === "Failed" ? "Failed to copy code" : text);
+      copyButton.title = desc;
+      copyButton.setAttribute("aria-label", desc);
     }
 
     function restoreButtonState() {


### PR DESCRIPTION
💡 What:
コピーボタン（Copy/Copied/Failed）に `aria-live="polite"` および `aria-atomic="true"` を追加し、状態変更時に `aria-label` と `title` を具体的なテキスト（「Copied code」や「Failed to copy code」など）に更新するように変更しました。

🎯 Why:
ボタンテキストが動的に変更された際に、スクリーンリーダーに正しい状態遷移をアナウンスさせるためです。また、単なる「Copied」より「Copied code」という具体的なラベルの方が、ユーザーに明確なコンテキストを提供できるためです。

📸 Before/After:
UIの見た目上の変更はありません。スクリーンリーダーやキーボードフォーカス時のツールチップの読み上げが改善されます。

♿ Accessibility:
`aria-live` 属性の追加と `aria-label` の同期により、視覚に障害があるユーザーにもボタンの状態変更が正しく通知されるようになります。

---
*PR created automatically by Jules for task [13529707063834549072](https://jules.google.com/task/13529707063834549072) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コピーボタン（Copy/Copied/Failed）に `aria-live=\"polite\"` および `aria-atomic=\"true\"` を追加し、状態変化時の `aria-label` と `title` をより具体的なテキスト（「Copied code」「Failed to copy code」）に更新するアクセシビリティ改善 PR です。

- `src/chatView.ts`: 初期レンダリングの `<button>` に `aria-live=\"polite\"` / `aria-atomic=\"true\"` を追加
- `src/webview/chatAssets.ts`: `setButtonState()` 内で `aria-label` と `title` を状態ごとの具体的な文字列にマッピングするよう変更。`restoreButtonState()` での元の値への復元ロジックは正しく実装されている
- `src/test/chatView.unit.test.ts`: 新しい ARIA 属性の初期レンダリングを確認するテストを追加
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

アクセシビリティ改善を目的とした小規模な変更で、既存のコピー機能への破壊的影響はありません。

`aria-live` をボタン要素自体に配置しているため、一部のスクリーンリーダーで「Copied code」が二重にアナウンスされる可能性があります。また `setButtonState` のマジックストリング比較は保守上の懸念点ですが、現時点での動作は正しく、コピー機能そのものへの影響はありません。

`src/chatView.ts` と `src/webview/chatAssets.ts` の `aria-live` 配置とマッピングロジックを中心に確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | `aria-live="polite"` と `aria-atomic="true"` をコピーボタンの初期 HTML に追加。`<button>` 要素自体への `aria-live` 配置がスクリーンリーダーの二重アナウンスを引き起こす可能性あり。 |
| src/webview/chatAssets.ts | `setButtonState` でマジックストリング比較により `aria-label`/`title` をより具体的な文字列へマッピング。`restoreButtonState` の復元ロジックは正しく動作する。マッピングが文字列キーに依存しているため保守性の懸念あり。 |
| src/test/chatView.unit.test.ts | 初期レンダリングに `aria-live` / `aria-atomic` 属性が含まれることを確認するテストを追加。`setButtonState` のマッピングロジック自体のテストはカバーされていない。 |
| .Jules/palette.md | コピーボタンのアクセシビリティ改善に関するラーニングエントリを追加。ドキュメント更新のみ。 |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as ユーザー
    participant Button as コピーボタン
    participant Clipboard as クリップボード API
    participant SR as スクリーンリーダー

    User->>Button: クリック
    Button->>Button: data-copy-feedback-active 設定
    Button->>Clipboard: navigator.clipboard.writeText(code)

    alt コピー成功
        Clipboard-->>Button: 成功
        Button->>Button: "textContent = Copied"
        Button->>Button: "aria-label = Copied code"
        SR-->>User: Copied code をアナウンス（aria-label 変更）
        SR-->>User: Copied code をアナウンス（aria-live リージョン）二重の可能性
        Note over Button,SR: 1200ms 後に restoreButtonState()
        Button->>Button: 元の状態に復元
    else コピー失敗
        Clipboard-->>Button: 例外
        Button->>Button: "textContent = Failed"
        Button->>Button: "aria-label = Failed to copy code"
        SR-->>User: Failed to copy code をアナウンス
        Note over Button,SR: 1200ms 後に restoreButtonState()
        Button->>Button: 元の状態に復元
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as ユーザー
    participant Button as コピーボタン
    participant Clipboard as クリップボード API
    participant SR as スクリーンリーダー

    User->>Button: クリック
    Button->>Button: data-copy-feedback-active 設定
    Button->>Clipboard: navigator.clipboard.writeText(code)

    alt コピー成功
        Clipboard-->>Button: 成功
        Button->>Button: "textContent = Copied"
        Button->>Button: "aria-label = Copied code"
        SR-->>User: Copied code をアナウンス（aria-label 変更）
        SR-->>User: Copied code をアナウンス（aria-live リージョン）二重の可能性
        Note over Button,SR: 1200ms 後に restoreButtonState()
        Button->>Button: 元の状態に復元
    else コピー失敗
        Clipboard-->>Button: 例外
        Button->>Button: "textContent = Failed"
        Button->>Button: "aria-label = Failed to copy code"
        SR-->>User: Failed to copy code をアナウンス
        Note over Button,SR: 1200ms 後に restoreButtonState()
        Button->>Button: 元の状態に復元
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/chatView.ts:60
**`<button>` 要素への `aria-live` 配置による二重アナウンス**

`aria-live="polite"` をボタン自体に設定すると、クリック後に `setButtonState()` が呼ばれた際、NVDA・JAWS などのスクリーンリーダーで「Copied code」が二回読み上げられる場合があります。ボタンにフォーカスが残っている状態でも `aria-label` の変更はスクリーンリーダーに通知されるため、`aria-live` リージョンからの追加アナウンスと重複します。

WAI-ARIA のベストプラクティスでは、ボタン要素に直接 `aria-live` を付与するより、ボタンの外側に視覚的に非表示の `aria-live` コンテナを別途配置するパターンが推奨されています。あるいは、`aria-live` を省略して `aria-label` 更新のみに頼る選択肢も検討できます。

### Issue 2 of 3
src/webview/chatAssets.ts:394-398
`setButtonState` がマジックストリング（`"Copied"` / `"Failed"`）を比較キーとして使用しています。呼び出し文字列を変更した場合、このマッピングがサイレントに壊れ、`aria-label` と `title` が短い文字列のまま残ります。状態を表すオブジェクトマップを使う方が堅牢です。

```suggestion
    const STATE_LABELS = { "Copied": "Copied code", "Failed": "Failed to copy code" };
    function setButtonState(text) {
      copyButton.textContent = text;
      const desc = STATE_LABELS[text] || text;
      copyButton.title = desc;
      copyButton.setAttribute("aria-label", desc);
```

### Issue 3 of 3
src/test/chatView.unit.test.ts:63-67
**`setButtonState` マッピングロジックのテスト不足**

追加されたテストは初期 HTML に `aria-live` / `aria-atomic` が含まれることを確認するだけで、`setButtonState("Copied")` が `aria-label` を `"Copied code"` に変換するマッピングロジックはカバーされていません。将来的に表示文字列が変更された場合、マッピングが壊れてもテストが通り続けます。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: improve copy button accessibility ..."](https://github.com/hiroki-org/jules-extension/commit/227a1447043bf4efd4753dcca24ddbec2032c5c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40835220)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->