### PR TITLE
⚡ Bolt: 1回の検索における不要なSet生成のオーバーヘッド削減

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,9 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // 1回の要素確認のために new Set() を使用すると O(N) のメモリ割り当てとハッシュ化のオーバーヘッドが発生するため、
+        // .includes() を使用してパフォーマンスを最適化しています。
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3280,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // 同様に、不要な Set 生成を避けるため .includes() を使用して最適化
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `new Set(array).has(value)` を使用していた単一の検索処理を、`array.includes(value)` に置き換えました。
🎯 Why: `new Set` のインスタンス化はO(N)のメモリ割り当てとハッシュ化のオーバーヘッドを伴うため、1回の要素確認のみを行う場合は `includes` を使用する方が高速かつ効率的です。
📊 Impact: ブランチ選択時の不要なメモリ割り当てとガベージコレクションのオーバーヘッドが削減され、実行速度が向上します。
🔬 Measurement: テストスイート (`pnpm test`) が正常に通過し、ブランチ選択処理が従来通り機能することを確認します。

---
*PR created automatically by Jules for task [10385434986858668670](https://jules.google.com/task/10385434986858668670) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ブランチ選択処理において、1回限りの要素存在確認のために `new Set(array).has(value)` を使用していた2箇所を、`array.includes(value)` に置き換える最適化PRです。`Array.includes()` と `Set.has()` はどちらも文字列に対して厳密等価（`===`）で比較するため、動作は完全に同一です。

- `remoteBranches.includes(startingBranch)`（キャッシュチェック）と `currentRemoteBranches.includes(startingBranch)`（再取得後チェック）の2箇所を変更
- 各変更箇所に日本語コメントを追加し、最適化の意図を説明
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

シンプルで安全な変更です。`Array.includes()` は `Set.has()` と文字列に対して同一の動作をするため、機能的な退行リスクはありません。

変更は2箇所の単純な1行置き換えで、セマンティクスは完全に等価です。`Array.includes()` と `new Set().has()` はどちらも SameValueZero アルゴリズムで比較するため、ブランチ名（文字列）の検索において動作の差異はありません。既存のコメント・ログ出力はそのまま維持されており、パフォーマンス改善以外への影響はありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 2箇所の `new Set(array).has(value)` を `array.includes(value)` に置き換えるマイクロ最適化。セマンティクスは同一で、コメントも追記されており問題なし。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ブランチ選択] --> B{remoteBranches.includes\nstartingBranch}
    B -- "見つかった" --> E[currentRemoteBranches = remoteBranches]
    B -- "見つからない" --> C[リモートブランチを再取得\nforceRefresh: true]
    C --> D[currentRemoteBranches = 再取得結果]
    D --> F{currentRemoteBranches.includes\nstartingBranch}
    E --> F
    F -- "見つかった" --> G[セッション開始処理へ]
    F -- "見つからない（ローカル専用）" --> H[警告ダイアログ表示]
    H --> I{ユーザー選択}
    I -- "リモートブランチを作成" --> J[ブランチ作成処理]
    I -- "デフォルトブランチを使用" --> K[デフォルトブランチでセッション開始]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ブランチ選択] --> B{remoteBranches.includes\nstartingBranch}
    B -- "見つかった" --> E[currentRemoteBranches = remoteBranches]
    B -- "見つからない" --> C[リモートブランチを再取得\nforceRefresh: true]
    C --> D[currentRemoteBranches = 再取得結果]
    D --> F{currentRemoteBranches.includes\nstartingBranch}
    E --> F
    F -- "見つかった" --> G[セッション開始処理へ]
    F -- "見つからない（ローカル専用）" --> H[警告ダイアログ表示]
    H --> I{ユーザー選択}
    I -- "リモートブランチを作成" --> J[ブランチ作成処理]
    I -- "デフォルトブランチを使用" --> K[デフォルトブランチでセッション開始]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 1回の検索における不要なSet生成のオーバーヘッド削減"](https://github.com/hiroki-org/jules-extension/commit/7a7a25cc9a2768ce90215e7f8d6d5a6e8a34f673) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43640383)</sub>

<!-- /greptile_comment -->