### PR TITLE
🎨 Palette: コピーボタンのアクセシビリティ改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,6 @@
 ## 2026-06-11 - Dynamic Empty State Announcers
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.
+## 2024-07-03 - 動的なボタンテキスト変更時のアクセシビリティ
+**Learning:** 動的にテキストが変わるボタンにおいて、`aria-live="polite"` と `aria-atomic="true"` を付与し、`aria-label` に詳細な説明（「Copied code」など）を設定することで、スクリーンリーダーユーザーにとってコンテキストが明確になる。
+**Action:** ボタンのテキストが動的に変わる実装を行う際は、必ず `aria-live` 属性を追加し、状態に応じた適切な `aria-label` の更新をJavaScript側で同期して行うようにする。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -587,7 +587,7 @@ suite("chatAssets unit tests", () => {
   });
 
   test("CHAT_JS should reset copy button text after failure", () => {
-    assert.ok(CHAT_JS.includes('setButtonState("Failed")'));
+    assert.ok(CHAT_JS.includes('setButtonState("Failed", "Failed to copy code")'));
     const resetCount = (
       CHAT_JS.match(
         /setTimeout\(restoreButtonState, 1200\)/g,

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,6 +63,8 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('aria-live="polite"'));
+    assert.ok(rendered.includes('aria-atomic="true"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -391,10 +391,10 @@ export const CHAT_JS = `(function() {
     const originalTitle = copyButton.title;
     const originalAriaLabel = copyButton.getAttribute("aria-label");
 
-    function setButtonState(text) {
+    function setButtonState(text, ariaLabelText) {
       copyButton.textContent = text;
       copyButton.title = text;
-      copyButton.setAttribute("aria-label", text);
+      copyButton.setAttribute("aria-label", ariaLabelText);
     }
 
     function restoreButtonState() {
@@ -406,10 +406,10 @@ export const CHAT_JS = `(function() {
 
     try {
       await navigator.clipboard.writeText(code);
-      setButtonState("Copied");
+      setButtonState("Copied", "Copied code");
       setTimeout(restoreButtonState, 1200);
     } catch {
-      setButtonState("Failed");
+      setButtonState("Failed", "Failed to copy code");
       setTimeout(restoreButtonState, 1200);
     }
   });


### PR DESCRIPTION
💡 What:
コードブロックのコピーボタンに `aria-live="polite"` および `aria-atomic="true"` 属性を追加し、コピー成功・失敗時に `aria-label` をより詳細な説明（"Copied code", "Failed to copy code"）に更新するようにしました。

🎯 Why:
コピーボタンをクリックした際、テキストが「Copied」に変わるだけでは、スクリーンリーダーユーザーにとって何の操作が完了したのかコンテキストが不足する場合があるためです。

📸 Before/After:
Before: `aria-label="Copied"` (ボタン本体のテキストのみ変化、aria-live属性なし)
After: `aria-live="polite"` と `aria-atomic="true"` が追加され、動的に `aria-label="Copied code"` に更新されます。

♿ Accessibility:
スクリーンリーダーが状態の変化を適切に読み上げ、ユーザーに正確なフィードバックを提供するようになります。

---
*PR created automatically by Jules for task [7264759411402740913](https://jules.google.com/task/7264759411402740913) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コードブロックのコピーボタンに `aria-live="polite"` / `aria-atomic="true"` を追加し、コピー成功・失敗時の `aria-label` をより説明的なテキスト（"Copied code" / "Failed to copy code"）に更新するアクセシビリティ改善です。対応するテストも更新されています。

- `src/chatView.ts` でボタンの HTML テンプレートに `aria-live` / `aria-atomic` 属性を追加
- `src/webview/chatAssets.ts` の `setButtonState` に `ariaLabelText` 引数を追加し、コピー操作の結果に応じた詳細な `aria-label` を設定するよう変更
- `src/test/chatView.unit.test.ts` と `src/test/chatAssets.unit.test.ts` のテストを新しい実装に合わせて更新
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

機能面の破壊的変更はなく、アクセシビリティの改善を意図した変更として全体的に安全です。

コピー操作完了後に `restoreButtonState` が `aria-label` を元の値へ戻す際、`aria-live` が付いているためスクリーンリーダーが "Copy code" を余分に読み上げる動作が発生します。また `aria-live` をインタラクティブ要素（`<button>`）に直接付与するパターンは一部のスクリーンリーダーで動作が不安定になる可能性があり、この変更が目指すアクセシビリティの向上が完全には達成されない恐れがあります。

`src/webview/chatAssets.ts` の `restoreButtonState` の動作と、`src/chatView.ts` での `aria-live` 属性の配置場所を確認することを推奨します。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/chatView.ts | `<button>` に `aria-live="polite"` と `aria-atomic="true"` を追加。インタラクティブ要素への `aria-live` 付与はスクリーンリーダーによっては動作が不安定になる可能性あり |
| src/webview/chatAssets.ts | `setButtonState` に `ariaLabelText` 引数を追加し、より詳細な `aria-label` を設定する変更。ただし `restoreButtonState` も `aria-live` によって読み上げられる点に注意が必要 |
| src/test/chatView.unit.test.ts | `aria-live` と `aria-atomic` 属性の存在をアサートするテストを追加。問題なし |
| src/test/chatAssets.unit.test.ts | `setButtonState` の失敗時呼び出しを新しいシグネチャに合わせてテストを更新。問題なし |
| .Jules/palette.md | 今回の変更に関するラーニングエントリを追加。ドキュメントのみの変更 |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as ユーザー
    participant Button as コピーボタン(aria-live=polite)
    participant SR as スクリーンリーダー
    participant Clipboard as クリップボード

    User->>Button: クリック
    Button->>Clipboard: navigator.clipboard.writeText(code)
    alt 成功
        Clipboard-->>Button: 解決
        Button->>Button: "setButtonState - aria-label = Copied code"
        SR-->>User: Copied code を読み上げ
        Note over Button,SR: 1200ms 後
        Button->>Button: "restoreButtonState - aria-label = Copy code"
        SR-->>User: Copy code を読み上げ（余分なアナウンス）
    else 失敗
        Clipboard-->>Button: 例外
        Button->>Button: "setButtonState - aria-label = Failed to copy code"
        SR-->>User: Failed to copy code を読み上げ
        Note over Button,SR: 1200ms 後
        Button->>Button: "restoreButtonState - aria-label = Copy code"
        SR-->>User: Copy code を読み上げ（余分なアナウンス）
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as ユーザー
    participant Button as コピーボタン(aria-live=polite)
    participant SR as スクリーンリーダー
    participant Clipboard as クリップボード

    User->>Button: クリック
    Button->>Clipboard: navigator.clipboard.writeText(code)
    alt 成功
        Clipboard-->>Button: 解決
        Button->>Button: "setButtonState - aria-label = Copied code"
        SR-->>User: Copied code を読み上げ
        Note over Button,SR: 1200ms 後
        Button->>Button: "restoreButtonState - aria-label = Copy code"
        SR-->>User: Copy code を読み上げ（余分なアナウンス）
    else 失敗
        Clipboard-->>Button: 例外
        Button->>Button: "setButtonState - aria-label = Failed to copy code"
        SR-->>User: Failed to copy code を読み上げ
        Note over Button,SR: 1200ms 後
        Button->>Button: "restoreButtonState - aria-label = Copy code"
        SR-->>User: Copy code を読み上げ（余分なアナウンス）
    end
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/webview/chatAssets.ts`, line 400-404 ([link](https://github.com/hiroki-org/jules-extension/blob/41398d96f6c915a165c46817403b3429468b3c4b/src/webview/chatAssets.ts#L400-L404)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`restoreButtonState` がライブリージョンの余分な読み上げを引き起こす**

   `aria-live="polite"` がボタン自体に付いているため、`restoreButtonState` 内で `aria-label` を `"Copy code"` に戻す処理もスクリーンリーダーに読み上げられます。ユーザーは「Copied code」の直後（1.2秒後）に「Copy code」とも読み上げられ、不必要なノイズになります。

   コピー完了後の復元時のみ `aria-live` を一時的に除去するか、または `aria-live` をボタン本体ではなく非表示の兄弟 `<span>` に持たせる（ボタンには `aria-live` を付けない）パターンの方が、ARIA の慣例としても堅牢です。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 400-404

   Comment:
   **`restoreButtonState` がライブリージョンの余分な読み上げを引き起こす**

   `aria-live="polite"` がボタン自体に付いているため、`restoreButtonState` 内で `aria-label` を `"Copy code"` に戻す処理もスクリーンリーダーに読み上げられます。ユーザーは「Copied code」の直後（1.2秒後）に「Copy code」とも読み上げられ、不必要なノイズになります。

   コピー完了後の復元時のみ `aria-live` を一時的に除去するか、または `aria-live` をボタン本体ではなく非表示の兄弟 `<span>` に持たせる（ボタンには `aria-live` を付けない）パターンの方が、ARIA の慣例としても堅牢です。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/webview/chatAssets.ts:400-404
**`restoreButtonState` がライブリージョンの余分な読み上げを引き起こす**

`aria-live="polite"` がボタン自体に付いているため、`restoreButtonState` 内で `aria-label` を `"Copy code"` に戻す処理もスクリーンリーダーに読み上げられます。ユーザーは「Copied code」の直後（1.2秒後）に「Copy code」とも読み上げられ、不必要なノイズになります。

コピー完了後の復元時のみ `aria-live` を一時的に除去するか、または `aria-live` をボタン本体ではなく非表示の兄弟 `<span>` に持たせる（ボタンには `aria-live` を付けない）パターンの方が、ARIA の慣例としても堅牢です。

### Issue 2 of 2
src/chatView.ts:57-60
**`aria-live` をインタラクティブ要素（`<button>`）に直接付与することの互換性リスク**

WAI-ARIA の慣例として `aria-live` はコンテナ要素（`<div>` や `<span>` など）に付与するものであり、`<button>` などのインタラクティブ要素に直接付与した場合の動作は一部のスクリーンリーダーで一貫しないことがあります。特に NVDA のブラウズモードや古いバージョンの VoiceOver では `aria-label` の変更がライブリージョンとして正しくアナウンスされない可能性があります。

より堅牢なパターンは、ボタンの近くに `<span class="sr-only" aria-live="polite" aria-atomic="true"></span>` を配置し、コピー操作のたびにそのテキストを更新する方法です。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: コピーボタンのアクセシビリティ改善"](https://github.com/hiroki-org/jules-extension/commit/41398d96f6c915a165c46817403b3429468b3c4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41655809)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->