### PR TITLE
⚡ Bolt: 不要な中間配列とSetインスタンスの生成を排除してパフォーマンスを最適化

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,9 +134,11 @@ export async function handleFilterActivitiesCommand(
   });
 
   if (selected !== undefined) {
-    const newFilter = new Set<ActivityCategory>(
-      selected.map((item) => item.label as ActivityCategory),
-    );
+    // [Performance] Avoid .map() inside Set constructor to prevent intermediate array allocation
+    const newFilter = new Set<ActivityCategory>();
+    for (const item of selected) {
+      newFilter.add(item.label as ActivityCategory);
+    }
     sessionsProvider.setActivityCategoryFilter(newFilter);
   }
 }
@@ -3258,7 +3260,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // [Performance] Use .includes() for single lookup instead of allocating a Set
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3281,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // [Performance] Use .includes() for single lookup instead of allocating a Set
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,

--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -188,7 +188,11 @@ export async function recoverCorruptedActivities(
 
   // Optimize N+1 fetch by fetching activities in bulk via the paginated endpoint.
   // We process directly into a Map and shrink the search Set to avoid intermediate arrays.
-  const corruptedIds = new Set(corruptedActivities.map((a) => a.id));
+  // [Performance] Avoid .map() inside Set constructor to prevent intermediate array allocation
+  const corruptedIds = new Set<string>();
+  for (const a of corruptedActivities) {
+    corruptedIds.add(a.id);
+  }
   const recoveredMap = new Map<string, Activity>();
   let pageToken: string | undefined;
   const MAX_PAGES = 10;


### PR DESCRIPTION
💡 What: `new Set(array.map(...))` を `for...of` ループでの直接追加に変更し、単発の検索における `new Set(array).has(...)` を `array.includes(...)` に置き換えました。
🎯 Why: 中間配列の生成や不要なオブジェクト割り当て（アロケーション）を防ぎ、メモリ消費とCPUのオーバーヘッドを削減するため。
📊 Impact: ガベージコレクションの負荷が減少し、対象パスの実行速度が向上します。
🔬 Measurement: ユニットテストおよびE2Eテストが正常に通過することを確認。

---
*PR created automatically by Jules for task [11555780858009562474](https://jules.google.com/task/11555780858009562474) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、`new Set(array.map(...))` パターンを `for...of` ループによる直接追加に、単発検索での `new Set(array).has(...)` を `array.includes(...)` に置き換えるマイクロ最適化です。すべての変更は機能的に同等であり、正確性に影響はありません。

- `extension.ts` の `handleFilterActivitiesCommand` 内で中間配列アロケーションを排除し、ブランチ存在確認の2箇所で単発Set生成を `includes()` に置き換え。
- `sessionUtils.ts` の `recoverCorruptedActivities` 内で `corruptedIds` Set構築を `for...of` ループに変更。既存の「中間配列を避ける」コメントと新コメントが若干重複している点は軽微な問題。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はいずれも機能的に同等で、既存の動作を変えることなく安全にマージできます。

3箇所の変更はすべて意味的に等価です。`Set.has()` と `Array.includes()` はどちらも SameValueZero アルゴリズムを使用するため、文字列比較において挙動に差はありません。`for...of` ループによる Set 構築も `new Set(array.map(...))` と同一の結果を生成します。ロジックの変更がなく、副作用のリスクも存在しません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `new Set(array.map(...))` を `for...of` ループに、単発の `new Set(array).has(...)` を `array.includes(...)` に置き換え。いずれも機能的に同等で安全な変更。 |
| src/sessionUtils.ts | `corruptedIds` の Set 構築を `for...of` ループに変更。既存の「中間配列を避ける」コメントと新コメントが若干重複するが、機能的に正しく安全。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["変更前"]
        B1["array.map(fn)"] --> B2["中間配列を生成"]
        B2 --> B3["new Set(中間配列)"]
        B3 --> B4["Set インスタンスを返す"]
    end

    subgraph After["変更後 (for...of)"]
        A1["new Set()"] --> A2["for...of でループ"]
        A2 --> A3["set.add(fn(item))"]
        A3 --> A4["Set インスタンスを返す"]
    end

    subgraph Before2["変更前 (単発検索)"]
        C1["new Set(array)"] --> C2["Set を構築 O(n)"]
        C2 --> C3[".has(x) → O(1)"]
        C3 --> C4["合計: O(n) + アロケーション"]
    end

    subgraph After2["変更後 (includes)"]
        D1["array.includes(x)"] --> D2["線形探索 O(n)"]
        D2 --> D3["合計: O(n)、アロケーション不要"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before["変更前"]
        B1["array.map(fn)"] --> B2["中間配列を生成"]
        B2 --> B3["new Set(中間配列)"]
        B3 --> B4["Set インスタンスを返す"]
    end

    subgraph After["変更後 (for...of)"]
        A1["new Set()"] --> A2["for...of でループ"]
        A2 --> A3["set.add(fn(item))"]
        A3 --> A4["Set インスタンスを返す"]
    end

    subgraph Before2["変更前 (単発検索)"]
        C1["new Set(array)"] --> C2["Set を構築 O(n)"]
        C2 --> C3[".has(x) → O(1)"]
        C3 --> C4["合計: O(n) + アロケーション"]
    end

    subgraph After2["変更後 (includes)"]
        D1["array.includes(x)"] --> D2["線形探索 O(n)"]
        D2 --> D3["合計: O(n)、アロケーション不要"]
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["perf: avoid intermediate array allocatio..."](https://github.com/hiroki-org/jules-extension/commit/3d278b6ed11476938d92e71ae33d43f622a20bfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41813829)</sub>

<!-- /greptile_comment -->