### PR TITLE
⚡ Bolt: new Set().has()の呼び出しを.includes()に最適化してパフォーマンスを向上

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,9 +134,11 @@ export async function handleFilterActivitiesCommand(
   });
 
   if (selected !== undefined) {
-    const newFilter = new Set<ActivityCategory>(
-      selected.map((item) => item.label as ActivityCategory),
-    );
+    // ⚡ Bolt: new Set(array.map(...)) は中間配列を生成するため、for...of ループを使用して直接 Set に追加し、メモリ割り当てを最適化します。
+    const newFilter = new Set<ActivityCategory>();
+    for (const item of selected) {
+      newFilter.add(item.label as ActivityCategory);
+    }
     sessionsProvider.setActivityCategoryFilter(newFilter);
   }
 }
@@ -3258,8 +3260,7 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        // ⚡ Bolt: 配列の要素チェックに new Set(array).has() を使用すると、不要なメモリ割り当てとオーバーヘッドが発生するため、includes() を使用します。
-        if (!remoteBranches.includes(startingBranch)) {
+        if (!new Set(remoteBranches).has(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3279,8 +3280,7 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        // ⚡ Bolt: 配列の要素チェックに new Set(array).has() を使用すると、不要なメモリ割り当てとオーバーヘッドが発生するため、includes() を使用します。
-        if (!currentRemoteBranches.includes(startingBranch)) {
+        if (!new Set(currentRemoteBranches).has(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: 配列の要素チェックに new Set(array).has() を使用すると、不要なメモリ割り当てとオーバーヘッドが発生するため、includes() を使用します。
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: 配列の要素チェックに new Set(array).has() を使用すると、不要なメモリ割り当てとオーバーヘッドが発生するため、includes() を使用します。
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `src/extension.ts`において、配列内の要素の存在確認に使用されていた `new Set(array).has(value)` を、`array.includes(value)` に置換しました。

🎯 Why: 1回の検索のためにSetオブジェクトを生成すると、不要なメモリ割り当てと初期化（O(N)の空間・時間）のオーバーヘッドが発生します。これを `.includes()` に変更することで、オーバーヘッドを削減しパフォーマンスを向上させます。

📊 Impact: Setの生成に関するメモリ割り当てとガベージコレクションの負荷がなくなり、実行時のオーバーヘッドが削減されます。

🔬 Measurement: 変更後のLintおよびユニットテストが通過していることで確認できます。

---
*PR created automatically by Jules for task [9585477562096616704](https://jules.google.com/task/9585477562096616704) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`src/extension.ts` のブランチ存在確認を、一度限りの検索で `Set` を生成する実装から配列の直接検索へ変更しています。
- キャッシュ済みリモートブランチの確認に `Array.includes()` を使用
- 再取得後のリモートブランチの確認にも同じ最適化を適用
- 到達可能な入力に対する既存の判定 semantics を維持
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージして問題ないと判断します。

`remoteBranches` と再取得後の配列はいずれも `string[]` であり、対応ランタイム上の `Array.includes()` は従来の `Set.has()` と同じ存在判定結果を返すため、ブロッキングな不具合は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 2か所の一度限りのブランチ存在確認を `Set.has()` から `Array.includes()` へ置換しており、到達可能な `string[]` 入力では動作を維持しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: new Set().has()の呼び出しを.includes()..."](https://github.com/hiroki-org/jules-extension/commit/3301b2758e7151456cf910d57cd33821b1d58e7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50094276)</sub>

**Context used:**

- Knowledge Base — [Extension Entrypoint (activate/deactivate)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/extension-entrypoint.md)

<!-- /greptile_comment -->