### PR TITLE
⚡ Bolt: 配列検索のパフォーマンス改善 (Setインスタンス化の回避)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // Bolt最適化: 単一の検索のためのSetのインスタンス化によるO(N)のメモリとCPUのオーバーヘッドを避けるため、Array.prototype.includesを使用
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // Bolt最適化: 単一の検索のためのSetのインスタンス化によるO(N)のメモリとCPUのオーバーヘッドを避けるため、Array.prototype.includesを使用
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `new Set(array).has(value)` を `array.includes(value)` に置き換えました。
🎯 Why: 単一の検索のためにSetをインスタンス化すると、不必要なO(N)のメモリ確保とハッシュ計算のオーバーヘッドが発生するためです。
📊 Impact: ブランチ検索時のメモリ割り当てとCPUオーバーヘッドが削減されます。
🔬 Measurement: コードレビューおよび自動テスト (`pnpm run test:unit`, `xvfb-run -a pnpm test`) の通過で確認。

---
*PR created automatically by Jules for task [14005031305604735168](https://jules.google.com/task/14005031305604735168) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ブランチ検索ロジックにおいて、単一検索のためだけに `new Set(array)` をインスタンス化していた箇所を `array.includes(value)` に置き換える最適化PRです。機能的な等価性は保たれており（どちらもSameValueZero比較）、不要なO(N)メモリ割り当てを削減する正当な改善です。

- `src/extension.ts` の2箇所で `new Set(remoteBranches).has(startingBranch)` → `remoteBranches.includes(startingBranch)` に変更。動作は完全に同一。
- 変更の説明として詳細なインラインコメント（\"Bolt最適化: ...\"）が2行追加されており、コードの可読性を下げているため削除を推奨します。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

動作は元のコードと完全に同一であり、マージしても問題ありません。

変更は `new Set(array).has(value)` を `array.includes(value)` に置き換えるだけで、両者は文字列に対してSameValueZero比較を使用するため動作は完全に等価です。追加されたインラインコメントは冗長ですが、ロジックに影響しません。

特に注意が必要なファイルはありません。`src/extension.ts` の変更箇所は局所的で影響範囲が明確です。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | ブランチ存在チェックを `new Set(array).has(value)` から `array.includes(value)` に変更。機能的には完全に等価だが、単一検索にSetを生成することで発生する不要なメモリ割り当てを解消する正当な最適化。追加されたインラインコメント2行が冗長でコードノイズになっている点のみ指摘。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ブランチ選択: startingBranch] --> B{remoteBranches.includes\nstartingBranch?}
    B -- "含まれる" --> E[currentRemoteBranches = remoteBranches]
    B -- "含まれない" --> C[リモートブランチを再取得\nforceRefresh: true]
    C --> D[currentRemoteBranches = freshBranchInfo.remoteBranches]
    D --> F{currentRemoteBranches.includes\nstartingBranch?}
    E --> F
    F -- "含まれる" --> G[セッション開始処理へ]
    F -- "含まれない" --> H[警告: ローカル専用ブランチ]
    H --> I{ユーザー選択}
    I -- "リモートブランチ作成" --> J[プッシュ処理]
    I -- "デフォルトブランチ使用" --> K[デフォルトブランチで続行]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ブランチ選択: startingBranch] --> B{remoteBranches.includes\nstartingBranch?}
    B -- "含まれる" --> E[currentRemoteBranches = remoteBranches]
    B -- "含まれない" --> C[リモートブランチを再取得\nforceRefresh: true]
    C --> D[currentRemoteBranches = freshBranchInfo.remoteBranches]
    D --> F{currentRemoteBranches.includes\nstartingBranch?}
    E --> F
    F -- "含まれる" --> G[セッション開始処理へ]
    F -- "含まれない" --> H[警告: ローカル専用ブランチ]
    H --> I{ユーザー選択}
    I -- "リモートブランチ作成" --> J[プッシュ処理]
    I -- "デフォルトブランチ使用" --> K[デフォルトブランチで続行]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/extension.ts:3261-3262
追加されたインラインコメントは、コードそのものが十分に自己説明的であり、PR説明に書くべき内容を重複して記述しています。既存のコードスタイルに合わせ、不要なノイズを避けるために削除することを推奨します。

```suggestion
        if (!remoteBranches.includes(startingBranch)) {
```

### Issue 2 of 2
src/extension.ts:3282-3283
2箇所目も同様に、インラインコメントは冗長です。`includes` は十分に意図が明確なAPIであるため、コメントは不要です。

```suggestion
        if (!currentRemoteBranches.includes(startingBranch)) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 配列検索のパフォーマンス改善 (Setインスタンス化の回避)"](https://github.com/hiroki-org/jules-extension/commit/930c28c34d7059d01d05c32a040861aa9cb23ebd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42092210)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->