### PR TITLE
🎨 Palette: 送信中の入力フィールドとチェックボックスの非活性状態に対するUX・アクセシビリティ改善

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-08-08 - Accessible disabled states on form elements with labels
+**Learning:** When dynamically adding an `aria-label` to explain a disabled state (e.g., "Cannot change while sending") on an element that previously relied on a linked `<label>` for its accessible name, the new `aria-label` will completely override the `<label>`. This causes the user to lose context of what the element is.
+**Action:** When updating `aria-label` for disabled states on elements with visible labels, concatenate the original label text with the disabled explanation (e.g., `Create PR automatically? (Cannot change while sending)`), or use `aria-description` if appropriate, to maintain context.

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -279,11 +279,17 @@ export function getComposerHtml(
       const srStatus = document.getElementById('sr-status');
       if (srStatus) srStatus.textContent = 'Sending message...';
       textarea.disabled = true;
+      textarea.title = 'Cannot edit message while sending';
+      textarea.setAttribute('aria-label', 'Cannot edit message while sending');
       if (createPrCheckbox) {
         createPrCheckbox.disabled = true;
+        createPrCheckbox.title = 'Cannot change PR setting while sending';
+        createPrCheckbox.setAttribute('aria-label', 'Create PR automatically? (Cannot change while sending)');
       }
       if (requireApprovalCheckbox) {
         requireApprovalCheckbox.disabled = true;
+        requireApprovalCheckbox.title = 'Cannot change approval setting while sending';
+        requireApprovalCheckbox.setAttribute('aria-label', 'Require plan approval before execution? (Cannot change while sending)');
       }
       const cancelButton = document.getElementById('cancel');
       if (cancelButton) {

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -628,6 +628,8 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("if (srStatus) srStatus.textContent = 'Sending message...';"));
       assert.ok(html.includes("submitButton.disabled = true;"));
       assert.ok(html.includes("textarea.disabled = true;"));
+      assert.ok(html.includes("textarea.title = 'Cannot edit message while sending';"));
+      assert.ok(html.includes("textarea.setAttribute('aria-label', 'Cannot edit message while sending');"));
       assert.ok(html.includes("const cancelButton = document.getElementById('cancel');"));
       assert.ok(html.includes("if (cancelButton) {"));
       assert.ok(html.includes("cancelButton.disabled = true;"));
@@ -672,8 +674,12 @@ suite("Composer Test Suite", () => {
       );
       assert.ok(html.includes("if (createPrCheckbox) {"));
       assert.ok(html.includes("createPrCheckbox.disabled = true;"));
+      assert.ok(html.includes("createPrCheckbox.title = 'Cannot change PR setting while sending';"));
+      assert.ok(html.includes("createPrCheckbox.setAttribute('aria-label', 'Create PR automatically? (Cannot change while sending)');"));
       assert.ok(html.includes("if (requireApprovalCheckbox) {"));
       assert.ok(html.includes("requireApprovalCheckbox.disabled = true;"));
+      assert.ok(html.includes("requireApprovalCheckbox.title = 'Cannot change approval setting while sending';"));
+      assert.ok(html.includes("requireApprovalCheckbox.setAttribute('aria-label', 'Require plan approval before execution? (Cannot change while sending)');"));
     });
   });
 });


### PR DESCRIPTION
💡 What:
メッセージ送信中に非活性（disabled）になるテキストエリアとチェックボックスに対して、単に非活性にするだけでなく、具体的な理由を説明する `title` および `aria-label` 属性を動的に追加しました。

🎯 Why:
インタラクティブ要素が非活性になった際、視覚的なフィードバック（カーソル変更や透明度低下）だけでなく、スクリーンリーダーなどの支援技術を利用するユーザーや、ツールチップを確認するユーザーに対しても、「なぜ操作できないのか（例：送信中のため変更不可）」という具体的な理由を明示することで、混乱を防ぎ一貫したUXを提供するためです。また、チェックボックスの `aria-label` を上書きする際、元のラベルの内容（例：「Create PR automatically?」）を維持することで、コンテキストの喪失を防いでいます。

📸 Before/After:
Before: `textarea.disabled = true;`
After: `textarea.disabled = true; textarea.title = 'Cannot edit message while sending'; textarea.setAttribute('aria-label', 'Cannot edit message while sending');`

♿ Accessibility:
非活性状態の理由をスクリーンリーダーで確実に読み上げさせるため、`aria-label` と `title` を更新しました。また、既存の `<label>` に依存する要素に対しては、文脈を失わないように元の名前を `aria-label` に含めました。

---
*PR created automatically by Jules for task [16004460797339445511](https://jules.google.com/task/16004460797339445511) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

メッセージ送信中に無効化される composer の入力欄とチェックボックスへ、操作できない理由を示す `title` と `aria-label` を追加しています。
- チェックボックスでは既存の設定名を accessible name に維持しています。
- 生成 HTML に新しいアクセシビリティ属性が含まれることを単体テストで確認しています。
- 今回の変更による具体的な不具合は確認されませんでした。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は既存の送信フローを壊しておらず、安全にマージできると判断します。

composer は送信後に破棄される一回限りの画面であり、追加された属性は無効状態と一致し、チェックボックスの既存ラベル文脈も維持されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | 送信時に無効化される textarea と任意のチェックボックスへ、状態の理由を示す静的な title および aria-label を追加しています。 |
| src/test/composer.unit.test.ts | composer の生成 HTML に追加された各アクセシビリティ属性が含まれることを検証しています。 |
| .jules/palette.md | aria-label で disabled 理由を追加する際も、元の accessible name を維持する方針を記録しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: 送信中の入力フィールドとチェックボックスの非活性状態に対..."](https://github.com/hiroki-org/jules-extension/commit/2bb88ef3377e5fdc649cacc0e7feacc6bfce9f34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51448628)</sub>

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->