### PR TITLE
🎨 Palette: Composerの送信ボタン非活性時のフォーカス制御の改善

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+## 2024-08-04 - [Test]
+**Learning:** [Test]
+**Action:** [Test]
+## 2026-08-04 - ComposerのSubmit時のフォーカス制御
+**Learning:** 送信ボタンクリックなどにより非同期処理を開始した際、ボタンがdisabledになるとフォーカスが失われキーボード操作が途切れる問題がある。
+**Action:** 送信処理開始時に、もしアクティブな要素が送信ボタンだった場合は、入力用のtextareaにフォーカスを明示的に戻す（`if (document.activeElement === submitButton) { textarea.focus(); }`）ようにする。

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -268,6 +268,8 @@ export function getComposerHtml(
         return;
       }
 
+      const wasSubmitButtonFocused = document.activeElement === submitButton;
+
       submitButton.disabled = true;
       submitButton.textContent = 'Sending... ';
       const spinnerSpan = document.createElement('span');
@@ -299,6 +301,10 @@ export function getComposerHtml(
         createPR: createPrCheckbox ? createPrCheckbox.checked : false,
         requireApproval: requireApprovalCheckbox ? requireApprovalCheckbox.checked : false,
       });
+
+      if (wasSubmitButtonFocused) {
+        textarea.focus();
+      }
     };
 
     submitButton.addEventListener('click', submit);

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -595,6 +595,17 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("submitButton.addEventListener('click', submit);"));
     });
 
+    test("should explicitly return focus to textarea when submit button was focused", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("const wasSubmitButtonFocused = document.activeElement === submitButton;"));
+      assert.ok(html.includes("if (wasSubmitButtonFocused) {"));
+      assert.ok(html.includes("textarea.focus();"));
+    });
+
     test("validation should not interfere with cancel button functionality", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
💡 What: Composerの送信ボタンを押下した際、ボタンが非活性(disabled)になるとフォーカスが失われてしまう問題を修正し、明示的にテキストエリアにフォーカスを戻すようにしました。
🎯 Why: キーボード操作中に送信ボタンで処理を開始した際、フォーカスがドキュメント本体に落ちてしまい、連続した操作が困難になるキーボードアクセシビリティの問題を解決するためです。
📸 Before/After: （視覚的な変更はなし、フォーカス制御のみ）
♿ Accessibility: 送信ボタン非活性化時にフォーカスを失うことなく入力欄に戻るため、キーボードナビゲーションの連続性が保たれます。

---
*PR created automatically by Jules for task [10819364073168121538](https://jules.google.com/task/10819364073168121538) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

送信ボタンからメッセージを送った際、入力欄へフォーカスを戻す処理とその単体テストを追加しています。ただし、入力欄を無効化した後にフォーカスしているため、目的の復元処理は機能しません。
- 送信開始前に送信ボタンのフォーカス状態を保存
- 送信処理後、該当する場合に textarea.focus() を実行
- 生成HTMLにフォーカス処理が含まれることを確認するテストを追加
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

無効化済み textarea への focus() では目的のフォーカス復元が行われないため、修正してからマージする必要があります。

送信処理は textarea.disabled を true にした後で textarea.focus() を呼ぶため、送信ボタンから失われたフォーカスを入力欄へ移せず、追加テストもこの実行時挙動を検出できません。

**Files Needing Attention:** src/composer.ts、src/test/composer.unit.test.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | 送信ボタンのフォーカス状態を保存して入力欄へ戻す処理を追加したが、無効化済み textarea への focus() になっている。 |
| src/test/composer.unit.test.ts | フォーカス復元コードの存在を確認するテストを追加したが、実際のDOMフォーカス結果は検証していない。 |
| .jules/palette.md | 今回のフォーカス制御に関する学習事項と実装方針を記録している。 |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  actor User
  participant Button as 送信ボタン
  participant Submit as submit()
  participant Textarea as textarea
  participant Host as VS Codeホスト
  User->>Button: フォーカスして送信
  Button->>Submit: click
  Submit->>Submit: フォーカス状態を保存
  Submit->>Button: "disabled = true"
  Submit->>Textarea: "disabled = true"
  Submit->>Host: postMessage(submit)
  Submit->>Textarea: focus()
  Note over Textarea: disabled のためフォーカス不可
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/composer.ts:305-307
**無効な入力欄へのフォーカス復元**

送信ボタンにフォーカスがある状態で送信すると、先に `textarea.disabled = true` を設定してから `textarea.focus()` を呼ぶため、無効な入力欄はフォーカスを受け取れず、キーボードフォーカスが文書本体へ落ちたままになります。

### Issue 2
src/test/composer.unit.test.ts:598-607
**フォーカス結果を検証しないテスト**

このテストは生成HTML内の部分文字列だけを確認しており、インラインスクリプトを実行して `document.activeElement` を検証していません。そのため、現在のように無効な入力欄への `focus()` が効果を持たない実装でも成功し、目的のアクセシビリティ回帰を検出できません。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: Composerの送信ボタン非活性時のフォーカス制御の改..."](https://github.com/hiroki-org/jules-extension/commit/80a66bcdb837ab761b12a0b6ad21c7709f086d5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50094006)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->