### PR TITLE
🛡️ Sentinel: [MEDIUM] CSPの改善 (object-src 'none'の追加)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,7 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+## 2026-08-09 - Webview CSP の多層防御
+**Vulnerability:** レガシーブラウザの一部では `default-src 'none'` のフォールバックを無視してプラグインが実行される可能性があります。
+**Learning:** `default-src 'none'` が指定されていても、`object-src 'none'` を明示的に設定することで、悪意のある `<object>`, `<embed>`, `<applet>` タグに対する追加の防御層を提供します。
+**Prevention:** Webview の Content-Security-Policy では、常に `object-src 'none'` を明示的に含めるようにします。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; object-src \'none\'; base-uri \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; object-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: CSPの設定において、`default-src 'none'` が指定されていますが、一部のレガシーブラウザの挙動により、`<object>`, `<embed>`, `<applet>` などのプラグイン実行がデフォルトフォールバックをバイパスする可能性があります。
🎯 Impact: 防御の層が薄くなり、古いブラウザ環境での悪意あるプラグイン実行やXSSのリスクが残ります。
🔧 Fix: WebviewのCSPに `object-src 'none'` を明示的に追加し、多層防御を強化しました。
✅ Verification: `pnpm test` がパスし、CSPに `object-src 'none'` が含まれていることをテストで確認しました。

---
*PR created automatically by Jules for task [12972394700345933781](https://jules.google.com/task/12972394700345933781) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Webview の CSP に `object-src 'none'` を明示し、プラグインコンテンツに対する多層防御を追加しています。
- チャットおよびコンポーザーの CSP を強化
- 両 Webview の生成 HTML に対する単体テストを追加
- Sentinel のセキュリティ学習記録を更新
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更は既存の Webview 動作を維持したまま CSP を強化しており、安全にマージできると判断します。

追加された `object-src 'none'` は有効な CSP ディレクティブで、既存のスクリプト、スタイル、画像および DOMPurify の読み込み許可を変更せず、到達可能な機能障害も確認されません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット Webview の有効な CSP に `object-src 'none'` を追加しており、既存リソースの許可設定は維持されています。 |
| src/composer.ts | コンポーザー Webview の CSP に同じ防御策を追加しており、既存フォームの動作への影響は確認されません。 |
| src/test/chatView.unit.test.ts | チャット HTML に新しい CSP ディレクティブが含まれることを検証しています。 |
| src/test/composer.unit.test.ts | コンポーザー HTML に新しい CSP ディレクティブが含まれることを検証しています。 |
| .jules/sentinel.md | 今回の CSP 防御策と再発防止方針を記録しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] CSPの改善 (object-sr..."](https://github.com/hiroki-org/jules-extension/commit/c0108a2d34f37b0653465b4fe2c1a07ebd0c086a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51608852)</sub>

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->