### PR TITLE
🛡️ Sentinel: [HIGH] sanitize-html のスキーム設定を修正してXSS脆弱性を防止

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,7 @@
 **Vulnerability:** 相対パス (`path.relative`) とプレフィックス (`startsWith`) に依存したパス探索検証は、OS間のセパレーター (`/` vs `\`) の違いやエッジケースにより脆弱性 (`..config` の誤検知など) を生む可能性があります。
 **Learning:** ファイルパスが特定のディレクトリ内に収まっているかを安全に検証するには、`path.resolve` で絶対パス化した後、対象パスがルートディレクトリのパス + `path.sep` で始まるか、またはルートディレクトリと完全一致するかを検証するべきです。
 **Prevention:** 常に絶対パスのプレフィックス比較 (`candidatePath.startsWith(folderPath + path.sep) || candidatePath === folderPath`) を使用して境界チェックを実装します。
+## 2026-07-21 - sanitize-html のスキーム設定を安全に設定
+**Vulnerability:** デフォルトの `sanitize-html` 設定はURIスキームの制限が緩く、カスタムプロトコルを通じたXSSのリスクがあります。
+**Learning:** VS CodeのWebview内で `sanitize-html` を使用する際は、`allowedSchemes` を明示的に設定し、安全なプロトコルのみを許可し、`allowedSchemesByTag` を使用して `data` URIを画像のみに制限する必要があります。
+**Prevention:** デフォルトに依存せず、常に `allowedSchemes`（例: `['http', 'https', 'mailto', 'vscode-webview-resource']`）と `allowedSchemesByTag`（例: `img` に対してのみ `data` を許可）を明示的に設定します。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -136,6 +136,10 @@ const DEFAULT_SANITIZER_OPTIONS: sanitizeHtml.IOptions = {
     "listing",
     "plaintext",
   ],
+  allowedSchemes: ["http", "https", "mailto", "vscode-webview-resource"],
+  allowedSchemesByTag: {
+    img: ["data", "http", "https", "vscode-webview-resource"],
+  },
 };
 
 /**


### PR DESCRIPTION
🚨 Severity: HIGH\n💡 Vulnerability: \`sanitize-html\` のデフォルト設定ではURIスキームの制限が緩く、予期せぬプロトコルを利用したXSSのリスクがあります。\n🎯 Impact: 悪意のあるユーザーがカスタムプロトコルを使用して、Webview内で任意のスクリプトを実行できる可能性があります。\n🔧 Fix: \`DEFAULT_SANITIZER_OPTIONS\` において \`allowedSchemes\` を明示的に設定し、許可するプロトコルを制限しました。また、\`allowedSchemesByTag\` を設定し、\`data\` スキームを \`img\` タグのみに制限しました。\n✅ Verification: \`pnpm run lint\` と \`xvfb-run -a pnpm test\` を実行し、すべてのテストがパスすることを確認しました。

---
*PR created automatically by Jules for task [5949840463567638815](https://jules.google.com/task/5949840463567638815) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、チャットWebviewのHTMLサニタイズ設定を明示的に絞ります。主な変更は以下です。

- `sanitize-html` の許可URIスキームを `http`、`https`、`mailto`、`vscode-webview-resource` に限定。
- `img` タグだけに `data` スキームを追加許可。
- Sentinelメモに今回のXSS対策の学習内容を追記。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | `DEFAULT_SANITIZER_OPTIONS` にURIスキーム制限が追加され、チャットWebviewへ渡すHTMLの許可範囲が狭まりました。 |
| .jules/sentinel.md | sanitize-htmlのスキーム設定に関するセキュリティ学習メモが追加されました。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: secure sanitize-html options to pre..."](https://github.com/hiroki-org/jules-extension/commit/666e7ebc203d05ea9b07ad5e9c2aa6823fc6eeb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45978106)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/hiroki-org/github/Hiroki-org/jules-extension/-/custom-context?memory=b33d4b65-e205-4323-8803-9f1b54e305f9))
- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->