### PR TITLE
⚡ Bolt: 静的なSetのモジュールレベルへの引き上げと、不要なSet生成の削除によるパフォーマンス改善

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -54,3 +54,7 @@
 ## 2026-06-04 - [Performance] Optimize string prefix removal
 **Learning:** Using regular expressions like `.replace(/^sessions\//, '')` introduces unnecessary compilation and execution overhead compared to basic string operations.
 **Action:** When conditionally removing a fixed string prefix, prefer using `.startsWith()` combined with `.slice()` for better execution speed and reduced memory allocation.
+
+## 2026-07-10 - isSessionActiveのSetのモジュールレベルへの引き上げと、不要なSet生成の削減
+**Learning:** `isSessionActive` 内で毎回 `Set` をインスタンス化すると不要なメモリ割り当てとGCが発生していました。また、単一要素の存在確認のために `new Set(array).has(value)` を使用するのは、O(N)の時間と空間のオーバーヘッドを伴うアンチパターンでした。
+**Action:** 静的な `Set` やコレクションは関数の外（モジュールレベル）で初期化し、配列内の単一要素の検索には `new Set().has()` ではなくネイティブの `array.includes()` を使用するようにします。

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,15 +205,17 @@ export function mapApiStateToSessionState(apiState: string): SessionState {
   }
 }
 
