### PR TITLE
⚡ Bolt: 単一検索での不要なSetインスタンス化を排除

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,8 +3258,7 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        // 単発の要素検索のため、無駄な O(N) の Set インスタンス化を避け .includes() を使用
-        if (!remoteBranches.includes(startingBranch)) {
+        if (!new Set(remoteBranches).has(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3279,8 +3278,7 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        // 同様に Set のインスタンス化を排除してパフォーマンスを改善
-        if (!currentRemoteBranches.includes(startingBranch)) {
+        if (!new Set(currentRemoteBranches).has(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // 単発の要素検索のため、無駄な O(N) の Set インスタンス化を避け .includes() を使用
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // 同様に Set のインスタンス化を排除してパフォーマンスを改善
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,

--- a/src/sessionUtils.ts
+++ b/src/sessionUtils.ts
@@ -188,7 +188,11 @@ export async function recoverCorruptedActivities(
 
   // Optimize N+1 fetch by fetching activities in bulk via the paginated endpoint.
   // We process directly into a Map and shrink the search Set to avoid intermediate arrays.
-  const corruptedIds = new Set(corruptedActivities.map((a) => a.id));
+  // 中間配列の生成を避けるため、.map()を使用せずにループ内で直接 Set に追加し、メモリ割り当てを最適化します
+  const corruptedIds = new Set<string>();
+  for (const a of corruptedActivities) {
+    corruptedIds.add(a.id);
+  }
   const recoveredMap = new Map<string, Activity>();
   let pageToken: string | undefined;
   const MAX_PAGES = 10;


### PR DESCRIPTION
💡 What: リモートブランチの存在チェックにおいて、`new Set(array).has(value)` を `array.includes(value)` に置き換えました。
🎯 Why: 単一の要素チェックのために毎回O(N)のメモリ割り当てとハッシュ計算を伴うSetを生成するのは非効率であるためです。
📊 Impact: リモートブランチ数に比例する無駄なメモリ割り当てとガベージコレクションのオーバーヘッドを削減し、ブランチ選択時のパフォーマンスを改善します。
🔬 Measurement: `pnpm run lint` および `xvfb-run -a pnpm test` にて既存機能が正常に動作することを確認済みです。ブランチ選択時の実行速度から改善が測定できます。

---
*PR created automatically by Jules for task [12421229738988155675](https://jules.google.com/task/12421229738988155675) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

リモートブランチの存在確認を、毎回 `Set` を生成する方式から配列を直接検索する方式へ変更しています。
- キャッシュ済みリモートブランチに選択ブランチが含まれるかの判定を `Array.includes()` に変更
- 再取得後のリモートブランチに対する同じ判定も `Array.includes()` に変更
- 判定対象はいずれも文字列配列であり、従来の `Set.has()` と同じ比較結果を維持
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

動作上の問題は確認されず、このPRは安全にマージできると考えられます。

対象値と配列要素はいずれも文字列であり、Set.has と Array.includes はこの経路で同じ SameValueZero 比較を行うため、キャッシュ再取得およびローカル専用ブランチ判定の結果は変わりません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 2か所の単一要素検索から一時的な Set の生成を除去しており、既存の分岐動作を維持しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 単一検索での不要なSetインスタンス化を排除"](https://github.com/hiroki-org/jules-extension/commit/8784d876ad4c3cff25f9bc3dcd7fa07a7ba8f8e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47376966)</sub>

<!-- /greptile_comment -->