### PR TITLE
⚡ Bolt: 不要な Set のインスタンス化を排除しパフォーマンスを向上

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: 単一の要素の検索において、不要な O(N) の Set インスタンス化のメモリ割り当てとオーバーヘッドを避けるため、.includes() を使用します。
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: 単一の要素の検索において、不要な O(N) の Set インスタンス化のメモリ割り当てとオーバーヘッドを避けるため、.includes() を使用します。
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `src/extension.ts` 内の `new Set(array).has(value)` を `array.includes(value)` に置き換えました。
🎯 Why: 単一の値を検索する際に `Set` を生成すると、不要なメモリの割り当てとハッシュ化による O(N) のオーバーヘッドが発生するためです。
📊 Impact: ブランチの存在確認時のメモリ割り当てとガベージコレクションのオーバーヘッドを削減し、実行速度を向上させます。
🔬 Measurement: コードレビューによって、`Set` のインスタンス化が削除されていること、及び既存のテスト (`xvfb-run -a pnpm test`) が全てパスすることを確認しました。

---
*PR created automatically by Jules for task [4689694645725027853](https://jules.google.com/task/4689694645725027853) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

この PR は、ブランチ存在確認の単一値検索を軽くしています。

- `src/extension.ts` のリモートブランチ確認で `Set` 生成を削除。
- `Array.includes` を使って `startingBranch` の存在を確認。
- キャッシュ済み一覧と再取得後一覧の両方で同じ置き換えを適用。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | リモートブランチ一覧の存在確認 2 箇所で `new Set(...).has(...)` を `includes(...)` に置き換えています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 不要な Set のインスタンス化を排除しパフォーマンスを向上"](https://github.com/hiroki-org/jules-extension/commit/6d3fecaa2a73758e9a36841787364a224ab00da8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45109756)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))

<!-- /greptile_comment -->