### PR TITLE
🎨 Palette: 送信中のキャンセルボタンに無効化の理由を明示

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-31 - Add reasons to disabled states
+**Learning:** When disabling interactive elements (like buttons) during asynchronous operations, relying solely on the `disabled` state is insufficient. It is crucial to set the `title` and `aria-label` attributes to explicitly explain to all users why the element is disabled (e.g., 'Cannot cancel while sending').
+**Action:** Always verify if a disabled element requires an explanation and implement synchronous updates to its visual tooltip (`title`) and accessible label (`aria-label`).

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -287,6 +287,8 @@ export function getComposerHtml(
       const cancelButton = document.getElementById('cancel');
       if (cancelButton) {
         cancelButton.disabled = true;
+        cancelButton.title = 'Cannot cancel while sending';
+        cancelButton.setAttribute('aria-label', 'Cannot cancel while sending');
       }
       document.body.style.cursor = 'wait';
 

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -608,6 +608,8 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("const cancelButton = document.getElementById('cancel');"));
       assert.ok(html.includes("if (cancelButton) {"));
       assert.ok(html.includes("cancelButton.disabled = true;"));
+      assert.ok(html.includes("cancelButton.title = 'Cannot cancel while sending';"));
+      assert.ok(html.includes("cancelButton.setAttribute('aria-label', 'Cannot cancel while sending');"));
       assert.ok(html.includes("document.body.style.cursor = 'wait';"));
     });
 


### PR DESCRIPTION
💡 What: 送信中の非同期処理において、キャンセルボタンが無効化される際に `title` および `aria-label` を更新し、「送信中はキャンセルできません (Cannot cancel while sending)」という理由を明示的に伝えるようにしました。
🎯 Why: ボタンが単に `disabled` 状態になるだけでは、スクリーンリーダーなどの支援技術を利用するユーザーや一般ユーザーに対して、なぜ操作できないのかの理由が伝わらず、混乱を招くためです。
📸 Before/After: 非同期処理中に無効化されたボタンにツールチップによる理由の提示が追加され、スクリーンリーダーでも適切に理由が読み上げられるようになります。
♿ Accessibility: 無効化の理由を `title` と `aria-label` を用いて同期させることで、視覚的インターフェースと非視覚的インターフェースの双方に一貫したコンテキストを提供します。

---
*PR created automatically by Jules for task [14591439389987582581](https://jules.google.com/task/14591439389987582581) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

キャンセルボタンが送信中に無効化された際、その理由を利用者へ伝えるためのアクセシビリティ属性を追加します。
- 送信開始時のキャンセルボタンに `Cannot cancel while sending` という `title` と `aria-label` を設定
- 生成HTMLに新しい属性更新処理が含まれることを単体テストで確認
- 無効化された操作には理由を明示するというPaletteの学習事項を追加
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更は安全にマージできると考えられます。

既存の送信処理やキャンセル動作を変更せず、送信開始時に無効化されるボタンへ静的な説明属性を同期して追加しており、具体的な回帰やブロッキング要因は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | 送信開始時に無効化されるキャンセルボタンへ、無効化理由を示すtitleとaria-labelを追加しています。 |
| src/test/composer.unit.test.ts | 生成HTMLにキャンセルボタンのtitleおよびaria-label更新処理が含まれることを検証しています。 |
| .jules/palette.md | 非同期処理中に操作を無効化する場合の説明方針を記録しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: 送信中のキャンセルボタンに無効化の理由を明示"](https://github.com/hiroki-org/jules-extension/commit/ea088a33fef1ec1055fcffbf11bafeadd5e46404) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49059173)</sub>

<!-- /greptile_comment -->