+// ⚡ Bolt: `isSessionActive` 関数が頻繁に呼び出されるため、メモリ割り当てとGCのオーバーヘッドを防ぐためにSetをモジュールレベルに引き上げます。
+const ACTIVE_SESSION_STATES = new Set([
+  "IN_PROGRESS",
+  "QUEUED",
+  "PLANNING",
+  "AWAITING_PLAN_APPROVAL",
+  "AWAITING_USER_FEEDBACK",
+]);
+
 function isSessionActive(session: Session): boolean {
-  const activeStates = new Set([
-    "IN_PROGRESS",
-    "QUEUED",
-    "PLANNING",
-    "AWAITING_PLAN_APPROVAL",
-    "AWAITING_USER_FEEDBACK",
-  ]);
-  return activeStates.has(session.rawState);
+  return ACTIVE_SESSION_STATES.has(session.rawState);
 }
 
 export interface CachedSessionState {
@@ -3258,7 +3260,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: 配列の存在確認に `new Set(array).has(value)` を使用すると、毎回O(N)のメモリ割り当てが発生するため `array.includes(value)` に置き換えます。
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3281,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: 配列の存在確認に `new Set(array).has(value)` を使用すると、毎回O(N)のメモリ割り当てが発生するため `array.includes(value)` に置き換えます。
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `isSessionActive` 内の静的な `Set` の初期化をモジュールレベルに引き上げました。また、`remoteBranches` の存在確認における `new Set().has()` を `Array.prototype.includes()` に置き換えました。
🎯 Why: `isSessionActive` は頻繁に呼び出される関数であり、呼び出しごとに `Set` を再生成すると不要なメモリ割り当てとガベージコレクション（GC）のオーバーヘッドが発生します。また、単一の要素検索のために `new Set(array).has(value)` を使用すると、配列からセットへの変換で O(N) の時間と空間のオーバーヘッドが無駄に生じます。これらを最適化することで、メインスレッドのブロックを防ぎ効率を向上させます。
📊 Impact: `isSessionActive` の呼び出しごとのO(N)のメモリ割り当てコストをO(1)に削減しました。また、ブランチの存在確認時の不要なSetインスタンス化を排除し、処理速度とメモリ効率を向上させました。
🔬 Measurement: `pnpm run test:unit` および `xvfb-run -a pnpm test` を実行し、既存のセッション状態判定やブランチ切り替え処理にデグレがないことを確認します。

---
*PR created automatically by Jules for task [5016460401070589146](https://jules.google.com/task/5016460401070589146) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

頻繁に呼び出される `isSessionActive` 関数内の静的 `Set` をモジュールレベルに引き上げ、リモートブランチの存在確認における `new Set(array).has(value)` を `array.includes(value)` に置き換えることで、不要なメモリ割り当てとGCオーバーヘッドを削減するパフォーマンス改善PRです。

- `ACTIVE_SESSION_STATES` をモジュール定数として宣言し、`isSessionActive` 呼び出しごとのO(N)割り当てをO(1)に削減しています。Set内の文字列は変更されておらず、ロジックの等価性は保たれています。
- `remoteBranches` の2箇所の存在確認を `Array.prototype.includes()` に置き換え、Setオブジェクト生成のオーバーヘッドを排除しています。`includes()` と `Set.has()` はstring比較において同一の厳密等値（`===`）を使用するため、動作は完全に等価です。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

機能的には安全にマージ可能。最適化のロジックは等価であり、既存のテストでデグレがないことを確認できます。

両最適化の正確性は問題なく、`Set.has()` と `Array.includes()` の挙動は文字列に対して等価です。コードに追加された `// ⚡ Bolt:` プレフィックス付きコメントが既存のコメントスタイルと一致しておらず、同一内容のコメントが重複している点が気になります。

インラインコメントのスタイルを `src/extension.ts` で確認すると良いでしょう。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 静的な `Set` のモジュールレベルへの引き上げと `Array.prototype.includes()` への置き換えは、いずれもロジックの変更なしに正しく最適化されています。スタイル上の小さな懸念（`// ⚡ Bolt:` コメント）はありますが、機能的な問題はありません。 |
| .jules/bolt.md | Julesエージェントのラーニングログに今回の最適化に関するエントリが追加されています。内容は変更内容と一致しており、問題ありません。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["isSessionActive(session) 呼び出し"] --> B{"ACTIVE_SESSION_STATES.has\n(session.rawState)"}
    B -- true --> C["return true\n（セッションはアクティブ）"]
    B -- false --> D["return false\n（セッションは非アクティブ）"]

    E["モジュールロード時（1回のみ）"] --> F["ACTIVE_SESSION_STATES = new Set(\n  IN_PROGRESS, QUEUED, PLANNING,\n  AWAITING_PLAN_APPROVAL,\n  AWAITING_USER_FEEDBACK\n)"]
    F --> A

    G["startingBranch 存在確認"] --> H{"remoteBranches\n.includes(startingBranch)"}
    H -- false --> I["リモートブランチを再取得\nforceRefresh: true"]
    I --> J{"currentRemoteBranches\n.includes(startingBranch)"}
    J -- false --> K["ローカル専用ブランチの警告表示"]
    J -- true --> L["セッション開始処理へ"]
    H -- true --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["isSessionActive(session) 呼び出し"] --> B{"ACTIVE_SESSION_STATES.has\n(session.rawState)"}
    B -- true --> C["return true\n（セッションはアクティブ）"]
    B -- false --> D["return false\n（セッションは非アクティブ）"]

    E["モジュールロード時（1回のみ）"] --> F["ACTIVE_SESSION_STATES = new Set(\n  IN_PROGRESS, QUEUED, PLANNING,\n  AWAITING_PLAN_APPROVAL,\n  AWAITING_USER_FEEDBACK\n)"]
    F --> A

    G["startingBranch 存在確認"] --> H{"remoteBranches\n.includes(startingBranch)"}
    H -- false --> I["リモートブランチを再取得\nforceRefresh: true"]
    I --> J{"currentRemoteBranches\n.includes(startingBranch)"}
    J -- false --> K["ローカル専用ブランチの警告表示"]
    J -- true --> L["セッション開始処理へ"]
    H -- true --> J
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/extension.ts:3263
**`// ⚡ Bolt:` プレフィックスがコーディングスタイルと不一致**

既存のインラインコメント（例: `// キャッシュが古い場合、リモートに存在するブランチが...`）にはプレフィックスが付いておらず、`// ⚡ Bolt:` 形式は既存のスタイルと統一されていません。また、同一内容のコメントが3264行目と3284行目に重複しており、冗長です。ツール由来のメタデータ識別子を含む表記よりも、通常の日本語コメントに揃えた方がコードの保守性が向上します。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 静的なSetのモジュールレベルへの引き上げと、不要なSet生成の..."](https://github.com/hiroki-org/jules-extension/commit/72094640775c28476f08106d019fefa61cf1df8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43314760)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->