### PR TITLE
⚡ Bolt: [パフォーマンス改善] 不要なSetインスタンス化を排除し単一ルックアップを最適化

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // 1回のみの検索のためのSet生成のオーバーヘッドを避けるため、includesを使用する
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // 1回のみの検索のためのSet生成のオーバーヘッドを避けるため、includesを使用する
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What:
`src/extension.ts`内にある、単一の要素が含まれているか確認するための `new Set(array).has(value)` を `array.includes(value)` に変更しました。

🎯 Why:
1回のみの検索のために配列からSetをインスタンス化すると、メモリ割り当てやハッシュ化による不要な O(N) の時間および空間オーバーヘッドが発生します。これをネイティブの `includes()` に置き換えることで、オーバーヘッドを削減しパフォーマンスを向上させることができます。

📊 Impact:
Setのインスタンス化およびガベージコレクションのオーバーヘッドが削減され、メモリ使用量が低下し処理速度が向上します。

🔬 Measurement:
テストスイート (`pnpm run test:unit` および `xvfb-run -a pnpm test`) が正常に通過することを確認します。

---
*PR created automatically by Jules for task [9355074839567897634](https://jules.google.com/task/9355074839567897634) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

リモートブランチ存在チェックで使われていた `new Set(array).has(value)` を `array.includes(value)` に置き換えた2箇所の最適化PRです。1回限りのルックアップにSetを生成するのは確かに不要なアロケーションコストであり、変更のセマンティクスも完全に同一（両者とも SameValueZero 比較）です。

- `remoteBranches` および `currentRemoteBranches` の両ブランチ存在チェックで `includes()` を採用し、Set生成オーバーヘッドを排除。
- 変更に伴い最適化理由を説明するインラインコメントが追加されているが、`includes()` は自明なAPIであるため、このコメントはコードノイズになる可能性があります（提案コメント参照）。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は安全にマージ可能です。2箇所のブランチ存在チェックが includes() に置き換えられており、動作は変わりません。

new Set(array).has(value) から array.includes(value) への変更はセマンティクスが完全に同一で、ロジック上のリスクはゼロです。追加されたインラインコメントはスタイル上の好みの問題であり、機能への影響はありません。

特に注意が必要なファイルはありません。src/extension.ts の変更箇所は局所的で、ブランチ存在チェックのみに限定されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `new Set(array).has(value)` を `array.includes(value)` に置き換えた2箇所の変更。セマンティクスは完全に同一（SameValueZero比較）で安全な置き換え。ただし説明的すぎるインラインコメントが追加されており、コードノイズになっている。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ブランチ選択完了 startingBranch 取得] --> B{remoteBranches.includes startingBranch ?}
    B -- 含まれる --> D[currentRemoteBranches = remoteBranches]
    B -- 含まれない --> C[リモートブランチを再取得 forceRefresh: true]
    C --> D
    D --> E{currentRemoteBranches.includes startingBranch ?}
    E -- 含まれる --> F[セッション開始処理へ]
    E -- 含まれない --> G[ローカル専用ブランチの警告表示]
    G --> H{ユーザー選択}
    H -- Create Remote Branch --> I[リモートブランチ作成]
    H -- Use Default Branch --> J[デフォルトブランチへフォールバック]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ブランチ選択完了 startingBranch 取得] --> B{remoteBranches.includes startingBranch ?}
    B -- 含まれる --> D[currentRemoteBranches = remoteBranches]
    B -- 含まれない --> C[リモートブランチを再取得 forceRefresh: true]
    C --> D
    D --> E{currentRemoteBranches.includes startingBranch ?}
    E -- 含まれる --> F[セッション開始処理へ]
    E -- 含まれない --> G[ローカル専用ブランチの警告表示]
    G --> H{ユーザー選択}
    H -- Create Remote Branch --> I[リモートブランチ作成]
    H -- Use Default Branch --> J[デフォルトブランチへフォールバック]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/extension.ts:3261-3262
追加されたコメントが実装の詳細を過剰に説明しており、コードノイズになっています。`includes()` は自明なAPIであり、最適化理由をインラインで記述する必要はありません。また、直前の既存コメントブロック（3258〜3259行）が既にこのブロックの意図を説明しているため、重複感もあります。

```suggestion
        if (!remoteBranches.includes(startingBranch)) {
```

### Issue 2 of 2
src/extension.ts:3282-3283
同様に、2箇所目のコメントも不要です。`includes()` の選択理由をインラインに記述すると、将来のメンテナーにとって読み流す必要のあるノイズになります。

```suggestion
        if (!currentRemoteBranches.includes(startingBranch)) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: Optimize single lookups by avoid..."](https://github.com/hiroki-org/jules-extension/commit/571c5120bc97ac5602d06ae6de8416eac83b349a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43030059)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->