### PR TITLE
⚡ Bolt: [Performance] Replace Set instantiation with array.includes for single lookups

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,7 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3278,7 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: Replaced `new Set(array).has(value)` with `array.includes(value)` for single element lookups in `src/extension.ts`.
🎯 Why: Instantiating a `Set` from an array just to perform a single `.has()` check introduces unnecessary O(N) memory allocation and iteration overhead. Using `array.includes()` directly on the array performs the same lookup without the extra memory footprint and GC pressure.
📊 Impact: Reduces memory allocations and GC overhead when validating branch selections, especially in repositories with many branches.
🔬 Measurement: Run the test suite (`xvfb-run -a pnpm test`) to ensure branch validation logic remains correct.

---
*PR created automatically by Jules for task [15891051504438781208](https://jules.google.com/task/15891051504438781208) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR simplifies the remote branch lookup in the extension command flow.

- Replaces `new Set(remoteBranches).has(startingBranch)` with `remoteBranches.includes(startingBranch)`.
- Applies the same lookup change after refreshing the remote branch cache.
- Keeps the existing branch validation flow unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The checked values are branch-name strings, where `includes` preserves the lookup behavior used by the previous code.
- Nearby branch validation code and tests already use the same lookup pattern.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | Branch existence checks now use `Array.includes` for the cached and refreshed remote branch arrays. |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: Replace Set instantiation with a..."](https://github.com/hiroki-org/jules-extension/commit/549d9c2f7ed92bc6d33cdb63e22f18351bd8a0cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45659785)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
- Knowledge Base — [Extension Entrypoint (activate/deactivate)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/extension-entrypoint.md)

<!-- /greptile_comment -->