### PR TITLE
⚡ Bolt: 単一検索時のSetインスタンス化オーバーヘッドの削減

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: 1回の検索のためにSetをインスタンス化するとO(N)のメモリと時間を消費するため、.includes()を使用
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: 1回の検索のためにSetをインスタンス化するとO(N)のメモリと時間を消費するため、.includes()を使用
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: 配列から値が存在するかを1回だけ確認する処理において、`new Set(array).has(value)` を `array.includes(value)` に置き換えました。
🎯 Why: 単一の検索のために `Set` を新しくインスタンス化すると、不要なメモリ確保（O(N)）やガベージコレクションのオーバーヘッドが発生するためです。
📊 Impact: 実行の度に発生する `Set` のインスタンス生成とハッシュ構築のオーバーヘッドがなくなり、メモリ使用量と実行時間の削減が期待できます。
🔬 Measurement: パフォーマンスプロファイラやメモリプロファイラを使用して、ブランチ選択時のメモリ確保量と実行時間を計測することで効果を確認できます。

---
*PR created automatically by Jules for task [13745498999496783307](https://jules.google.com/task/13745498999496783307) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

1回限りの存在確認のために `new Set(array).has(value)` を使っていた2箇所を `array.includes(value)` に置き換えるパフォーマンス最適化です。Set の生成コストは O(N) のメモリ確保とハッシュ構築を伴うため、単一検索では `includes()` が適切です。

- ブランチキャッシュの存在確認（1回目: `remoteBranches`）と、再取得後の確認（2回目: `currentRemoteBranches`）の両方を `includes()` に統一しました。
- 変更はコメントを追加して最適化の理由を明示しており、動作の正確性も維持されています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

シンプルな1行置き換えで、動作ロジックに変更はなく安全にマージできます。

変更はブランチ存在確認の2箇所のみで、`new Set(array).has(value)` を `array.includes(value)` に統一しただけです。どちらも線形探索であり戻り値の型・意味は完全に同一なため、動作の変化はありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | ブランチ存在確認の2箇所で `new Set(...).has()` を `Array.includes()` に置き換え。ロジックの変更なし、動作は同等。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ブランチ選択] --> B{remoteBranches.includes\nstartingBranch?}
    B -- "あり" --> E[currentRemoteBranches = remoteBranches]
    B -- "なし" --> C[リモートブランチを再取得\nforceRefresh: true]
    C --> D[currentRemoteBranches = freshBranchInfo.remoteBranches]
    D --> E
    E --> F{currentRemoteBranches.includes\nstartingBranch?}
    F -- "あり" --> G[セッション開始処理へ]
    F -- "なし" --> H[警告メッセージ表示\nリモートブランチなし]
    H --> I{ユーザー操作}
    I -- "Create Remote Branch" --> J[リモートブランチ作成]
    I -- "Use Default Branch" --> K[デフォルトブランチを使用]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ブランチ選択] --> B{remoteBranches.includes\nstartingBranch?}
    B -- "あり" --> E[currentRemoteBranches = remoteBranches]
    B -- "なし" --> C[リモートブランチを再取得\nforceRefresh: true]
    C --> D[currentRemoteBranches = freshBranchInfo.remoteBranches]
    D --> E
    E --> F{currentRemoteBranches.includes\nstartingBranch?}
    F -- "あり" --> G[セッション開始処理へ]
    F -- "なし" --> H[警告メッセージ表示\nリモートブランチなし]
    H --> I{ユーザー操作}
    I -- "Create Remote Branch" --> J[リモートブランチ作成]
    I -- "Use Default Branch" --> K[デフォルトブランチを使用]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor: replace new Set.has with Array..."](https://github.com/hiroki-org/jules-extension/commit/865daa306660c3fd023931b3a821d66a26014149) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44816302)</sub>

<!-- /greptile_comment -->