### PR TITLE
🎨 Palette: タイピングインジケーターにツールチップを追加

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-01 - [Added explicit title tooltip to accessible typing indicator]
+**Learning:** While `aria-label` effectively communicates states like 'working' or 'typing' to screen reader users, sighted users relying on mouse hover might miss this context if visual indicators (like typing dots) are not immediately self-explanatory. Adding a native `title` attribute alongside `aria-label` provides a tooltip, ensuring visual clarity without overriding or conflicting with the accessibility label.
+**Action:** When creating animated or abstract visual indicators (like spinners or typing dots), provide both an `aria-label` for screen readers and a `title` for sighted mouse users.

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -514,7 +514,7 @@ export function getChatWebviewHtml(
     nonce +
     '">' +
     CHAT_CSS +
-    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)" required></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
+    '</style></head><body><div id="chat"></div><div id="typing" class="typing" aria-live="polite" aria-atomic="true" aria-label="Jules is working" title="Jules is currently typing or processing"><span>Jules is working</span><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div><form id="composer"><textarea id="messageInput" aria-label="Enter message" placeholder="Enter message (Ctrl/Cmd+Enter to send)" required></textarea><div class="composer-actions"><div id="sessionLabel" class="session-label" aria-live="polite" aria-atomic="true">Session: None selected</div><button id="sendButton" type="submit" aria-label="Send message" disabled>Send</button></div></form><script nonce="' +
     nonce +
     '" src="' +
     domPurifyScriptUri +


### PR DESCRIPTION
💡 What: チャット画面の「Jules is working」タイピングインジケーター（点滅するドット）に \`title\` 属性（ツールチップ）を追加しました。
🎯 Why: 現在、タイピングインジケーターにはスクリーンリーダー用の \`aria-label\` は設定されていますが、マウスユーザーに対する視覚的な説明（ツールチップ）が欠けていたため、ホバー時により明確な状態を伝えるために追加しました。
📸 Before/After: タイピングインジケーターをマウスオーバーすると「Jules is currently typing or processing」というツールチップが表示されるようになります。
♿ Accessibility: マウスユーザーに対する視覚的フィードバックが向上しました（既存の\`aria-label\`と競合せず併存します）。

---
*PR created automatically by Jules for task [15886427939434247684](https://jules.google.com/task/15886427939434247684) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

タイピングインジケーターに、マウスホバー時の状態説明を表示する静的な `title` 属性を追加しています。
- 既存の `aria-label` を維持しつつ、ネイティブツールチップを追加
- 今回のアクセシビリティ上の知見を `.jules/palette.md` に記録
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると判断します。

静的な title 属性の追加に限定され、既存の aria-label、WebviewのHTML構造、タイピング状態の制御を変更しておらず、具体的な不具合は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | タイピングインジケーターへ静的な title 属性を追加しており、既存のHTML生成や状態更新への悪影響は見当たりません。 |
| .jules/palette.md | aria-label と title を併用する意図および今回の変更内容を記録した文書です。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: Add tooltip to typing indica..."](https://github.com/hiroki-org/jules-extension/commit/ae4cebe8662685014df08aaefb8ef8c8a2e77a8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49336665)</sub>

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->