### PR TITLE
⚡ Bolt: 不要なSetのインスタンス化を削減し、メモリ割り当てを最適化

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -213,7 +213,7 @@ const ACTIVE_SESSION_STATES = new Set([
   "AWAITING_USER_FEEDBACK",
 ]);
 
-function isSessionActive(session: Session): boolean {
+export function isSessionActive(session: Session): boolean {
   return ACTIVE_SESSION_STATES.has(session.rawState);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,15 +205,16 @@ export function mapApiStateToSessionState(apiState: string): SessionState {
   }
 }
 
+const ACTIVE_SESSION_STATES = new Set([
+  "IN_PROGRESS",
+  "QUEUED",
+  "PLANNING",
+  "AWAITING_PLAN_APPROVAL",
+  "AWAITING_USER_FEEDBACK",
+]);
+
 function isSessionActive(session: Session): boolean {
-  const activeStates = new Set([
-    "IN_PROGRESS",
-    "QUEUED",
-    "PLANNING",
-    "AWAITING_PLAN_APPROVAL",
-    "AWAITING_USER_FEEDBACK",
-  ]);
-  return activeStates.has(session.rawState);
+  return ACTIVE_SESSION_STATES.has(session.rawState);
 }
 
 export interface CachedSessionState {
@@ -3258,7 +3259,7 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,7 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,

--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -188,7 +188,10 @@ export async function recoverCorruptedActivities(
 
   // Optimize N+1 fetch by fetching activities in bulk via the paginated endpoint.
   // We process directly into a Map and shrink the search Set to avoid intermediate arrays.
-  const corruptedIds = new Set(corruptedActivities.map((a) => a.id));
+  const corruptedIds = new Set<string>();
+  for (const a of corruptedActivities) {
+    corruptedIds.add(a.id);
+  }
   const recoveredMap = new Map<string, Activity>();
   let pageToken: string | undefined;
   const MAX_PAGES = 10;

--- a/src/test/extension.isSessionActive.unit.test.ts
+++ b/src/test/extension.isSessionActive.unit.test.ts
@@ -1,0 +1,33 @@
+import * as assert from "assert";
+import { isSessionActive } from "../extension";
+import { Session } from "../types";
+
+suite("extension.ts - isSessionActive", () => {
+  test("should return true for active states", () => {
+    const states = [
+      "IN_PROGRESS",
+      "QUEUED",
+      "PLANNING",
+      "AWAITING_PLAN_APPROVAL",
+      "AWAITING_USER_FEEDBACK",
+    ];
+
+    for (const state of states) {
+      assert.strictEqual(isSessionActive({ rawState: state } as Session), true);
+    }
+  });
+
+  test("should return false for non-active states", () => {
+    const states = [
+      "COMPLETED",
+      "FAILED",
+      "CANCELLED",
+      "UNKNOWN_STATE",
+      "",
+    ];
+
+    for (const state of states) {
+      assert.strictEqual(isSessionActive({ rawState: state } as Session), false);
+    }
+  });
+});


### PR DESCRIPTION
💡 What:
- 配列の包含チェックにおける `new Set(array).has(value)` を `array.includes(value)` に置換。
- `isSessionActive` 関数の内部で静的に生成していた `Set` をモジュールレベルの定数に抽出。
- `new Set(array.map(...))` を `for...of` ループによる要素の追加にリファクタリング。

🎯 Why:
関数呼び出しや単一の検索のたびに発生していた不要なO(N)のメモリ割り当てと、ガベージコレクションのオーバーヘッドを削減するため。

📊 Impact:
余分な `Set` オブジェクトと中間配列の生成が排除され、ガベージコレクションの負担を軽減。メモリ効率が向上します。

🔬 Measurement:
`xvfb-run -a pnpm test` を実行し、既存のテストがすべて通過することを検証済み。

---
*PR created automatically by Jules for task [7719676292354505477](https://jules.google.com/task/7719676292354505477) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Set の不要な生成と中間配列の割り当てを削減する最適化です。
- セッションのアクティブ状態を表す Set をモジュールレベルの定数へ移動
- ブランチの包含判定を `Set.has` から `Array.includes` へ変更
- 破損アクティビティ ID の Set を中間配列なしで構築
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は既存の動作を維持した割り当て最適化であり、安全にマージできると考えます。

変更された包含判定はいずれも SameValueZero に基づく既存の比較動作を維持し、ID 収集のループも従来と同じ Set を構築するため、具体的な機能上の不具合は確認されませんでした。

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 状態およびブランチの包含判定について、既存の比較セマンティクスを維持しながら一時 Set の割り当てを削減しています。 |
| src/sessionUtils.ts | 破損アクティビティ ID の収集をループへ変更し、中間配列をなくしつつ既存の Set 内容を維持しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Optimize Set allocations to reduce memor..."](https://github.com/hiroki-org/jules-extension/commit/07ce14d952533d61e48d280565839b68e22ff018) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46690504)</sub>

<!-- /greptile_comment -->