### PR TITLE
⚡ Bolt: 単一検索での不要なSetインスタンス化を排除

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,15 +205,17 @@ export function mapApiStateToSessionState(apiState: string): SessionState {
   }
 }
 
+// Performance optimization: Move Set out of function to avoid O(N) allocation on every call
+const ACTIVE_SESSION_STATES = new Set([
+  "IN_PROGRESS",
+  "QUEUED",
+  "PLANNING",
+  "AWAITING_PLAN_APPROVAL",
+  "AWAITING_USER_FEEDBACK",
+]);
+
 function isSessionActive(session: Session): boolean {
-  const activeStates = new Set([
-    "IN_PROGRESS",
-    "QUEUED",
-    "PLANNING",
-    "AWAITING_PLAN_APPROVAL",
-    "AWAITING_USER_FEEDBACK",
-  ]);
-  return activeStates.has(session.rawState);
+  return ACTIVE_SESSION_STATES.has(session.rawState);
 }
 
 export interface CachedSessionState {
@@ -3258,7 +3260,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // Performance optimization: Avoid unnecessary O(N) Set instantiation for a single lookup
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3281,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // Performance optimization: Avoid unnecessary O(N) Set instantiation for a single lookup
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: 配列に特定の値が含まれているかどうかの判定において、`new Set(array).has(value)` を `array.includes(value)` に置き換えました。また、`isSessionActive` 関数内で毎回生成されていた `Set` をモジュールレベルの定数に移動しました。
🎯 Why: 単一の検索のためにわざわざ `Set` をインスタンス化するのは、メモリ割り当てと時間において無駄なオーバーヘッド（O(N)）を発生させるためです。
📊 Impact: リモートブランチの存在確認時の不要なメモリ割り当てと計算オーバーヘッドを削減しました。さらに、`isSessionActive` が呼び出されるたびの `Set` インスタンス化を防ぐことでパフォーマンスが向上します。
🔬 Measurement: コードレビューによって、`includes` の使用と定数化が正しく行われていることを確認します。既存のユニットテストおよびE2Eテストがパスすることを検証します。

---
*PR created automatically by Jules for task [11231318525379307880](https://jules.google.com/task/11231318525379307880) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `src/extension.ts` 内の2箇所のパフォーマンス最適化を行っています。単一検索用に毎回 `new Set(array).has(value)` を呼び出していた箇所を `array.includes(value)` に置き換え、また `isSessionActive` 関数内で呼び出されるたびに生成されていた `Set` をモジュールレベルの定数 `ACTIVE_SESSION_STATES` に移動しました。

- `isSessionActive` 関数内の `activeStates` を、モジュールレベル定数 `ACTIVE_SESSION_STATES` として切り出し、関数呼び出しごとの `Set` 生成コストを排除。
- リモートブランチ存在チェック2箇所で `new Set(array).has(value)` → `array.includes(value)` に置き換え、一度きりの検索における不要なメモリアロケーションを削減。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はすべて動作等価なリファクタリングであり、既存のロジックを変えないためマージしても安全です。

3箇所の変更はいずれも機能的に同等の置き換えです。`Array.includes` は `new Set().has()` と同じ厳密等価（===）で比較するため、戻り値の違いはありません。モジュールレベルに移した `ACTIVE_SESSION_STATES` は不変定数なのでテストへの影響もなく、`resetUpdatePreviousStatesCachesForTests` でリセットする必要もありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 3箇所のパフォーマンス最適化（`Set`→`includes`への置き換えと定数化）を適用。ロジックは同等で、メモリアロケーションを削減する安全な変更。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Perf: Eliminate unnecessary Set instanti..."](https://github.com/hiroki-org/jules-extension/commit/5e92d55ae43c1e383b0435493ba307168f1590f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42733487)</sub>

<!-- /greptile_comment -->