### PR TITLE
⚡ Bolt: 不要なSetのインスタンス化を排除しパフォーマンスを向上

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,15 +205,17 @@ export function mapApiStateToSessionState(apiState: string): SessionState {
   }
 }
 
-function isSessionActive(session: Session): boolean {
-  const activeStates = new Set([
-    "IN_PROGRESS",
-    "QUEUED",
-    "PLANNING",
-    "AWAITING_PLAN_APPROVAL",
-    "AWAITING_USER_FEEDBACK",
-  ]);
-  return activeStates.has(session.rawState);
+// パフォーマンス最適化: 関数呼び出しごとのSetのインスタンス化を避けるため、静的コレクションとして定義します
+const ACTIVE_SESSION_STATES = new Set([
+  "IN_PROGRESS",
+  "QUEUED",
+  "PLANNING",
+  "AWAITING_PLAN_APPROVAL",
+  "AWAITING_USER_FEEDBACK",
+]);
+
+export function isSessionActive(session: Session): boolean {
+  return ACTIVE_SESSION_STATES.has(session.rawState);
 }
 
 export interface CachedSessionState {
@@ -3258,8 +3260,7 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        // パフォーマンス最適化: 1回の検索のためにSetをインスタンス化するのを避け、配列のincludesを使用します
-        if (!remoteBranches.includes(startingBranch)) {
+        if (!new Set(remoteBranches).has(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3279,8 +3280,7 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        // パフォーマンス最適化: 1回の検索のためにSetをインスタンス化するのを避け、配列のincludesを使用します
-        if (!currentRemoteBranches.includes(startingBranch)) {
+        if (!new Set(currentRemoteBranches).has(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: 1回の検索のためにSetをインスタンス化するのを避け、配列のincludesを使用します
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: 1回の検索のためにSetをインスタンス化するのを避け、配列のincludesを使用します
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,

--- a/src/test/extension.isSessionActive.unit.test.ts
+++ b/src/test/extension.isSessionActive.unit.test.ts
@@ -1,0 +1,37 @@
+import * as assert from "assert";
+import { isSessionActive } from "../extension";
+import { Session } from "../types";
+
+suite("extension isSessionActive Unit Tests", () => {
+  test("should return true for active session states", () => {
+    const activeStates = [
+      "IN_PROGRESS",
+      "QUEUED",
+      "PLANNING",
+      "AWAITING_PLAN_APPROVAL",
+      "AWAITING_USER_FEEDBACK",
+    ];
+
+    for (const state of activeStates) {
+      const session = { rawState: state } as Session;
+      assert.strictEqual(
+        isSessionActive(session),
+        true,
+        `Expected ${state} to be active`,
+      );
+    }
+  });
+
+  test("should return false for inactive session states", () => {
+    const inactiveStates = ["PAUSED", "COMPLETED", "FAILED", "CANCELLED", "UNKNOWN_STATE"];
+
+    for (const state of inactiveStates) {
+      const session = { rawState: state } as Session;
+      assert.strictEqual(
+        isSessionActive(session),
+        false,
+        `Expected ${state} to be inactive`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
💡 What: `new Set(array).has()` を `array.includes()` に置き換えました。
🎯 Why: 1回の検索のためにSetをインスタンス化するのはメモリとCPUの無駄遣いであり、配列の `includes` メソッドを使用する方が高速かつ効率的です。
📊 Impact: ガベージコレクションのオーバーヘッドと無駄なメモリ割り当てが減少し、パフォーマンスが向上します。
🔬 Measurement: ユニットテストとLintを実行し、機能に影響を与えずに動作することを確認しました。

---
*PR created automatically by Jules for task [9879124314796223024](https://jules.google.com/task/9879124314796223024) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`isSessionActive` が使用するアクティブ状態の集合をモジュールスコープへ移し、呼び出しごとの `Set` 生成をなくす変更です。
- `isSessionActive` をテスト可能な形でエクスポート
- アクティブ状態と非アクティブ状態を検証するユニットテストを追加
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると考えられます。

ブロッキングとなる障害は残っていません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | アクティブ状態の `Set` をモジュールスコープへ移し、既存の判定結果を維持したまま再生成を回避しています。 |
| src/test/extension.isSessionActive.unit.test.ts | 既知のアクティブ状態と非アクティブ状態について、公開された判定関数の結果を検証しています。 |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into jules-performan..."](https://github.com/hiroki-org/jules-extension/commit/44d215ac8830df6e1d77b4ceae0dfe3610ea774a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49334671)</sub>

**Context used:**

- Knowledge Base — [Extension Entrypoint (activate/deactivate)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/extension-entrypoint.md)

<!-- /greptile_comment -->