### PR TITLE
🛡️ Sentinel: [HIGH] XSS防止のためのsanitize-htmlのスキーマ制限の追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** 相対パス (`path.relative`) とプレフィックス (`startsWith`) に依存したパス探索検証は、OS間のセパレーター (`/` vs `\`) の違いやエッジケースにより脆弱性 (`..config` の誤検知など) を生む可能性があります。
 **Learning:** ファイルパスが特定のディレクトリ内に収まっているかを安全に検証するには、`path.resolve` で絶対パス化した後、対象パスがルートディレクトリのパス + `path.sep` で始まるか、またはルートディレクトリと完全一致するかを検証するべきです。
 **Prevention:** 常に絶対パスのプレフィックス比較 (`candidatePath.startsWith(folderPath + path.sep) || candidatePath === folderPath`) を使用して境界チェックを実装します。
+
+## 2026-07-20 - [sanitize-htmlのスキーマ設定脆弱性]
+**Vulnerability:** `allowedSchemes` と `allowedSchemesByTag` が明示的に設定されていない場合、sanitize-html はデフォルトで `javascript:` のような危険なスキーマを特定の属性に対して許可します。
+**Learning:** sanitize-html のURLスキーマに関するデフォルト設定は寛容すぎるため、リンクや画像ソースを通じたXSS攻撃を許す可能性があります。
+**Prevention:** `sanitize-html` を使用する際は、常に `allowedSchemes` と `allowedSchemesByTag` を明示的に設定して安全なスキーマのみを許可してください。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -127,6 +127,10 @@ const DEFAULT_SANITIZER_OPTIONS: sanitizeHtml.IOptions = {
     "*": ["class", "id", "data-*", "aria-*"],
     button: ["type", "title"],
   },
+  allowedSchemes: ["http", "https", "mailto", "vscode-webview-resource"],
+  allowedSchemesByTag: {
+    img: ["data", "http", "https", "vscode-webview-resource"],
+  },
   nonTextTags: [
     "script",
     "style",


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `sanitize-html`のデフォルト設定ではURLのスキーマ制限が緩く、特定の属性で`javascript:`のような危険なスキーマが許可される可能性があり、XSS攻撃に繋がる恐れがあります。
🎯 Impact: 悪意のあるユーザーが`javascript:`リンクなどを埋め込むことで、他のユーザーのブラウザ上で任意のスクリプトを実行されるリスクがあります。
🔧 Fix: `src/chatView.ts`の`DEFAULT_SANITIZER_OPTIONS`に`allowedSchemes`と`allowedSchemesByTag`を明示的に追加し、安全なスキーマのみを許可するように修正しました。
✅ Verification: `pnpm run lint`と`xvfb-run -a pnpm test`を実行し、変更が既存の機能を壊していないことを確認しました。

---
*PR created automatically by Jules for task [7148017984410827203](https://jules.google.com/task/7148017984410827203) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens URL sanitization for chat HTML.

- Adds explicit safe URI schemes to the chat sanitizer.
- Allows `data:` images only through the `img` tag-specific scheme list.
- Records the sanitize-html scheme hardening note in the sentinel document.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after a small sanitizer allowlist cleanup.

- No blocking issues found in the changed code.
- The only follow-up is a compatibility mismatch for a few benign link schemes already allowed by the webview layer.

src/chatView.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | Adds explicit sanitize-html URI scheme allowlists for chat rendering, with a small server/client scheme mismatch noted. |
| .jules/sentinel.md | Documents the sanitize-html scheme configuration issue and prevention guidance. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/chatView.ts:130-132
**Client Scheme Allowlist Drift**

When chat markdown includes a legitimate `tel:`, `sms:`, `callto:`, `cid:`, or `xmpp:` link, the server-side sanitizer now strips the `href` even though the webview sanitizer already treats those schemes as allowed. The rendered message can show link text that is no longer clickable, so the two chat sanitization layers no longer preserve the same safe URI set.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[HIGH\] XSS防止のためのsanitize-h..."](https://github.com/hiroki-org/jules-extension/commit/4077d9773a22d82e6d4a61b6b6c603a0ce7216f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45649574)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved HTML sanitization for chat and Markdown content.
  * Restricted links and images to approved URL schemes, helping prevent unsafe schemes such as `javascript:` from being rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->