### PR TITLE
⚡ Bolt: リモートブランチ存在確認時の無駄なSet生成を削減

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-07 - Avoid Set instantiations for single lookups
+**Learning:** `new Set(array).has(value)` is an anti-pattern for single membership checks. While `has()` is O(1), building the `Set` from an array is O(N) in both time and space, causing unnecessary garbage collection pressure and CPU overhead during frequent UI/state operations like branch switching.
+**Action:** Always prefer the native `array.includes(value)` for one-off membership checks. Only use `Set` when checking multiple items against a persistent collection.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,9 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: new Set(array).has() の代わりに array.includes() を使用し、
+        // 不必要なO(N)のメモリ割り当てとSetのインスタンス化を回避します。
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3280,9 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: new Set(array).has() の代わりに array.includes() を使用し、
+        // 不必要なO(N)のメモリ割り当てとSetのインスタンス化を回避します。
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `src/extension.ts` において、`new Set(array).has(value)` による単一要素の存在確認を `array.includes(value)` に置き換えました。
🎯 Why: 配列から `Set` を生成して1度だけ `has()` を呼ぶ処理は、不要な中間オブジェクトの割り当てとハッシュ計算を伴うためです。`includes()` を使用することで、O(N)のメモリ割り当てを回避し、CPUとメモリのオーバーヘッドを削減しました。
📊 Impact: ブランチ作成・切り替え時の一時的なメモリ確保とガベージコレクションの負荷が軽減され、処理がわずかに高速化されます。
🔬 Measurement: `pnpm run check-types`、`pnpm run lint`、および `xvfb-run -a pnpm test` による静的解析と自動テストにより機能に影響がないことを確認できます。

---
*PR created automatically by Jules for task [12952395560308955110](https://jules.google.com/task/12952395560308955110) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `src/extension.ts` 内のリモートブランチ存在確認ロジックにおいて、`new Set(array).has(value)` を `array.includes(value)` に置き換えるパフォーマンス最適化です。変更は2箇所に適用されており、動作の等価性は維持されています。

- `new Set(remoteBranches).has(startingBranch)` → `remoteBranches.includes(startingBranch)` に置き換え（2箇所）、一時的な `Set` オブジェクトの生成を回避し、メモリ割り当てを削減
- `.Jules/bolt.md` を追加し、Julesエージェント向けの学習ノートとして最適化の知見を記録
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は安全にマージ可能です。動作の等価性が保たれており、ロジックへの影響はありません。

コードの変更は意味的に完全に等価であり、`Array.includes()` と `Set.has()` はいずれも文字列比較において同じ結果を返します。追加された2箇所のインラインコメントがやや冗長で、読みやすさをわずかに損ねている点が唯一の指摘事項です。

特に要注意ファイルはありません。`src/extension.ts` の変更箇所は限定的で、ブランチ選択フローの2箇所のみです。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `new Set(array).has(value)` を `array.includes(value)` に置き換え（2箇所）。意味的に等価な変更であり、ロジックの破壊なし。追加されたインラインコメントはやや冗長。 |
| .Jules/bolt.md | Julesエージェント向けの学習ノートファイル。`Set` vs `includes()` の最適化パターンを記録したドキュメント。プロダクションコードへの影響なし。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ブランチ選択] --> B{remoteBranches.includes\nstartingBranch?}
    B -- true --> E[currentRemoteBranches = remoteBranches]
    B -- false --> C[リモートブランチを再取得\nforceRefresh: true]
    C --> D[currentRemoteBranches = freshBranchInfo.remoteBranches]
    D --> F{currentRemoteBranches.includes\nstartingBranch?}
    E --> F
    F -- true --> G[セッション開始処理へ]
    F -- false --> H[警告メッセージを表示\nローカル専用ブランチ]
    H --> I{ユーザー選択}
    I -- Create Remote Branch --> J[リモートブランチを作成]
    I -- Use Default Branch --> K[デフォルトブランチを使用]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ブランチ選択] --> B{remoteBranches.includes\nstartingBranch?}
    B -- true --> E[currentRemoteBranches = remoteBranches]
    B -- false --> C[リモートブランチを再取得\nforceRefresh: true]
    C --> D[currentRemoteBranches = freshBranchInfo.remoteBranches]
    D --> F{currentRemoteBranches.includes\nstartingBranch?}
    E --> F
    F -- true --> G[セッション開始処理へ]
    F -- false --> H[警告メッセージを表示\nローカル専用ブランチ]
    H --> I{ユーザー選択}
    I -- Create Remote Branch --> J[リモートブランチを作成]
    I -- Use Default Branch --> K[デフォルトブランチを使用]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/extension.ts:3261-3263
パフォーマンス最適化のコメントが2行にわたって追加されていますが、変更後のコード (`array.includes(value)`) はすでに意図が自明であり、これほど詳細な説明は不要です。通常の最適化メモはコードを読めば理解できるため、コメントを省略するか、より簡潔な一言にとどめることを推奨します。同様のコメントが3283〜3284行目にも存在します。

```suggestion
        if (!remoteBranches.includes(startingBranch)) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(extension): replace new Set().has()..."](https://github.com/hiroki-org/jules-extension/commit/6c03b94c9ecb8df136e52520dafbe4ca3f45460f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42397579)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->