### PR TITLE
🛡️ Sentinel: [CRITICAL] localResourceRootsの制限によるパストラバーサルの防止

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,7 @@
 **Vulnerability:** デフォルトの `sanitize-html` 設定はURIスキームの制限が緩く、カスタムプロトコルを通じたXSSのリスクがあります。
 **Learning:** VS CodeのWebview内で `sanitize-html` を使用する際は、`allowedSchemes` を明示的に設定し、安全なプロトコルのみを許可し、`allowedSchemesByTag` を使用して `data` URIを画像のみに制限する必要があります。
 **Prevention:** デフォルトに依存せず、常に `allowedSchemes`（例: `['http', 'https', 'mailto', 'vscode-webview-resource']`）と `allowedSchemesByTag`（例: `img` に対してのみ `data` を許可）を明示的に設定します。
+## 2024-05-25 - コンポーザーWebviewのローカルリソースアクセスの制限
+**Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
+**Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
+**Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -25,6 +25,7 @@ export async function showMessageComposer(
     {
       enableScripts: true,
       retainContextWhenHidden: true,
+      localResourceRoots: [],
     }
   );
 

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -89,6 +89,29 @@ suite("Composer Test Suite", () => {
       assert.ok(harness.panel.webview.html.includes("<title>Composer</title>"));
     });
 
+    test("should disable local resource access for the composer webview", async () => {
+      const harness = installPanelStub();
+      const createWebviewPanel = (vscode.window as any)
+        .createWebviewPanel as sinon.SinonStub;
+
+      const promise = showMessageComposer({ title: "Composer" });
+
+      sinon.assert.calledOnceWithExactly(
+        createWebviewPanel,
+        "julesMessageComposer",
+        "Composer",
+        vscode.ViewColumn.Active,
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          localResourceRoots: [],
+        }
+      );
+
+      harness.emitMessage({ type: "cancel" });
+      await promise;
+    });
+
     test("should resolve undefined on cancel", async () => {
       const harness = installPanelStub();
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: コンポーザーのWebviewパネルに `localResourceRoots` の制限がなく、ローカルファイルアクセスに対して脆弱でした。
🎯 Impact: 厳密に制限されていない場合、Webviewに注入された悪意のあるコンテンツによってパストラバーサルが発生し、ローカルリソースにアクセスされる可能性があります。
🔧 Fix: Webviewパネルを初期化する際に、明示的に `localResourceRoots: []` を設定しました。
✅ Verification: テストの実行、リンター、およびWebviewの動作を検査することで検証済み。

---
*PR created automatically by Jules for task [16904797435112663223](https://jules.google.com/task/16904797435112663223) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コンポーザーWebviewのローカルファイルアクセスを明示的に無効化する変更です。
- `createWebviewPanel` に `localResourceRoots: []` を追加
- Webview生成オプションを検証する単体テストを追加
- セキュリティ上の知見を Sentinel ドキュメントへ追記
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると考えられます。

ブロッキングとなる不具合は残っていません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | コンポーザーWebviewのローカルリソース参照を空の許可リストで明示的に禁止しています。 |
| src/test/composer.unit.test.ts | Webviewパネル生成時に制限済みオプションが正確に渡されることを検証しています。 |
| .jules/sentinel.md | Webviewのローカルリソース制限に関するセキュリティ指針を追記しています。 |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/hiroki-org/jules-extension/commit/a905df47307092cf0003bb9f2e7739f4faee04a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49062003)</sub>

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->