### PR TITLE
⚡ Bolt: new Set().has()を.includes()に置き換えてメモリ割り当てを削減

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,9 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: new Set(array).has() の代わりに .includes() を使用し、
+        // 1回の検索のための不必要なO(N)のメモリ割り当てとハッシュ化のオーバーヘッドを削減します。
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3280,9 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: new Set(array).has() の代わりに .includes() を使用し、
+        // 1回の検索のための不必要なO(N)のメモリ割り当てとハッシュ化のオーバーヘッドを削減します。
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: 配列内の要素検索において、`new Set(array).has(value)` の代わりにネイティブの `array.includes(value)` を使用するようにリファクタリングしました。
🎯 Why: 1回の検索のために `Set` をインスタンス化すると、不必要なO(N)のメモリ割り当てとハッシュ化のオーバーヘッドが発生するためです。
📊 Impact: 中間オブジェクトの生成とガベージコレクションのオーバーヘッドを削減し、実行効率を向上させます。
🔬 Measurement: `pnpm run lint` と `xvfb-run -a pnpm test` を実行して既存機能に影響がないことを確認。

---
*PR created automatically by Jules for task [8319986415740070760](https://jules.google.com/task/8319986415740070760) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ブランチ存在確認ロジックにおいて `new Set(array).has()` を `array.includes()` に置き換えるシンプルなリファクタリングです。1回限りの検索に対してSetを生成するのは不要なオーバーヘッドであり、`includes()` への変更は機能的に等価かつメモリ効率が向上します。

- `src/extension.ts` の2箇所で `remoteBranches` と `currentRemoteBranches` の検索を `includes()` に統一
- 各変更箇所にO(N)メモリ削減を説明するインラインコメントが追加されたが、コードから自明なため冗長
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は小さく、動作に影響を与えない安全なリファクタリングです。

置き換えは機能的に同等で、`Set.has()` と `Array.includes()` はどちらも SameValueZero 比較を使用するため、ブランチ名（文字列）の検索動作は変わりません。追加されたインラインコメントが冗長なのは惜しいですが、ロジック自体に問題はありません。

特に問題のあるファイルはありませんが、`src/extension.ts` の追加コメントの削除を検討してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `new Set(array).has()` を `array.includes()` に置き換えるリファクタリング。2箇所で変更あり。動作は同等で、メモリ効率が改善されるが、追加されたインラインコメントが冗長。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ブランチ選択] --> B{remoteBranches.includes\nstartingBranch}
    B -- false --> C[リモートブランチを再取得\nforceRefresh: true]
    C --> D[currentRemoteBranches を更新]
    D --> E{currentRemoteBranches.includes\nstartingBranch}
    B -- true --> F[currentRemoteBranches = remoteBranches のまま]
    F --> E
    E -- true --> G[セッション開始処理へ]
    E -- false --> H[警告ダイアログ表示]
    H --> I{ユーザー選択}
    I -- Create Remote Branch --> J[リモートブランチを作成]
    I -- Use Default Branch --> K[デフォルトブランチを使用]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ブランチ選択] --> B{remoteBranches.includes\nstartingBranch}
    B -- false --> C[リモートブランチを再取得\nforceRefresh: true]
    C --> D[currentRemoteBranches を更新]
    D --> E{currentRemoteBranches.includes\nstartingBranch}
    B -- true --> F[currentRemoteBranches = remoteBranches のまま]
    F --> E
    E -- true --> G[セッション開始処理へ]
    E -- false --> H[警告ダイアログ表示]
    H --> I{ユーザー選択}
    I -- Create Remote Branch --> J[リモートブランチを作成]
    I -- Use Default Branch --> K[デフォルトブランチを使用]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/extension.ts:3261-3263
追加されたインラインコメントが冗長です。`includes()` を使っていることはコードを見れば明らかですし、O(N) のメモリ割り当てといった実装詳細はコードに埋め込むより PR 説明やコミットメッセージに留めるのが適切です。同様のコメントが2箇所に追加されていますが、いずれも削除して簡潔に保つことを推奨します。

```suggestion
        if (!remoteBranches.includes(startingBranch)) {
```

### Issue 2 of 2
src/extension.ts:3283-3285
同様に、2箇所目のインラインコメントも削除することを推奨します。コードの意図はコメントなしで十分伝わります。

```suggestion
        if (!currentRemoteBranches.includes(startingBranch)) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: new Set().has()を.includes()に置き換え..."](https://github.com/hiroki-org/jules-extension/commit/516c82678725b268be141055b6a3216b13a12aee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44158187)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->