### PR TITLE
⚡ Bolt: 配列操作とSet生成のパフォーマンス最適化

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // 単一のルックアップのためにSetを生成するのはO(N)のメモリとハッシュ化のオーバーヘッドがあるため、.includes() を使用します
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // 単一のルックアップのためにSetを生成するのはO(N)のメモリとハッシュ化のオーバーヘッドがあるため、.includes() を使用します
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,

--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -188,7 +188,11 @@ export async function recoverCorruptedActivities(
 
   // Optimize N+1 fetch by fetching activities in bulk via the paginated endpoint.
   // We process directly into a Map and shrink the search Set to avoid intermediate arrays.
-  const corruptedIds = new Set(corruptedActivities.map((a) => a.id));
+  // .map() による不要な中間配列の生成を避け、メモリ割り当てとガベージコレクションのオーバーヘッドを削減します
+  const corruptedIds = new Set<string>();
+  for (const a of corruptedActivities) {
+    corruptedIds.add(a.id);
+  }
   const recoveredMap = new Map<string, Activity>();
   let pageToken: string | undefined;
   const MAX_PAGES = 10;


### PR DESCRIPTION
💡 What: 
- `src/extension.ts`: 1回の検索のために `new Set(array).has()` を使用していた箇所を `array.includes()` に変更しました。
- `src/sessionUtils.ts`: `.map()` による中間配列の生成を避け、空の `Set` に `for...of` ループで直接値を追加するように変更しました。

🎯 Why: 
- 1回の検索のために `Set` をインスタンス化するのは、メモリの割り当てとハッシュ化の不要なオーバーヘッド（O(N)）を伴うためです。
- `new Set(array.map(...))` は不要な中間配列を生成し、メモリ割り当てとガベージコレクションのオーバーヘッドを増加させるためです。

📊 Impact: 不要なメモリ割り当てとガベージコレクションを削減し、単一ルックアップの処理速度を向上させます。

🔬 Measurement: `pnpm run lint` と `pnpm test` が正常に通過し、既存のテストでリグレッションがないことを確認。

---
*PR created automatically by Jules for task [14708161400772514640](https://jules.google.com/task/14708161400772514640) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、不要なメモリ割り当てを減らすための2件のマイクロ最適化を行っています。`extension.ts` では単一ルックアップ用の `new Set().has()` を `array.includes()` に、`sessionUtils.ts` では `new Set(array.map())` の中間配列を `for...of` ループで回避するよう変更しています。いずれも機能的に等価で、既存のテストで動作が確認されています。

- `extension.ts`: リモートブランチ存在チェックの2箇所で `new Set().has()` → `.includes()` に変更。同一内容のコメントが重複して追加されています。
- `sessionUtils.ts`: `corruptedIds` Set の構築を `for...of` ループで行い、`.map()` による中間配列の生成を回避。新しい日本語コメントが既存の英語コメントと同内容を重複して説明しています。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

両変更とも機能的に等価であり、マージしても安全です。

コードの変更自体は正確で安全です。2ファイルとも既存の動作を変えず、テストも通過しています。追加されたコメントに重複・混在の問題がありますが、実際の挙動への影響はありません。

特に注意が必要なファイルはありませんが、src/sessionUtils.ts の日本語・英語コメントの重複は整理を検討してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `new Set(array).has()` を `array.includes()` に置き換えた2箇所の変更。機能的に等価で安全。同一内容のコメントが2箇所に重複追加されている（スタイル上の指摘あり）。 |
| src/sessionUtils.ts | `new Set(array.map())` を `for...of` ループに置き換えて中間配列の生成を回避。機能的に等価で安全。日本語コメントが既存の英語コメントと重複している（スタイル上の指摘あり）。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["変更前"]
        A1["remoteBranches（配列）"] -->|"new Set(remoteBranches)"| B1["Set生成 O(N)メモリ確保"]
        B1 -->|".has(startingBranch)"| C1["ルックアップ"]
        A2["corruptedActivities"] -->|".map(a => a.id)"| B2["中間配列生成"]
        B2 -->|"new Set(...)"| C2["Set生成"]
    end
    subgraph After["変更後"]
        D1["remoteBranches（配列）"] -->|".includes(startingBranch)"| E1["直接ルックアップ O(N)"]
        D2["corruptedActivities"] -->|"for...of ループ"| E2["Set に直接追加\n中間配列なし"]
    end
    Before -.->|"最適化"| After
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before["変更前"]
        A1["remoteBranches（配列）"] -->|"new Set(remoteBranches)"| B1["Set生成 O(N)メモリ確保"]
        B1 -->|".has(startingBranch)"| C1["ルックアップ"]
        A2["corruptedActivities"] -->|".map(a => a.id)"| B2["中間配列生成"]
        B2 -->|"new Set(...)"| C2["Set生成"]
    end
    subgraph After["変更後"]
        D1["remoteBranches（配列）"] -->|".includes(startingBranch)"| E1["直接ルックアップ O(N)"]
        D2["corruptedActivities"] -->|"for...of ループ"| E2["Set に直接追加\n中間配列なし"]
    end
    Before -.->|"最適化"| After
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/sessionUtils.ts:189-195
**コメントの重複**

191行目に追加された日本語コメント（「中間配列の生成を避け…」）は、直前の英語コメント（190行目: "We process directly into a Map and shrink the search Set to avoid intermediate arrays."）と実質的に同じ内容を述べています。2言語で同じことを説明するコメントが並ぶと、将来の読み手が混乱したり、どちらかを更新し忘れて不整合が生じるリスクがあります。英語コメントに統合するか、どちらか一方に絞ることを検討してください。

### Issue 2 of 2
src/extension.ts:3261-3283
**同一コメントの重複**

3261行目と3282行目に、まったく同じ内容のコメント（「単一のルックアップのためにSetを生成するのはO(N)のメモリとハッシュ化のオーバーヘッドがあるため、.includes() を使用します」）が追加されています。同一説明を2か所に繰り返すよりも、最初の出現箇所のみに記載するか、コメントなしでコードの自明さに任せる方がノイズを減らせます。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 配列操作とSet生成のパフォーマンス最適化"](https://github.com/hiroki-org/jules-extension/commit/9a1d8ade857b81fe75d3630eb7f4de9c997fb721) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43841952)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->