### PR TITLE
⚡ Bolt: [パフォーマンス改善] Set の初期化で中間配列の生成を回避

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -54,3 +54,7 @@
 ## 2026-06-04 - [Performance] Optimize string prefix removal
 **Learning:** Using regular expressions like `.replace(/^sessions\//, '')` introduces unnecessary compilation and execution overhead compared to basic string operations.
 **Action:** When conditionally removing a fixed string prefix, prefer using `.startsWith()` combined with `.slice()` for better execution speed and reduced memory allocation.
+
+## 2025-07-02 - ⚡ Bolt: Setのコンストラクタでの .map() の回避
+**Learning:** new Set(array.map(...)) を使用すると、キーの配列という不必要な中間配列が作成され、メモリ割り当てとガベージコレクションのオーバーヘッドが増加します。
+**Action:** new Set(array.map(...)) の代わりに、空の Set を初期化し、for...of ループで直接 .add() を呼び出すことで、中間配列の割り当てを回避します。

--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -188,7 +188,12 @@ export async function recoverCorruptedActivities(
 
   // Optimize N+1 fetch by fetching activities in bulk via the paginated endpoint.
   // We process directly into a Map and shrink the search Set to avoid intermediate arrays.
-  const corruptedIds = new Set(corruptedActivities.map((a) => a.id));
+  // ⚡ Bolt: パフォーマンス最適化。new Set(array.map(...)) による中間配列の生成を避け、
+  // GC（ガベージコレクション）のプレッシャーを低減するために for...of と add() を使用。
+  const corruptedIds = new Set<string>();
+  for (const a of corruptedActivities) {
+    corruptedIds.add(a.id);
+  }
   const recoveredMap = new Map<string, Activity>();
   let pageToken: string | undefined;
   const MAX_PAGES = 10;


### PR DESCRIPTION
💡 What: `sessionUtils.ts` で `new Set(corruptedActivities.map(...))` を使用していた箇所を、`for...of` ループと `.add()` を使用するように変更し、最適化の理由をコメントに追加しました。
🎯 Why: `new Set(array.map(...))` は一時的な中間配列を作成するため、メモリ割り当てとガベージコレクションのオーバーヘッドが発生します。これを排除することでパフォーマンスを改善できます。
📊 Impact: 不要なメモリ割り当てを削減し、CPU サイクルを節約します。
🔬 Measurement: メモリプロファイラを使用して、配列割り当ての減少を確認できます。

---
*PR created automatically by Jules for task [1738304862206871203](https://jules.google.com/task/1738304862206871203) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `sessionUtils.ts` の `recoverCorruptedActivities` 関数内で `new Set(corruptedActivities.map((a) => a.id))` を `for...of` + `.add()` に置き換え、中間配列の生成を回避するマイクロ最適化です。ロジックの変更はなく、`.jules/bolt.md` に対応するラーニングエントリも追加されています。

- `src/sessionUtils.ts`: `new Set<string>()` + `for...of` ループに書き換え。機能的な差異はなく、プロジェクト内の既存最適化パターンと一致。
- `.jules/bolt.md`: 新しいラーニングエントリを追加。ただし日付が `2025-07-02` と記録されており、既存エントリ（最新 `2026-06-04`）と比較して1年分の時系列が逆転している。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

コード変更はロジックに一切影響せず、安全にマージできます。

変更は機能的に同一であり、既存の動作を壊すリスクはありません。`.jules/bolt.md` の新エントリの日付が `2025-07-02` と既存ログより1年古く記録されており、ラーニングログの時系列整合性に軽微な問題があります。ソースコードに埋め込まれた絵文字付きコメントもプロジェクトのスタイルから逸脱しています。

`.jules/bolt.md` の日付誤記を確認・修正してください。`src/sessionUtils.ts` のコメントスタイルも既存のものに合わせると良いでしょう。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/sessionUtils.ts | `new Set(array.map(...))` を `for...of` + `.add()` に置き換える微最適化。ロジックに変更なし。追加コメントの絵文字スタイルが既存スタイルと不一致。 |
| .jules/bolt.md | 新しいラーニングエントリを追加。日付が `2025-07-02` と既存ログより1年古くなっており、正しくは `2026-07-02` と思われる。 |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant recoverCorruptedActivities
    participant Set
    participant JulesApiClient

    Caller->>recoverCorruptedActivities: activities[]を渡す
    recoverCorruptedActivities->>recoverCorruptedActivities: filter(isActivityCorrupted)
    Note over recoverCorruptedActivities,Set: 変更前: new Set(array.map(...)) → 中間配列あり
    Note over recoverCorruptedActivities,Set: 変更後: new Set() + for...of + .add() → 中間配列なし
    loop corruptedActivities
        recoverCorruptedActivities->>Set: corruptedIds.add(a.id)
    end
    loop ページネーション (最大10ページ)
        recoverCorruptedActivities->>JulesApiClient: listActivities(sessionName, 1000, pageToken)
        JulesApiClient-->>recoverCorruptedActivities: "{ activities, nextPageToken }"
        recoverCorruptedActivities->>Set: corruptedIds.has / .delete
    end
    recoverCorruptedActivities-->>Caller: 復旧完了
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant recoverCorruptedActivities
    participant Set
    participant JulesApiClient

    Caller->>recoverCorruptedActivities: activities[]を渡す
    recoverCorruptedActivities->>recoverCorruptedActivities: filter(isActivityCorrupted)
    Note over recoverCorruptedActivities,Set: 変更前: new Set(array.map(...)) → 中間配列あり
    Note over recoverCorruptedActivities,Set: 変更後: new Set() + for...of + .add() → 中間配列なし
    loop corruptedActivities
        recoverCorruptedActivities->>Set: corruptedIds.add(a.id)
    end
    loop ページネーション (最大10ページ)
        recoverCorruptedActivities->>JulesApiClient: listActivities(sessionName, 1000, pageToken)
        JulesApiClient-->>recoverCorruptedActivities: "{ activities, nextPageToken }"
        recoverCorruptedActivities->>Set: corruptedIds.has / .delete
    end
    recoverCorruptedActivities-->>Caller: 復旧完了
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.jules/bolt.md:58-60
**ラーニングログの日付が1年ズレている**

新しく追加されたエントリの日付が `2025-07-02` になっていますが、直前のエントリ（`2026-06-04`）を含む既存のログと比較すると、正しくは `2026-07-02` であるべきです。ラーニングログの時系列が崩れ、後から参照した際に混乱を招く可能性があります。

### Issue 2 of 2
src/sessionUtils.ts:191-193
ソースコードに絵文字を含む `⚡ Bolt:` プレフィックスのコメントが追加されています。同ファイルの他のコメントはすべてシンプルな散文スタイルであり、ツール名を埋め込んだ絵文字コメントは可読性や将来的なメンテナンス性の観点でスタイルが統一されていません。直前の既存コメント（"Optimize N+1 fetch..."）はすでに中間配列の回避について言及しており、重複した説明にもなっています。

```suggestion
  // new Set(array.map(...)) による中間配列の生成を避け、GC プレッシャーを低減。
  const corruptedIds = new Set<string>();
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: Optimize Set initialization to a..."](https://github.com/hiroki-org/jules-extension/commit/5a531a219e514fe752449508a4f7446c18c709b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41392705)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->