### PR TITLE
🎨 Palette: 送信ボタンを制御する textarea に required 属性を追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,6 @@
 ## 2026-06-11 - Dynamic Empty State Announcers
 **Learning:** When dynamically inserting empty state indicators (e.g., "Ready to assist" or "Welcome to Jules" placeholder messages) into a chat or feed interface, screen readers might not immediately announce the new content if it is simply appended to the DOM. Adding `aria-live="polite"` and `aria-atomic="true"` directly to the container element ensures the screen reader announces the status change appropriately.
 **Action:** Whenever dynamically creating and injecting a completely new 'empty state' container to replace existing content, apply `aria-live="polite"` and `aria-atomic="true"` to the container so that users relying on assistive technology are immediately aware of the UI change.
+## 2026-07-07 - 送信ボタンを制御するtextareaへの required 属性追加
+**Learning:** 値が空の場合に送信ボタンが無効化されるアクセシブルなフォームでは、対応する入力要素(`<textarea>`や`<input>`)にネイティブの `required` 属性を明示的に追加することで、スクリーンリーダーに意味的なフィードバックを即座に提供できる。
+**Action:** 同様のパターンを実装する際は、スクリプトによる制御だけでなくネイティブの `required` 属性も併用する。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -510,7 +510,7 @@ export function getChatWebviewHtml(
     nonce +
     '">' +
     CHAT_CSS +
-    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
+    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" required aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)"></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
     nonce +
     '" src="' +
     domPurifyScriptUri +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -240,7 +240,7 @@ export function getComposerHtml(
 </head>
 <body>
   <div id="sr-status" class="sr-only" aria-live="polite" aria-atomic="true"></div>
-  <textarea id="message" aria-label="${placeholder || 'Message input'}" placeholder="${placeholder}" autofocus>${value}</textarea>
+  <textarea id="message" required aria-label="${placeholder || 'Message input'}" placeholder="${placeholder}" autofocus>${value}</textarea>
   <div class="actions">
     ${createPrCheckbox}
     ${requireApprovalCheckbox}

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -142,7 +142,7 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("<title>&lt;Title&gt;</title>"));
       assert.ok(
         html.includes(
-          `<textarea id="message" aria-label="Your &quot;placeholder&quot;" placeholder="Your &quot;placeholder&quot;" autofocus>`
+          `<textarea id="message" required aria-label="Your &quot;placeholder&quot;" placeholder="Your &quot;placeholder&quot;" autofocus>`
         )
       );
       assert.ok(html.includes(">Initial &amp; value</textarea>"));


### PR DESCRIPTION
💡 What: 送信ボタンの無効化状態と連動している `<textarea>` 要素（`src/composer.ts` および `src/chatView.ts`）に `required` 属性を追加しました。
🎯 Why: ユーザーが空の入力を行おうとした際に、スクリーンリーダーに意味的なフィードバックを即座に提供するため。
📸 Before/After: 見た目の変更はありません。
♿ Accessibility: スクリーンリーダーを使用するユーザーが、入力必須項目であることをネイティブのセマンティクスを通じて理解しやすくなりました。

---
*PR created automatically by Jules for task [17385863626576443976](https://jules.google.com/task/17385863626576443976) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

送信ボタンの無効化と連動している `<textarea>` 要素（`chatView.ts` および `composer.ts`）に `required` 属性を追加するアクセシビリティ改善PRです。既存のJavaScriptによるバリデーションには影響を与えず、スクリーンリーダーへのセマンティクス提供が目的です。

- `chatView.ts`の`<form id=\"composer\">`内のtextareaに `required` を追加。フォームの送信イベントハンドラーは `e.preventDefault()` を呼び出しているため、ネイティブ制約バリデーションとの干渉はありません。
- `composer.ts`のtextareaに `required` を追加。こちらは `<form>` 要素が存在せず、ボタンは `type=\"button\"` のため、純粋にスクリーンリーダー向けのセマンティクス付与となります。
- `composer.unit.test.ts` のスナップショットアサーションは `required` 属性を含む文字列に正しく更新されています。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージして問題ない変更です。既存のJavaScriptバリデーションやフォーム送信フローには影響がなく、スクリーンリーダー向けのセマンティクス追加が正しく実装されています。

`composer.unit.test.ts` は `required` 属性を反映した期待値に更新されていますが、`chatView.unit.test.ts` は同様の更新がなく、`getChatWebviewHtml` の出力に対するテストカバレッジに小さな欠けがあります。機能的な問題はなく、アクセシビリティ改善の実装自体は正確です。

`src/test/chatView.unit.test.ts` — `required` 属性を検証するアサーションの追加を検討してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | `<form>` 内の `<textarea>` に `required` を追加。`e.preventDefault()` が既に呼ばれているため機能的影響なし。対応するテストの更新が漏れている。 |
| src/composer.ts | `<form>` を持たないtextareaに `required` を追加。純粋なセマンティクス変更で、スクリーンリーダーへの意図通りの効果を持つ。 |
| src/test/composer.unit.test.ts | テストの期待値を `required` 属性を含む文字列に正しく更新。 |
| .Jules/palette.md | 今回の学習内容（`required` 属性によるアクセシビリティ改善のパターン）をパレットドキュメントに追記。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ユーザーがtextareaに入力] --> B{テキストが空?}
    B -- はい --> C[sendButton disabled=true]
    B -- いいえ --> D[sendButton disabled=false]
    C --> E[required属性によりスクリーンリーダーが「必須項目」を通知]
    D --> F[フォーム送信可能]
    F --> G[form submit イベント発火]
    G --> H[e.preventDefault 呼び出し]
    H --> I[vscode.postMessage でメッセージ送信]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ユーザーがtextareaに入力] --> B{テキストが空?}
    B -- はい --> C[sendButton disabled=true]
    B -- いいえ --> D[sendButton disabled=false]
    C --> E[required属性によりスクリーンリーダーが「必須項目」を通知]
    D --> F[フォーム送信可能]
    F --> G[form submit イベント発火]
    G --> H[e.preventDefault 呼び出し]
    H --> I[vscode.postMessage でメッセージ送信]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/chatView.ts:510-513
**chatView のテストが未更新**

`src/test/chatView.unit.test.ts` は `getChatWebviewHtml` をインポートしてHTMLを生成しているにもかかわらず、今回の `required` 属性の追加に対応するアサーションが追加されていません。`composer.unit.test.ts` では同様の期待値文字列が正しく更新されているため、`chatView.unit.test.ts` にも `messageInput` が `required` 属性を持つことを検証するテストを追加すると、将来の退行を防げます。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: 送信ボタンを制御する textarea に requir..."](https://github.com/hiroki-org/jules-extension/commit/0a3e68d615f34cf31d6af279ee790ed106cca8dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42396313)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->