### PR TITLE
⚡ Bolt: 不要なSetインスタンス化を排除して配列検索を最適化

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,8 +3258,7 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        // パフォーマンス最適化: O(N)のSet生成オーバーヘッドを回避するためincludesを使用
-        if (!remoteBranches.includes(startingBranch)) {
+        if (!new Set(remoteBranches).has(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3279,8 +3278,7 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        // パフォーマンス最適化: O(N)のSet生成オーバーヘッドを回避するためincludesを使用
-        if (!currentRemoteBranches.includes(startingBranch)) {
+        if (!new Set(currentRemoteBranches).has(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3258,7 +3258,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: O(N)のSet生成オーバーヘッドを回避するためincludesを使用
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3278,7 +3279,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: O(N)のSet生成オーバーヘッドを回避するためincludesを使用
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,

--- a/src/inlineCommands.ts
+++ b/src/inlineCommands.ts
@@ -239,13 +239,11 @@ export async function handleInlineTask(
         remoteBranches,
     } = branchInfo;
 
-    const remoteBranchSet = new Set(remoteBranches);
-
-    // Performance optimization: Avoid chained .filter().map() to reduce intermediate array allocations.
+    // パフォーマンス最適化: O(N)のSet生成オーバーヘッドを回避するためincludesを使用
     // We combine the filtering and mapping into a single pass using a for...of loop.
     const quickPickItems: vscode.QuickPickItem[] = [];
     for (const branch of branches) {
-        if (remoteBranchSet.has(branch)) {
+        if (remoteBranches.includes(branch)) {
             quickPickItems.push({
                 label: branch,
                 picked: branch === selectedDefaultBranch,


### PR DESCRIPTION
💡 What: 配列内の単一要素の存在確認において、`new Set(array).has(value)` を `array.includes(value)` に置き換えました。
🎯 Why: `new Set()` を実行するたびに配列の全要素に対して不要なメモリ割り当てとハッシュ化のオーバーヘッド（O(N)の時間と空間）が発生していましたが、単一の検索であれば `includes()` の方が高速かつメモリ効率が良いためです。
📊 Impact: ブランチの存在確認時の不必要なオブジェクト生成（メモリ割り当てとガベージコレクションの負担）と実行時間を削減します。
🔬 Measurement: ローカル環境で実行し、エラーなくブランチ選択が機能すること、およびテストスイートが通過することを確認しました。

---
*PR created automatically by Jules for task [18129937919338707458](https://jules.google.com/task/18129937919338707458) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

キャッシュ済みおよび再取得後のリモートブランチ存在確認を、都度生成する `Set` から配列の `includes` に置き換える最適化です。
- 単一回の検索で不要だった `Set` の生成とメモリ割り当てを排除
- キャッシュ未登録時の再取得処理と、ローカル専用ブランチの警告処理は従来どおり維持
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

動作上の問題は確認されず、安全にマージできる変更です。

対象値は文字列配列と文字列であり、`includes` は従来の一時的な `Set` による存在確認と同じ判定結果を返します。実行環境も同APIをサポートし、キャッシュ再取得およびローカル専用ブランチの各経路は維持されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 2か所の文字列配列の存在確認を、同値な `includes` 呼び出しへ安全に置き換えています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 不要なSetインスタンス化を排除して配列検索を最適化"](https://github.com/hiroki-org/jules-extension/commit/776c032b71955839c9337721cda08acddeb4c960) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51259727)</sub>

**Context used:**

- Knowledge Base — [Extension Entrypoint (activate/deactivate)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/extension-entrypoint.md)

<!-- /greptile_comment -->