### PR TITLE
⚡ Bolt: isSessionActive内のSetの不要な再生成を削減

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,15 +205,17 @@ export function mapApiStateToSessionState(apiState: string): SessionState {
   }
 }
 
+// パフォーマンスの最適化: 関数呼び出しごとのSet再生成（メモリ割り当てとGCのオーバーヘッド）を防ぐためモジュールレベルに移動
+const ACTIVE_SESSION_STATES = new Set([
+  "IN_PROGRESS",
+  "QUEUED",
+  "PLANNING",
+  "AWAITING_PLAN_APPROVAL",
+  "AWAITING_USER_FEEDBACK",
+]);
+
 function isSessionActive(session: Session): boolean {
-  const activeStates = new Set([
-    "IN_PROGRESS",
-    "QUEUED",
-    "PLANNING",
-    "AWAITING_PLAN_APPROVAL",
-    "AWAITING_USER_FEEDBACK",
-  ]);
-  return activeStates.has(session.rawState);
+  return ACTIVE_SESSION_STATES.has(session.rawState);
 }
 
 export interface CachedSessionState {


### PR DESCRIPTION
💡 What: `isSessionActive`関数内で毎回生成されていた`Set`オブジェクトをモジュールレベルの定数に移動させました。
🎯 Why: 関数が呼び出されるたびに`Set`がメモリに割り当てられ、ガベージコレクションのオーバーヘッドが発生していたため、パフォーマンスのボトルネックになる可能性があったからです。
📊 Impact: `isSessionActive`呼び出しごとのO(N)のメモリ割り当てがなくなり、実行速度とメモリ効率が向上します。
🔬 Measurement: `pnpm run lint` および `xvfb-run -a pnpm test` を実行し、すべてのテストがパスすることを確認します。

---
*PR created automatically by Jules for task [9734983243699564692](https://jules.google.com/task/9734983243699564692) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、セッションのアクティブ判定で使う状態一覧を共有定数に移動します。

- `isSessionActive` 内の `Set` 生成を削除。
- 同じ状態文字列を `ACTIVE_SESSION_STATES` としてモジュールレベルに定義。
- 呼び出しごとの不要な割り当てを避ける変更。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | `isSessionActive` の状態判定用 `Set` が、関数内生成からモジュールレベル定数へ移動されました。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Performance: Hoist activeStates Set out ..."](https://github.com/hiroki-org/jules-extension/commit/6ceb6ac5f0405b59a995bd53bcaccfe2184acce1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45970016)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
- Knowledge Base — [Extension Entrypoint (activate/deactivate)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/extension-entrypoint.md)

<!-- /greptile_comment -->