### PR TITLE
🎨 Palette: 非同期処理中の無効化されたボタンの理由明示

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-28 - Update Disabled State Labels
+**Learning:** 非同期処理中にボタンを無効化する際、単に disabled 属性を付与するだけでは、スクリーンリーダーユーザーなどに無効化の理由が伝わらない。
+**Action:** 送信中のキャンセルボタンのように、動的に要素を無効化する場合は、常に title と aria-label を更新し、理由（例: 'Cannot cancel while sending'）を明示すること。

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -287,6 +287,8 @@ export function getComposerHtml(
       const cancelButton = document.getElementById('cancel');
       if (cancelButton) {
         cancelButton.disabled = true;
+        cancelButton.title = 'Cannot cancel while sending';
+        cancelButton.setAttribute('aria-label', 'Cannot cancel while sending');
       }
       document.body.style.cursor = 'wait';
 

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -608,6 +608,8 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("const cancelButton = document.getElementById('cancel');"));
       assert.ok(html.includes("if (cancelButton) {"));
       assert.ok(html.includes("cancelButton.disabled = true;"));
+      assert.ok(html.includes("cancelButton.title = 'Cannot cancel while sending';"));
+      assert.ok(html.includes("cancelButton.setAttribute('aria-label', 'Cannot cancel while sending');"));
       assert.ok(html.includes("document.body.style.cursor = 'wait';"));
     });
 


### PR DESCRIPTION
💡 What:
送信中にキャンセルボタンが無効化される際、`title` と `aria-label` を更新し、無効化されている理由（「Cannot cancel while sending」）を明示するようにしました。

🎯 Why:
スクリーンリーダーを利用しているユーザーやツールチップに依存しているユーザーに対し、ボタンが操作できない理由を明確に伝えるためです。これにより、単に無効化されている状態から「なぜ無効化されているか」という文脈を提供し、より親切なUXを実現します。

📸 Before/After:
Before: キャンセルボタンは無効化されるだけで理由は提示されない
After: キャンセルボタンに「Cannot cancel while sending」という `title` と `aria-label` が追加される

♿ Accessibility:
非同期処理中に動的にボタンを無効化する際に、視覚的・セマンティックな理由を追加しました。

---
*PR created automatically by Jules for task [4350809280982775525](https://jules.google.com/task/4350809280982775525) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

キャンセルボタンが送信中に無効化される理由を、視覚支援技術とツールチップの利用者へ明示する変更です。
- 送信開始時、キャンセルボタンの `title` と `aria-label` を「Cannot cancel while sending」に更新
- 新しい属性更新を確認する単体テストを追加
- 非同期処理中の無効状態に関するアクセシビリティ指針を `.jules/palette.md` に記録
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると判断します。

追加されたラベルはキャンセルボタンが無効になる送信処理中だけ設定され、送信メッセージ受信後にはパネルごと破棄されるため、通常状態へ誤ったラベルが残る経路はありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | 送信時に無効化されるキャンセルボタンへ、操作不能の理由を示す title と aria-label を設定しています。 |
| src/test/composer.unit.test.ts | 生成されるスクリプトに新しいアクセシビリティ属性の更新処理が含まれることを検証しています。 |
| .jules/palette.md | 動的に無効化するボタンでは、その理由を title と aria-label で説明する方針を追加しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add title and aria-label to disabl..."](https://github.com/hiroki-org/jules-extension/commit/e8cad04b23c20ef7d3f5e0c5765b58d6d6aa2819) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47986592)</sub>

<!-- /greptile_comment -->