### PR TITLE
🎨 Palette: コピーボタンのアクセシビリティ改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,6 @@
 ## 2026-06-11 - Dynamic Empty State Announcers
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.
+## 2024-07-02 - 動的に変化するボタンのARIAラベルの改善
+**Learning:** コピーボタンのような動的にテキストが変化するインタラクティブな要素では、単なるテキストの変更（例：「Copied」）だけでなく、`aria-live="polite"` と `aria-atomic="true"` を追加し、`aria-label` に詳細なコンテキスト（例：「Copied code」）を設定することで、スクリーンリーダーユーザーにとってアクセシビリティが向上する。
+**Action:** 同様に状態が動的に変化するUIコンポーネントを実装する際は、要素に `aria-live` 属性を付与し、JavaScript側でコンテキストを含んだ `aria-label` を同期して更新するようにする。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,6 +63,8 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('aria-live="polite"'));
+    assert.ok(rendered.includes('aria-atomic="true"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -394,7 +394,8 @@ export const CHAT_JS = `(function() {
     function setButtonState(text) {
       copyButton.textContent = text;
       copyButton.title = text;
-      copyButton.setAttribute("aria-label", text);
+      const ariaText = text === "Copied" ? "Copied code" : (text === "Failed" ? "Failed to copy code" : text);
+      copyButton.setAttribute("aria-label", ariaText);
     }
 
     function restoreButtonState() {


### PR DESCRIPTION
💡 What: コードブロックのコピーボタンに aria-live="polite" と aria-atomic="true" を追加し、コピー時の aria-label をより詳細な "Copied code" などに変更しました。
🎯 Why: コピー状態が変化した際に、スクリーンリーダーユーザーにボタンの文言が単なる "Copied" ではなく、十分な文脈を伴う内容を確実に伝えるため。
📸 Before/After: Visual changes None
♿ Accessibility: aria-live の活用による動的テキスト変化時のフィードバック向上

---
*PR created automatically by Jules for task [6865313582464382412](https://jules.google.com/task/6865313582464382412) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コードブロックのコピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加し、コピー成功時の `aria-label` を `"Copied code"`、失敗時を `"Failed to copy code"` に変更するアクセシビリティ改善PRです。

- `src/chatView.ts` でボタンのHTML生成に `aria-live` / `aria-atomic` 属性を追加し、`src/webview/chatAssets.ts` の `setButtonState` で文脈付きの `aria-label` を設定するように変更しています。
- `restoreButtonState` がボタンのテキストを元に戻す際に `aria-live` が再発火し、リセット時にもスクリーンリーダーへアナウンスが流れる問題があります（意図しないノイズ）。
- `text === "Copied"` のハードコード文字列比較は、文字列が変更された際にサイレントに壊れるため、マップ方式への置き換えを推奨します。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

アクセシビリティの意図は正しいが、`restoreButtonState` でのスクリーンリーダーへの意図しない再アナウンスが修正前に必要。

`restoreButtonState` がボタンのテキストを "Copy" に戻す際に `aria-live` が再び発火し、スクリーンリーダーユーザーに不要なアナウンスが流れる。これはアクセシビリティ改善PRにおいて逆効果になり得るため、マージ前に対処すべき実挙動上の問題がある。

`src/webview/chatAssets.ts` の `restoreButtonState` 関数の `aria-live` 制御が要確認。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/chatView.ts | コピーボタンのHTML生成に `aria-live="polite"` と `aria-atomic="true"` を追加。属性自体は正しく付与されているが、ボタン要素への `aria-live` 付与はスクリーンリーダーによって動作が異なる場合がある。 |
| src/webview/chatAssets.ts | `setButtonState` で詳細な `aria-label` を設定する変更を実施。ただし `restoreButtonState` 呼び出し時にも `aria-live` が発火してリセットがアナウンスされる問題と、英語ハードコード文字列比較の脆弱性がある。 |
| src/test/chatView.unit.test.ts | 新しい `aria-live` と `aria-atomic` 属性に対応したテストケースを追加。変更内容を適切にカバーしている。 |
| .Jules/palette.md | 今回の変更で得た知見をパレット（ドキュメント）に追記。内容は正確。 |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as ユーザー
    participant Button as コピーボタン (aria-live)
    participant SR as スクリーンリーダー
    participant Clipboard as クリップボード

    User->>Button: クリック
    Button->>Clipboard: navigator.clipboard.writeText(code)
    Clipboard-->>Button: 成功
    Button->>Button: setButtonState("Copied")
    Button-->>SR: aria-live 発火 → "Copied code" アナウンス ✅
    Note over Button,SR: 1200ms 後
    Button->>Button: restoreButtonState()
    Button-->>SR: aria-live 再発火 → "Copy code" アナウンス ⚠️ (意図しないノイズ)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as ユーザー
    participant Button as コピーボタン (aria-live)
    participant SR as スクリーンリーダー
    participant Clipboard as クリップボード

    User->>Button: クリック
    Button->>Clipboard: navigator.clipboard.writeText(code)
    Clipboard-->>Button: 成功
    Button->>Button: setButtonState("Copied")
    Button-->>SR: aria-live 発火 → "Copied code" アナウンス ✅
    Note over Button,SR: 1200ms 後
    Button->>Button: restoreButtonState()
    Button-->>SR: aria-live 再発火 → "Copy code" アナウンス ⚠️ (意図しないノイズ)
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/webview/chatAssets.ts`, line 401-406 ([link](https://github.com/hiroki-org/jules-extension/blob/729218666b44f6e96b1a91a57df6bb75650055b5/src/webview/chatAssets.ts#L401-L406)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `restoreButtonState` がボタンの `textContent` を元に戻す際、ボタンに付与した `aria-live` が再び発火し、「Copy」がスクリーンリーダーにアナウンスされてしまいます。コピー完了から1200ms後に意図しないアナウンスが流れ、ユーザーにとってノイズになります。リストアの直前に `aria-live` を一時的に `"off"` に切り替えるのが確実です。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 401-406

   Comment:
   `restoreButtonState` がボタンの `textContent` を元に戻す際、ボタンに付与した `aria-live` が再び発火し、「Copy」がスクリーンリーダーにアナウンスされてしまいます。コピー完了から1200ms後に意図しないアナウンスが流れ、ユーザーにとってノイズになります。リストアの直前に `aria-live` を一時的に `"off"` に切り替えるのが確実です。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/webview/chatAssets.ts:401-406
`restoreButtonState` がボタンの `textContent` を元に戻す際、ボタンに付与した `aria-live` が再び発火し、「Copy」がスクリーンリーダーにアナウンスされてしまいます。コピー完了から1200ms後に意図しないアナウンスが流れ、ユーザーにとってノイズになります。リストアの直前に `aria-live` を一時的に `"off"` に切り替えるのが確実です。

```suggestion
    function restoreButtonState() {
      copyButton.setAttribute("aria-live", "off");
      copyButton.textContent = originalText;
      if (originalTitle) { copyButton.title = originalTitle; } else { copyButton.removeAttribute("title"); }
      if (originalAriaLabel) { copyButton.setAttribute("aria-label", originalAriaLabel); } else { copyButton.removeAttribute("aria-label"); }
      copyButton.removeAttribute("data-copy-feedback-active");
      copyButton.setAttribute("aria-live", "polite");
    }
```

### Issue 2 of 3
src/webview/chatAssets.ts:397
`text === "Copied"` / `text === "Failed"` という英語ハードコード比較は脆弱です。呼び出し元の文字列が変更された場合、フォールバックの `text` がそのまま `aria-label` に設定されてしまいます。定数またはマップで管理することを推奨します。

```suggestion
      const ariaLabelMap = { "Copied": "Copied code", "Failed": "Failed to copy code" };
      const ariaText = ariaLabelMap[text] ?? text;
```

### Issue 3 of 3
src/chatView.ts:60
**`<button>` への `aria-live` 付与はスクリーンリーダー間で動作が不安定**

WAI-ARIA のベストプラクティスでは、ライブリージョンはインタラクティブ要素（`<button>`）ではなく、専用の非表示コンテナ（例：`<span class="sr-only" role="status" aria-live="polite" aria-atomic="true"></span>`）に設定することが推奨されています。ボタンに直接 `aria-live` を付与した場合、NVDA＋Chrome では機能しても、VoiceOver（macOS/iOS）や JAWS ではアナウンスが二重になったり発火しない場合があります。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: コピーボタンのアクセシビリティ改善"](https://github.com/hiroki-org/jules-extension/commit/729218666b44f6e96b1a91a57df6bb75650055b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41393908)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->