### PR TITLE
⚡ Bolt: 配列の検索における不要な Set インスタンス化の排除

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: 単一の検索において new Set().has() の代わりに .includes() を使用し、不要な O(N) のメモリ割り当てを回避
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: 単一の検索において new Set().has() の代わりに .includes() を使用し、不要な O(N) のメモリ割り当てを回避
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `new Set(array).has(value)` を `array.includes(value)` に置き換えました。
🎯 Why: 単一要素の存在確認のためだけに O(N) の時間と空間を消費して Set をインスタンス化するのは非効率であるためです。
📊 Impact: 不要なメモリ割り当てとガベージコレクションのオーバーヘッドを削減し、パフォーマンスを向上させます。
🔬 Measurement: メモリプロファイラで配列からの不要な Set の作成が減少していることを確認できます。

---
*PR created automatically by Jules for task [13011027466113907786](https://jules.google.com/task/13011027466113907786) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`Set` の一時生成を避けつつ、ブランチ存在確認の意味論を維持する変更です。
- `remoteBranches` の単一要素検索を `Array.includes` に置き換え
- 再取得後の `currentRemoteBranches` に対しても同じ最適化を適用
- 最適化の意図を説明する日本語コメントを追加
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更は既存のブランチ存在判定を維持しており、安全にマージできると考えます。

`remoteBranches` と検索値はいずれも文字列であり、変更前後の検索方法は同じ一致判定を返すため、再取得やリモートブランチ警告の制御フローに機能上の差はありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 文字列配列の存在確認を `Set.has` から同じ SameValueZero 比較を行う `Array.includes` に変更しており、既存の分岐動作は維持されています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 配列の検索における不要な Set インスタンス化の排除"](https://github.com/hiroki-org/jules-extension/commit/c4dc1acdc9e6712a4154141c80ae9f9386502cca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47976459)</sub>

**Context used:**

- Knowledge Base — [Extension Entrypoint (activate/deactivate)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/extension-entrypoint.md)

<!-- /greptile_comment -->