### PR TITLE
⚡ Bolt: new Set(array).has() を array.includes() に置き換え

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: new Set(array).has() を array.includes() に置き換え、不要なメモリ割り当てとO(N)のオーバーヘッドを削減
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: new Set(array).has() を array.includes() に置き換え、不要なメモリ割り当てとO(N)のオーバーヘッドを削減
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `src/extension.ts` 内の `new Set(array).has()` を `array.includes()` に置き換えました。
🎯 Why: 単一の包含チェックのために Set をインスタンス化すると、不要な O(N) の時間とメモリのオーバーヘッドが発生するためです。
📊 Impact: 余分なメモリ割り当てと反復処理が排除され、実行速度がわずかに向上します。
🔬 Measurement: 既存のユニットテストを実行し、機能が維持されていることを確認しました。

---
*PR created automatically by Jules for task [762243736857565921](https://jules.google.com/task/762243736857565921) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

単発のリモートブランチ包含判定で Set を生成せず、配列を直接検索するように変更しています。
- `remoteBranches` のキャッシュ確認を `includes()` に置き換え
- 再取得後の `currentRemoteBranches` の確認も `includes()` に置き換え
- 両方の判定にパフォーマンス最適化の説明コメントを追加
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

挙動上は安全にマージできそうですが、追加されたパフォーマンスコメントの計算量説明は修正するとよいです。

Set の生成を `includes()` に置き換えても文字列配列の包含判定セマンティクスは維持されますが、コメントは線形探索コストまで削減されるかのように誤記しています。

**Files Needing Attention:** src/extension.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | Set の生成を避ける変更自体は SameValueZero に基づく包含判定の挙動を維持していますが、追加コメントは `includes()` にも残る O(N) の探索コストを削減すると誤って説明しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/extension.ts:3261
**線形探索コストの誤記**

`Array.includes()` も O(N) の線形探索であるため、このコメントは計算量まで削減されるかのように誤解を招きます。削減されるのは主に `Set` の生成と追加のメモリ割り当てであり、3282 行目の同じコメントも併せて説明を修正してください。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: Replace new Set(array).has() wit..."](https://github.com/hiroki-org/jules-extension/commit/e124810cfcc8d83a82fa90c90de056aef125534f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48715828)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->