### PR TITLE
⚡ Bolt: [パフォーマンス改善] 不要なSet生成を削減しメモリ割り当てを最適化

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,15 +205,17 @@ export function mapApiStateToSessionState(apiState: string): SessionState {
   }
 }
 
+// ⚡ Bolt: `isSessionActive` が呼ばれるたびに `Set` を生成するオーバーヘッドを削減するため、モジュールレベルに定数を引き上げました。
+const ACTIVE_SESSION_STATES = new Set([
+  "IN_PROGRESS",
+  "QUEUED",
+  "PLANNING",
+  "AWAITING_PLAN_APPROVAL",
+  "AWAITING_USER_FEEDBACK",
+]);
+
 function isSessionActive(session: Session): boolean {
-  const activeStates = new Set([
-    "IN_PROGRESS",
-    "QUEUED",
-    "PLANNING",
-    "AWAITING_PLAN_APPROVAL",
-    "AWAITING_USER_FEEDBACK",
-  ]);
-  return activeStates.has(session.rawState);
+  return ACTIVE_SESSION_STATES.has(session.rawState);
 }
 
 export interface CachedSessionState {
@@ -3258,7 +3260,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: `new Set(array).has()` は O(N) の Set 生成コストとガベージコレクションのオーバーヘッドがかかるため `.includes()` に置き換えました。
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3281,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: `new Set(array).has()` を `.includes()` に置き換え、無駄なオブジェクト生成を削減しました。
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `isSessionActive` 関数内で毎回生成されていた `Set` をモジュールレベルの静的定数 (`ACTIVE_SESSION_STATES`) に引き上げました。また、リモートブランチの存在確認で使用されていた `new Set(array).has()` をネイティブの `array.includes()` に置き換えました。
🎯 Why: 関数呼び出しごとの `Set` 生成や、一回の存在確認のための `Set` インスタンス化は、O(N)のメモリ確保とガベージコレクションのオーバーヘッドを不必要に増加させるためです。
📊 Impact: 不要なオブジェクト生成を回避することでメモリ割り当てが削減され、UI描画やブランチ確認などの頻繁な処理のパフォーマンスが向上します。
🔬 Measurement: `pnpm run lint` および `xvfb-run -a pnpm test` を実行し、既存のセッション状態判定やブランチ判定機能に影響がないことを確認しました。

---
*PR created automatically by Jules for task [14956705512358511359](https://jules.google.com/task/14956705512358511359) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `src/extension.ts` の小さなパフォーマンス改善です。

- セッションのアクティブ状態一覧をモジュールレベルの定数へ移動。
- リモートブランチの存在確認を `Set.has` から `includes` に変更。
- 不要な `Set` 生成を避ける形に更新。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | セッション状態判定とリモートブランチ存在確認の不要な `Set` 生成を削減しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: \[パフォーマンス改善\] 不要なSet生成を削減しメモリ割り当てを..."](https://github.com/hiroki-org/jules-extension/commit/c59d3602ab9ed70a231601935225d9cda0cdda36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45333949)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
- Knowledge Base — [Extension Entrypoint (activate/deactivate)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/extension-entrypoint.md)
- Knowledge Base — [Git and GitHub Integration](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/git-and-github.md)
- Knowledge Base — [Session Management](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/session-management.md)
</details>

<!-- /greptile_comment -->