### PR TITLE
🛡️ Sentinel: [MEDIUM] CSPへのobject-src 'none'の明示的追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,7 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+## 2026-08-08 - CSP Object-Src Policy
+**Vulnerability:** レガシーブラウザにおけるプラグインの悪用リスク
+**Learning:** `default-src 'none'` が設定されていても、古いブラウザの仕様により `<object>` などのプラグイン実行が許可される可能性がある。
+**Prevention:** WebViewのCSPを設定する際は、多層防御として必ず `object-src 'none'` を明示的に追加する。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; object-src \'none\'; base-uri \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; object-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -74,6 +74,20 @@ suite("Chat View Unit Test Suite", () => {
     assert.strictEqual(isGeneratingSessionState(undefined), false);
   });
 
+  test("getChatWebviewHtml should include object-src 'none' in Content-Security-Policy", () => {
+    const extensionUri = vscode.Uri.file("/tmp/jules-extension");
+    const html = getChatWebviewHtml(
+      {
+        cspSource: "https://example.com",
+        asWebviewUri: (uri: vscode.Uri) =>
+          vscode.Uri.parse("vscode-webview-resource://" + uri.fsPath),
+      } as vscode.Webview,
+      "nonce-123",
+      extensionUri,
+    );
+    assert.ok(html.includes("object-src 'none'"));
+  });
+
   test("getChatWebviewHtml should include typing indicator and send flow script", () => {
     const extensionUri = vscode.Uri.file("/tmp/jules-extension");
     const html = getChatWebviewHtml(

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `default-src 'none'` が指定されていても、古いブラウザの仕様により `<object>`、`<embed>`、`<applet>` などのタグを用いたプラグイン実行がバイパスされるリスクがある。
🎯 Impact: WebView内で悪意のあるプラグインが実行され、XSSやシステムリソースへの不正アクセスにつながる可能性がある。
🔧 Fix: `src/composer.ts` と `src/chatView.ts` のCSP (Content-Security-Policy) に `object-src 'none'` を明示的に追加し、多層防御 (defense-in-depth) を実装した。
✅ Verification: `pnpm test` を実行し、両方のWebView HTMLジェネレータがCSPに `object-src 'none'` を含んでいることを確認するユニットテストがパスすることを検証した。

---
*PR created automatically by Jules for task [362457210243782480](https://jules.google.com/task/362457210243782480) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CSPを強化し、チャットおよびコンポーザーのWebViewでプラグインコンテンツを明示的に禁止する変更です。
- 両WebViewのCSPへ `object-src 'none'` を追加
- CSPディレクティブの存在を確認する単体テストを追加
- Sentinelのセキュリティ学習記録を更新
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

CSPの変更は安全にマージできる内容ですが、文書規約に合わせて追加したセキュリティ記録の英語表記を日本語へ統一することを推奨します。

両WebViewのCSP強化と対応テストに動作上の問題は見当たらず、残る指摘はSentinel文書における非ブロッキングな言語規約違反のみです。

**Files Needing Attention:** .jules/sentinel.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャットWebViewのCSPに `object-src 'none'` を追加しており、既存のリソース許可には影響しません。 |
| src/composer.ts | コンポーザーWebViewのCSPに同じ制限を追加しており、既存のnonceベースのスクリプトとスタイルを維持しています。 |
| src/test/chatView.unit.test.ts | 生成されたチャットHTMLに新しいCSPディレクティブが含まれることを検証しています。 |
| src/test/composer.unit.test.ts | 生成されたコンポーザーHTMLに新しいCSPディレクティブが含まれることを検証しています。 |
| .jules/sentinel.md | CSP強化の背景を記録していますが、追加部分の見出しとラベルが日本語文書規約に反しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/sentinel.md:38-41
**セキュリティ記録の言語混在**

追加された見出しと各項目のラベルが英語のため、リポジトリ内のドキュメントを日本語で記述する規約に反し、文書内で言語が混在しています。

```suggestion
## 2026-08-08 - CSPのobject-srcポリシー
**脆弱性:** レガシーブラウザにおけるプラグインの悪用リスク
**学び:** `default-src 'none'` が設定されていても、古いブラウザの仕様により `<object>` などのプラグイン実行が許可される可能性がある。
**予防策:** WebViewのCSPを設定する際は、多層防御として必ず `object-src 'none'` を明示的に追加する。
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: CSPへのobject-src &#39;none&#39;の明示的追加"](https://github.com/hiroki-org/jules-extension/commit/cb2d569c681169bf82a4919d033726a70364ee8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51455993)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))
- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->