### PR TITLE
⚡ Bolt: 単一要素の検索における不要なSetのインスタンス化を削除

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: Setのインスタンス化によるメモリ割り当てとオーバーヘッドを避けるため、単一の検索には.includes()を使用します。
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // ⚡ Bolt: 単一要素の存在確認における不要なO(N)のメモリ割り当てを避けるため、.includes()を使用します。
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `src/extension.ts` 内で単一要素の存在確認を行う際に使用されていた `new Set(array).has(value)` を `array.includes(value)` に置き換えました。
🎯 Why: `new Set(array)` は、一度の検索のためだけに配列全体の反復処理とハッシュ化、そしてメモリの動的割り当てを伴うため、パフォーマンスのオーバーヘッドとなります。これを `includes` に変更することで、不要なO(N)のメモリ割り当てとガベージコレクションの負荷を回避します。
📊 Impact: 一度の検索ごとのSetの割り当てによる時間とメモリのオーバーヘッドが削減されます。
🔬 Measurement: `pnpm run lint` と `pnpm test` が正常に通過することを確認します。

---
*PR created automatically by Jules for task [6877378801297013929](https://jules.google.com/task/6877378801297013929) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`src/extension.ts` のリモートブランチ存在確認を、単発検索のための `Set` 生成から `Array.includes` に変更しています。
- キャッシュ済みリモートブランチに対する存在確認を最適化
- 強制再取得後のリモートブランチに対する存在確認も同様に最適化
- 現実的な `string[]` 入力における判定の意味論は維持
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

具体的な機能不具合やセキュリティ上の問題は確認されず、このPRは安全にマージできると考えます。

`remoteBranches` は文字列配列として生成され、`Set.has` と `Array.includes` はこの経路の現実的な入力に対して同じ存在判定を行うため、キャッシュ再取得やローカル専用ブランチ判定の動作は維持されます。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 2か所の単一要素検索から一時的な `Set` 生成を除去しており、既存のブランチ存在判定を維持した安全な最適化です。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 単一要素の検索における不要なSetのインスタンス化を削除"](https://github.com/hiroki-org/jules-extension/commit/0fbf3a3af8b79c3b5bd7c60af0debb5c70e7a814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50865200)</sub>

**Context used:**

- Knowledge Base — [Extension Entrypoint (activate/deactivate)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/extension-entrypoint.md)

<!-- /greptile_comment -->