### PR TITLE
🎨 Palette: コピーボタンのアクセシビリティ向上

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
+	version: '1.113.0',
 	files: 'out/test/**/*.test.js',
 	launchArgs: [
 		'--no-sandbox',

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button><span class="copy-code-status" role="status" aria-live="polite" aria-atomic="true"></span>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button><span class="copy-status-sr" role="status" aria-live="polite" aria-atomic="true"></span>' +
           rendered +
           "</div>"
         );

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button><span class="copy-code-status" role="status" aria-live="polite" aria-atomic="true"></span>' +
           rendered +
           "</div>"
         );
@@ -124,7 +124,7 @@ const DEFAULT_SANITIZER_OPTIONS: sanitizeHtml.IOptions = {
   ]),
   allowedAttributes: {
     ...sanitizeHtml.defaults.allowedAttributes,
-    "*": ["class", "id", "data-*", "aria-*"],
+    "*": ["class", "id", "data-*", "aria-*", "role"],
     button: ["type", "title"],
   },
   nonTextTags: [

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -57,7 +57,7 @@ export async function initMarkdownRenderer(): Promise<void> {
           ? defaultFence(tokens, idx, options, env, self)
           : self.renderToken(tokens, idx, options);
         return (
-          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code">Copy</button><span class="copy-status-sr" role="status" aria-live="polite" aria-atomic="true"></span>' +
+          '<div class="code-block"><button class="copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live="polite" aria-atomic="true">Copy</button>' +
           rendered +
           "</div>"
         );
@@ -124,7 +124,7 @@ const DEFAULT_SANITIZER_OPTIONS: sanitizeHtml.IOptions = {
   ]),
   allowedAttributes: {
     ...sanitizeHtml.defaults.allowedAttributes,
-    "*": ["class", "id", "data-*", "aria-*", "role"],
+    "*": ["class", "id", "data-*", "aria-*"],
     button: ["type", "title"],
   },
   nonTextTags: [

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -135,6 +135,7 @@ suite("chatAssets unit tests", () => {
         ".code-block:hover .copy-code-button, .copy-code-button:focus-visible",
       ),
     );
+    assert.ok(CHAT_CSS.includes(".copy-code-status"));
     assert.ok(CHAT_CSS.includes("#messageInput:focus-visible"));
   });
 
@@ -148,6 +149,7 @@ suite("chatAssets unit tests", () => {
     assert.ok(CHAT_JS.includes("requestInitialState"));
     assert.ok(CHAT_JS.includes('type: "sendMessage"'));
     assert.ok(CHAT_JS.includes("copy-code-button"));
+    assert.ok(CHAT_JS.includes("copy-code-status"));
     assert.ok(CHAT_JS.includes("navigator.clipboard.writeText"));
   });
 

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -135,7 +135,7 @@ suite("chatAssets unit tests", () => {
         ".code-block:hover .copy-code-button, .copy-code-button:focus-visible",
       ),
     );
-    assert.ok(CHAT_CSS.includes(".copy-code-status"));
+    assert.ok(CHAT_CSS.includes(".copy-status-sr"));
     assert.ok(CHAT_CSS.includes("#messageInput:focus-visible"));
   });
 
@@ -149,7 +149,7 @@ suite("chatAssets unit tests", () => {
     assert.ok(CHAT_JS.includes("requestInitialState"));
     assert.ok(CHAT_JS.includes('type: "sendMessage"'));
     assert.ok(CHAT_JS.includes("copy-code-button"));
-    assert.ok(CHAT_JS.includes("copy-code-status"));
+    assert.ok(CHAT_JS.includes("copy-status-sr"));
     assert.ok(CHAT_JS.includes("navigator.clipboard.writeText"));
   });
 

--- a/src/test/chatAssets.unit.test.ts
+++ b/src/test/chatAssets.unit.test.ts
@@ -135,7 +135,6 @@ suite("chatAssets unit tests", () => {
         ".code-block:hover .copy-code-button, .copy-code-button:focus-visible",
       ),
     );
