### PR TITLE
🛡️ Sentinel: [HIGH] XSS防止のためのsanitize-htmlの許可スキーム設定

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** 相対パス (`path.relative`) とプレフィックス (`startsWith`) に依存したパス探索検証は、OS間のセパレーター (`/` vs `\`) の違いやエッジケースにより脆弱性 (`..config` の誤検知など) を生む可能性があります。
 **Learning:** ファイルパスが特定のディレクトリ内に収まっているかを安全に検証するには、`path.resolve` で絶対パス化した後、対象パスがルートディレクトリのパス + `path.sep` で始まるか、またはルートディレクトリと完全一致するかを検証するべきです。
 **Prevention:** 常に絶対パスのプレフィックス比較 (`candidatePath.startsWith(folderPath + path.sep) || candidatePath === folderPath`) を使用して境界チェックを実装します。
+
+## 2026-07-18 - sanitize-htmlのデフォルトスキーマ制限
+**Vulnerability:** sanitize-htmlのデフォルト設定ではプロトコル(URIスキーム)が十分に制限されておらず、不要なプロトコル(例: javascript:)を介したXSS(クロスサイトスクリプティング)のリスクがありました。
+**Learning:** sanitize-htmlはDOMPurifyほどプロトコル(URIスキーム)を厳格に制限しないため、明示的に指定しないと不要なプロトコルが許可される。
+**Prevention:** sanitize-htmlを使用する際は、必ず `allowedSchemes` および `allowedSchemesByTag` を設定し、安全なスキーム(http, https, vscode-webview-resource等)のみを許可する。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -136,6 +136,10 @@ const DEFAULT_SANITIZER_OPTIONS: sanitizeHtml.IOptions = {
     "listing",
     "plaintext",
   ],
+  allowedSchemes: ["http", "https", "mailto", "vscode-webview-resource"],
+  allowedSchemesByTag: {
+    img: ["http", "https", "data", "vscode-webview-resource"],
+  },
 };
 
 /**


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `sanitize-html`のデフォルト設定ではプロトコル(URIスキーム)が十分に制限されておらず、不要なプロトコル(例: javascript:)を介したXSS(クロスサイトスクリプティング)のリスクがありました。
🎯 Impact: 悪意のあるユーザーが細工したMarkdownを送信した場合、バックエンド側でレンダリング時に不正なプロトコルのリンクが生成され、クライアント側で実行される可能性があります。
🔧 Fix: `DEFAULT_SANITIZER_OPTIONS` に `allowedSchemes` と `allowedSchemesByTag` を追加し、`http`, `https`, `mailto`, `vscode-webview-resource` などの安全なプロトコルのみを許可するように制限しました。`<img>` タグの `src` 属性には `data:` スキームも許可しています。
✅ Verification:
- `pnpm run lint` が通過することを確認しました。
- `xvfb-run -a pnpm test` を実行し、既存のテストがすべて成功することを確認しました。

---
*PR created automatically by Jules for task [5129269974018605852](https://jules.google.com/task/5129269974018605852) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens URI scheme handling for sanitized chat Markdown. The main changes are:

- Added explicit `sanitize-html` scheme allowlists in `src/chatView.ts`.
- Allowed `data:` only for image sources in the host-side sanitizer.
- Added a Sentinel note about requiring explicit scheme restrictions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changed flow looks mergeable after aligning `data:` image handling across the sanitizers and CSP.

- Host-side scheme filtering moves in the safer direction.
- The remaining issue is a contained policy mismatch for image URLs.
- No direct executable XSS path was identified in the changed code.

src/chatView.ts
</details>

<details open><summary><h3>Security Review</h3></summary>

The change reduces exposure to unsafe URI schemes in host-side Markdown sanitization. One policy mismatch remains: `data:` images are allowed in `sanitize-html` but still blocked by the later webview sanitizer and CSP.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | Adds explicit URI scheme allowlists to the chat Markdown sanitizer, with a remaining mismatch around `data:` image handling. |
| .jules/sentinel.md | Adds a security learning note about explicit `sanitize-html` scheme restrictions. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/chatView.ts:141
**Data Images Are Still Blocked**

When Markdown contains an image such as `![x](data:image/png;base64,...)`, this new allowlist keeps the `data:` URL after the host-side sanitize step, but the webview-side DOMPurify URI policy still rejects `data:` before insertion. The chat webview CSP also lacks `img-src`, so the advertised `data:` image support remains broken unless the later sanitizer and CSP are updated to the same policy.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Configure allowedSchemes for sanitize-ht..."](https://github.com/hiroki-org/jules-extension/commit/bbb7f0736b94010e67697d8e38481a96fb76449f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45333148)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->