### PR TITLE
🎨 Palette: 必須フィールドのアクセシビリティ向上

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-06-11 - Dynamic Empty State Announcers
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.
+
+## 2026-06-12 - 必須入力フィールドにおける required 属性の活用
+**Learning:** カスタムバリデーションで送信ボタンを無効化するだけでなく、ネイティブの `required` 属性を `<textarea>` や `<input>` に付与することで、スクリーンリーダーユーザーに対してフォームの必須性をセマンティックに伝え、アクセシビリティを大きく向上させることができます。
+**Action:** 必須となる入力フィールドには、JavaScriptによる検証の有無にかかわらず、常にHTMLのネイティブな `required` 属性を付与すること。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -510,7 +510,7 @@ export function getChatWebviewHtml(
     nonce +
     '">' +
     CHAT_CSS +
-    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
+    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)" required></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
     nonce +
     '" src="' +
     domPurifyScriptUri +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -240,7 +240,7 @@ export function getComposerHtml(
 </head>
 <body>
   <div id="sr-status" class="sr-only" aria-live="polite" aria-atomic="true"></div>
-  <textarea id="message" aria-label="${placeholder || 'Message input'}" placeholder="${placeholder}" autofocus>${value}</textarea>
+  <textarea id="message" aria-label="${placeholder || 'Message input'}" placeholder="${placeholder}" autofocus required>${value}</textarea>
   <div class="actions">
     ${createPrCheckbox}
     ${requireApprovalCheckbox}

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -142,7 +142,7 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("<title>&lt;Title&gt;</title>"));
       assert.ok(
         html.includes(
-          `<textarea id="message" aria-label="Your &quot;placeholder&quot;" placeholder="Your &quot;placeholder&quot;" autofocus>`
+          `<textarea id="message" aria-label="Your &quot;placeholder&quot;" placeholder="Your &quot;placeholder&quot;" autofocus required>`
         )
       );
       assert.ok(html.includes(">Initial &amp; value</textarea>"));


### PR DESCRIPTION
💡 What:
メッセージ入力欄 (`src/composer.ts` と `src/chatView.ts` の textarea) にHTMLネイティブの `required` 属性を追加しました。

🎯 Why:
スクリーンリーダーを利用するユーザーに対して、これらのフィールドが必須であることをセマンティックに伝えるためです。送信ボタンの無効化だけでなく、入力フィールド自体が必須であることを明示することで、アクセシビリティと直感的な操作性が向上します。

📸 Before/After:
(UI上の視覚的な変更はありませんが、スクリーンリーダーによる読み上げが改善されます)

♿ Accessibility:
カスタムバリデーションに依存せず、ネイティブの `required` 属性を用いることで、より堅牢なアクセシビリティを実現しました。

---
*PR created automatically by Jules for task [16584453395428596962](https://jules.google.com/task/16584453395428596962) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

スクリーンリーダーユーザー向けのアクセシビリティ向上を目的として、`src/composer.ts` と `src/chatView.ts` の `<textarea>` 要素にネイティブの `required` 属性を追加した小規模なPRです。

- **`src/composer.ts`**: `<form>` 要素を持たず送信ボタンも `type="button"` のため、`required` 属性はセマンティックな意味のみを持ち、ネイティブ制約バリデーションは発火しません。
- **`src/chatView.ts`**: `type="submit"` ボタンを持つ `<form>` 内にあるが、送信ボタンはテキストが空の間は常に `disabled` 状態に保たれるため、ブラウザのバリデーションポップアップが意図せず表示されることはありません。
- テストファイルが変更に合わせて更新され、`.Jules/palette.md` にも学習内容が記録されています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

既存のバリデーションロジックと競合しない最小限のアクセシビリティ改善であり、安全にマージできます。

`composer.ts` では `<form>` なし・全ボタンが `type="button"` のためネイティブ制約バリデーションは動作せず、`chatView.ts` では送信ボタンがテキスト空の間は常に `disabled` に保たれるため `required` によるバリデーションポップアップが意図せず表示される心配もありません。テストは変更に合わせて更新済みです。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | `<textarea>` に `required` 属性を追加。`<form>` 要素なし・ボタンは全て `type="button"` のため、ネイティブバリデーションは発火せず、スクリーンリーダー向けのセマンティックな変更のみ。 |
| src/chatView.ts | `<form>` 内の `<textarea>` に `required` 属性を追加。送信ボタンはテキスト空の間は `disabled` 維持のため、ネイティブバリデーションポップアップが意図せず表示されるリスクなし。 |
| src/test/composer.unit.test.ts | `required` 属性の追加に合わせてスナップショット文字列を更新。変更内容に完全に対応している。 |
| .Jules/palette.md | 必須フィールドへの `required` 属性付与に関する学習内容をドキュメントに追記。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(a11y): add required attribute to te..."](https://github.com/hiroki-org/jules-extension/commit/bd89ab51ac28efd7bba1a81f2d7eb4373432e453) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42102856)</sub>

<!-- /greptile_comment -->