-    assert.ok(CHAT_CSS.includes(".copy-status-sr"));
     assert.ok(CHAT_CSS.includes("#messageInput:focus-visible"));
   });
 
@@ -149,7 +148,6 @@ suite("chatAssets unit tests", () => {
     assert.ok(CHAT_JS.includes("requestInitialState"));
     assert.ok(CHAT_JS.includes('type: "sendMessage"'));
     assert.ok(CHAT_JS.includes("copy-code-button"));
-    assert.ok(CHAT_JS.includes("copy-status-sr"));
     assert.ok(CHAT_JS.includes("navigator.clipboard.writeText"));
   });
 

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,6 +63,8 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('aria-live="polite"'));
+    assert.ok(rendered.includes('aria-atomic="true"'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -63,8 +63,11 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
+    assert.ok(rendered.includes('class="copy-code-status"'));
+    assert.ok(rendered.includes('role="status"'));
     assert.ok(rendered.includes('aria-live="polite"'));
     assert.ok(rendered.includes('aria-atomic="true"'));
+    assert.ok(!rendered.includes('copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -62,13 +62,9 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes("<ul>"));
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
-    assert.ok(rendered.includes('title="Copy code"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
-    assert.ok(rendered.includes('class="copy-status-sr"'));
-    assert.ok(rendered.includes('role="status"'));
     assert.ok(rendered.includes('aria-live="polite"'));
     assert.ok(rendered.includes('aria-atomic="true"'));
-    assert.ok(!rendered.includes('copy-code-button" type="button" title="Copy code" aria-label="Copy code" aria-live'));
   });
 
   test("isGeneratingSessionState should detect active generation states", () => {

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -62,8 +62,9 @@ suite("Chat View Unit Test Suite", () => {
     assert.ok(rendered.includes("<ul>"));
     assert.ok(rendered.includes('class="code-block"'));
     assert.ok(rendered.includes('class="copy-code-button"'));
+    assert.ok(rendered.includes('title="Copy code"'));
     assert.ok(rendered.includes('aria-label="Copy code"'));
-    assert.ok(rendered.includes('class="copy-code-status"'));
+    assert.ok(rendered.includes('class="copy-status-sr"'));
     assert.ok(rendered.includes('role="status"'));
     assert.ok(rendered.includes('aria-live="polite"'));
     assert.ok(rendered.includes('aria-atomic="true"'));

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -20,6 +20,7 @@ p { margin: 0 0 8px; }
 .copy-code-button:hover { background: var(--vscode-button-secondaryHoverBackground); }
 .copy-code-button:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
 .copy-code-button:active { transform: scale(0.96); }
+.copy-code-status { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 @keyframes slide-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 .typing { display: none; align-items: center; gap: 4px; color: var(--vscode-descriptionForeground); font-size: 12px; font-style: italic; padding: 0 8px 8px; }
 .typing.visible { display: flex; }
@@ -386,7 +387,9 @@ export const CHAT_JS = `(function() {
     if (!copyButton || copyButton.hasAttribute("data-copy-feedback-active")) return;
     copyButton.setAttribute("data-copy-feedback-active", "true");
 
-    const code = copyButton.closest(".code-block").querySelector("code").innerText;
+    const codeBlock = copyButton.closest(".code-block");
+    const code = codeBlock.querySelector("code").innerText;
+    const status = codeBlock.querySelector(".copy-code-status");
     const originalText = copyButton.textContent;
     const originalTitle = copyButton.title;
     const originalAriaLabel = copyButton.getAttribute("aria-label");
@@ -396,12 +399,14 @@ export const CHAT_JS = `(function() {
       copyButton.title = text;
       const ariaLabel = text === "Copied" ? "Copied code" : text === "Failed" ? "Failed to copy code" : text;
       copyButton.setAttribute("aria-label", ariaLabel);
+      if (status) status.textContent = ariaLabel;
     }
 
     function restoreButtonState() {
       copyButton.textContent = originalText;
       if (originalTitle) { copyButton.title = originalTitle; } else { copyButton.removeAttribute("title"); }
       if (originalAriaLabel) { copyButton.setAttribute("aria-label", originalAriaLabel); } else { copyButton.removeAttribute("aria-label"); }
+      if (status) status.textContent = "";
       copyButton.removeAttribute("data-copy-feedback-active");
     }
 

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -20,7 +20,6 @@ p { margin: 0 0 8px; }
 .copy-code-button:hover { background: var(--vscode-button-secondaryHoverBackground); }
 .copy-code-button:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
 .copy-code-button:active { transform: scale(0.96); }
-.copy-status-sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 @keyframes slide-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 .typing { display: none; align-items: center; gap: 4px; color: var(--vscode-descriptionForeground); font-size: 12px; font-style: italic; padding: 0 8px 8px; }
 .typing.visible { display: flex; }
@@ -387,9 +386,7 @@ export const CHAT_JS = `(function() {
     if (!copyButton || copyButton.hasAttribute("data-copy-feedback-active")) return;
     copyButton.setAttribute("data-copy-feedback-active", "true");
 
-    const codeBlock = copyButton.closest(".code-block");
-    const code = codeBlock.querySelector("code").innerText;
-    const status = codeBlock.querySelector(".copy-status-sr");
+    const code = copyButton.closest(".code-block").querySelector("code").innerText;
     const originalText = copyButton.textContent;
     const originalTitle = copyButton.title;
     const originalAriaLabel = copyButton.getAttribute("aria-label");
@@ -397,16 +394,14 @@ export const CHAT_JS = `(function() {
     function setButtonState(text) {
       copyButton.textContent = text;
       copyButton.title = text;
-      const ariaLabel = text === "Copied" ? "Copied code" : text === "Failed" ? "Failed to copy code" : text === "Copy" ? "Copy code" : text;
+      const ariaLabel = text === "Copied" ? "Copied code" : text === "Failed" ? "Failed to copy code" : text;
       copyButton.setAttribute("aria-label", ariaLabel);
-      if (status) status.textContent = ariaLabel;
     }
 
     function restoreButtonState() {
       copyButton.textContent = originalText;
       if (originalTitle) { copyButton.title = originalTitle; } else { copyButton.removeAttribute("title"); }
       if (originalAriaLabel) { copyButton.setAttribute("aria-label", originalAriaLabel); } else { copyButton.removeAttribute("aria-label"); }
-      if (status) status.textContent = "";
       copyButton.removeAttribute("data-copy-feedback-active");
     }
 

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -394,7 +394,8 @@ export const CHAT_JS = `(function() {
     function setButtonState(text) {
       copyButton.textContent = text;
       copyButton.title = text;
-      copyButton.setAttribute("aria-label", text);
+      const ariaLabel = text === "Copied" ? "Copied code" : text === "Failed" ? "Failed to copy code" : text;
+      copyButton.setAttribute("aria-label", ariaLabel);
     }
 
     function restoreButtonState() {

--- a/src/webview/chatAssets.ts
+++ b/src/webview/chatAssets.ts
@@ -20,7 +20,7 @@ p { margin: 0 0 8px; }
 .copy-code-button:hover { background: var(--vscode-button-secondaryHoverBackground); }
 .copy-code-button:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
 .copy-code-button:active { transform: scale(0.96); }
-.copy-code-status { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.copy-status-sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 @keyframes slide-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 .typing { display: none; align-items: center; gap: 4px; color: var(--vscode-descriptionForeground); font-size: 12px; font-style: italic; padding: 0 8px 8px; }
 .typing.visible { display: flex; }
@@ -389,7 +389,7 @@ export const CHAT_JS = `(function() {
 
     const codeBlock = copyButton.closest(".code-block");
     const code = codeBlock.querySelector("code").innerText;
-    const status = codeBlock.querySelector(".copy-code-status");
+    const status = codeBlock.querySelector(".copy-status-sr");
     const originalText = copyButton.textContent;
     const originalTitle = copyButton.title;
     const originalAriaLabel = copyButton.getAttribute("aria-label");
@@ -397,7 +397,7 @@ export const CHAT_JS = `(function() {
     function setButtonState(text) {
       copyButton.textContent = text;
       copyButton.title = text;
-      const ariaLabel = text === "Copied" ? "Copied code" : text === "Failed" ? "Failed to copy code" : text;
+      const ariaLabel = text === "Copied" ? "Copied code" : text === "Failed" ? "Failed to copy code" : text === "Copy" ? "Copy code" : text;
       copyButton.setAttribute("aria-label", ariaLabel);
       if (status) status.textContent = ariaLabel;
     }

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,0 +1,3 @@
+pnpm run check-types
+pnpm run lint
+xvfb-run -a pnpm test

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-pnpm run check-types
-pnpm run lint
-xvfb-run -a pnpm test

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 pnpm run check-types
 pnpm run lint
 xvfb-run -a pnpm test


### PR DESCRIPTION
💡 What: コピーボタンに `aria-live="polite"` と `aria-atomic="true"` を追加し、状態変更時に `aria-label` をより詳細なテキスト（例: "Copied code"）に更新するようにしました。
🎯 Why: コピーボタンのテキストが「Copy」から「Copied」に動的に変更される際、スクリーンリーダーのユーザーに変更内容とそのコンテキストを明確に伝えるためです。
📸 Before/After: N/A (アクセシビリティの改善のみ)
♿ Accessibility: コピー操作の結果（成功/失敗）がスクリーンリーダーによって即座かつ適切に読み上げられるようになりました。

---
*PR created automatically by Jules for task [10006696707773931223](https://jules.google.com/task/10006696707773931223) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コピーボタンのアクセシビリティ改善として、`aria-live=\"polite\"` をボタン要素自体ではなく独立した `role=\"status\"` スパン（`.copy-status-sr`）に移動し、WAI-ARIA の推奨パターンに準拠した実装に変更しています。また、サニタイザーの `allowedAttributes` に `\"role\"` を追加し、新しいスパンの属性が sanitize-html を通過できるようにしています。

- コピー成功時は `setButtonState(\"Copied\")` が `aria-label` を \"Copied code\" に更新し、`.copy-status-sr` の `textContent` にも同文字列を書き込むことでスクリーンリーダーへ通知します。
- `restoreButtonState` は 1200ms 後にボタンの状態と `aria-label` を元に戻し、`.copy-status-sr` を空文字列でクリアします（再アナウンスは発生しません）。
- `clip: rect(0, 0, 0, 0)` への `clip-path: inset(50%)` の追加、`role` 属性の許可対象要素の絞り込み、二重アナウンスの可能性の検討などが小さな改善点として挙げられます。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は限定されたスコープ（コピーボタンのARIA実装）に留まり、既存機能を壊すリスクは低い。

WAI-ARIA の標準パターン（独立した role=status コンテナ）を正しく採用しており、以前指摘された aria-live のボタン直置き問題も解決されている。ロジックの変更はコピーハンドラー内に閉じており、テストも新しい属性を網羅している。

src/webview/chatAssets.ts の setButtonState 内の二重アナウンスの可能性、および src/chatView.ts のサニタイザーへの role 追加のスコープは確認しておくとよい。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/webview/chatAssets.ts | コピーボタンから aria-live を削除し、独立した role=status スパンを追加。setButtonState / restoreButtonState の両関数を更新してライブリージョンを適切に操作している。 |
| src/chatView.ts | マークダウンレンダラーの fence ルールに .copy-status-sr スパンを追加。サニタイザーの allowedAttributes に role を追加してスパンの属性が保持されるようにした。 |
| src/test/chatView.unit.test.ts | 新しい ARIA 属性と .copy-status-sr スパンがレンダリング結果に含まれることを検証するアサーションを追加。 |
| src/test/chatAssets.unit.test.ts | CHAT_CSS / CHAT_JS に .copy-status-sr が含まれることを確認するアサーションを追加。 |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as ユーザー
    participant Button as .copy-code-button
    participant SR as .copy-status-sr (role=status)
    participant Clip as navigator.clipboard

    User->>Button: クリック
    Button->>Button: data-copy-feedback-active 設定
    Button->>Clip: writeText(code)
    alt 成功
        Clip-->>Button: resolve
        Button->>Button: "aria-label = Copied code"
        Button->>SR: "textContent = Copied code"
        Note over SR: スクリーンリーダーが読み上げ
        Note over Button: 1200ms 後 restoreButtonState()
        Button->>Button: aria-label 復元
        Button->>SR: "textContent = """
    else 失敗
        Clip-->>Button: reject
        Button->>Button: "aria-label = Failed to copy code"
        Button->>SR: "textContent = Failed to copy code"
        Note over SR: スクリーンリーダーが読み上げ
        Note over Button: 1200ms 後 restoreButtonState()
        Button->>Button: aria-label 復元
        Button->>SR: "textContent = """
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as ユーザー
    participant Button as .copy-code-button
    participant SR as .copy-status-sr (role=status)
    participant Clip as navigator.clipboard

    User->>Button: クリック
    Button->>Button: data-copy-feedback-active 設定
    Button->>Clip: writeText(code)
    alt 成功
        Clip-->>Button: resolve
        Button->>Button: "aria-label = Copied code"
        Button->>SR: "textContent = Copied code"
        Note over SR: スクリーンリーダーが読み上げ
        Note over Button: 1200ms 後 restoreButtonState()
        Button->>Button: aria-label 復元
        Button->>SR: "textContent = """
    else 失敗
        Clip-->>Button: reject
        Button->>Button: "aria-label = Failed to copy code"
        Button->>SR: "textContent = Failed to copy code"
        Note over SR: スクリーンリーダーが読み上げ
        Note over Button: 1200ms 後 restoreButtonState()
        Button->>Button: aria-label 復元
        Button->>SR: "textContent = """
    end
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/webview/chatAssets.ts`, line 401-406 ([link](https://github.com/hiroki-org/jules-extension/blob/7df39fa4cf3ee3bcabf89a49ba92657bb0b1139c/src/webview/chatAssets.ts#L401-L406)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **restoreButtonState がライブリージョンの誤アナウンスを引き起こす**

   `aria-live="polite"` をボタン要素自体に設定したことで、`restoreButtonState` が1200ms後に `textContent` と `aria-label` を "Copy" / "Copy code" に戻す際にも、スクリーンリーダーが「Copy code」と再読み上げしてしまいます。ユーザーは「Copied code」の直後に意味のない「Copy code」を聞くことになり、このPRの目的であるアクセシビリティ向上と逆効果です。修正方法として、ボタンから `aria-live` を外し、別途 `role="status"` を持つ非表示の要素を用意してコピー成功時のみ更新する方法が推奨されます。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/webview/chatAssets.ts
   Line: 401-406

   Comment:
   **restoreButtonState がライブリージョンの誤アナウンスを引き起こす**

   `aria-live="polite"` をボタン要素自体に設定したことで、`restoreButtonState` が1200ms後に `textContent` と `aria-label` を "Copy" / "Copy code" に戻す際にも、スクリーンリーダーが「Copy code」と再読み上げしてしまいます。ユーザーは「Copied code」の直後に意味のない「Copy code」を聞くことになり、このPRの目的であるアクセシビリティ向上と逆効果です。修正方法として、ボタンから `aria-live` を外し、別途 `role="status"` を持つ非表示の要素を用意してコピー成功時のみ更新する方法が推奨されます。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: address copy feedback review thread..."](https://github.com/hiroki-org/jules-extension/commit/3e6db662e686f74c4ed2f91da9e466b4eab673e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41817756)</sub>

<!-- /greptile_comment -->