### PR TITLE
🛡️ Sentinel: [MEDIUM] CSPヘッダーの強化 (object-src 'none' の追加)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,7 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+## 2026-08-06 - CSPの強化 (object-src 'none')
+**Vulnerability:** WebView内のContent-Security-Policyにおいて、`object-src` ディレクティブが欠落していた。
+**Learning:** `default-src 'none'` が設定されていても、明示的に `object-src 'none'` を指定することで、`<object>`, `<embed>`, `<applet>` タグを用いたプラグインの実行を確実に防ぐことができる。
+**Prevention:** 今後、新しいWebViewを追加する際は、必ずCSPに `object-src 'none'` を含めること。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WebView内の Content-Security-Policy (CSP) において、`object-src` ディレクティブが指定されていませんでした。
🎯 Impact: 悪意のあるユーザーが `<object>`, `<embed>`, `<applet>` タグを利用して、プラグイン（Flash, Javaなど）経由でスクリプトを実行するリスク（XSS等）がありました。
🔧 Fix: `src/composer.ts` と `src/chatView.ts` のCSPメタタグに `object-src 'none'` を明示的に追加しました。
✅ Verification: 自動テスト (`pnpm test`) がパスすることを確認しました。

---
*PR created automatically by Jules for task [4298662527732985006](https://jules.google.com/task/4298662527732985006) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

WebView の CSP を防御的に強化し、チャット画面とコンポーザーでプラグインコンテンツの読み込みを明示的に禁止する変更です。
- `src/chatView.ts` の CSP に `object-src 'none'` を追加
- `src/composer.ts` の CSP に `object-src 'none'` を追加
- `.jules/sentinel.md` に今回のセキュリティ対策と今後の予防策を記録
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は安全にマージできると判断します。

変更は両 WebView の既存 CSP に制限的な `object-src 'none'` を追加するだけで、許可済みリソースや nonce の設定を変更しておらず、具体的な不具合は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット WebView の CSP に `object-src 'none'` を正しく追加しており、既存のスクリプト・スタイル・DOMPurify 読み込みには影響しません。 |
| src/composer.ts | コンポーザー WebView の CSP に `object-src 'none'` を正しく追加しており、既存の nonce ベースのインラインスクリプトとスタイルを維持しています。 |
| .jules/sentinel.md | CSP 強化の内容と、新規 WebView に対する予防方針を追記しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add object-src &#39;none&#39; to CSP in Webviews"](https://github.com/hiroki-org/jules-extension/commit/b6caace76e1bc383fc76c78bebbeee3e54208b66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50862046)</sub>

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->