### PR TITLE
⚡ Bolt: 1回限りの存在確認での不要なSet生成を削減

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3260,7 +3260,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: 1回限りのルックアップのためのSet生成を避け、includes()を使用します
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3280,7 +3281,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: 1回限りのルックアップのためのSet生成を避け、includes()を使用します
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: src/extension.ts内のブランチ存在確認において、毎回 \`new Set()\` を生成して \`.has()\` で判定していた箇所を、\`.includes()\` による配列の直接走査に変更しました。
🎯 Why: 一度しか行われないルックアップのためにわざわざSetを生成することは、メモリ割り当てとGCオーバーヘッドを発生させ、パフォーマンスを悪化させるためです（アンチパターン）。
📊 Impact: ブランチ選択時のメモリ割り当てを削減し、不必要なイテレーションを回避します。
🔬 Measurement: \`pnpm run lint\` および \`xvfb-run -a pnpm test\` を実行し、既存の機能が壊れていないことを確認します。

---
*PR created automatically by Jules for task [9413122998180406252](https://jules.google.com/task/9413122998180406252) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ブランチの存在確認を、一時的な `Set` の生成から配列の `includes()` に置き換える最適化です。文字列に対する判定結果と、キャッシュ再取得およびローカル専用ブランチ処理の挙動は維持されています。
- 一度限りの存在確認に伴う `Set` の割り当てを削減
- キャッシュ済みブランチと再取得後ブランチの両方に同じ最適化を適用
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更は既存のブランチ選択動作を維持しており、安全にマージできると考えられます。

対象は文字列配列と文字列の存在確認であり、`Set.has` と `Array.includes` はこの経路で同じ結果を返すため、キャッシュ再取得やローカル専用ブランチの処理を壊す変更はありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 2か所の文字列ブランチ存在確認を、同等の結果を返す `Array.includes()` に変更しており、具体的な不具合は確認されませんでした。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Optimize Set creation"](https://github.com/hiroki-org/jules-extension/commit/6bfd48a7b17cd8e7f769b0074b6cbd6904fc251f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51936595)</sub>

**Context used:**

- Knowledge Base — [Extension Entrypoint (activate/deactivate)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/extension-entrypoint.md)

<!-- /greptile_comment -->