### PR TITLE
🛡️ Sentinel: [MEDIUM] Content-Security-Policyのセキュリティ強化

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+
+## 2026-08-11 - CSPでの object-src 'none' の設定
+**Vulnerability:** WebView における Content-Security-Policy の設定で object-src 'none' が明示されていないため、古いブラウザや特定のレガシーな環境においてプラグイン（<object>, <embed>, <applet>）を通じたスクリプト実行や予期せぬ動作が引き起こされるリスクがあります。default-src 'none' によるフォールバックだけでは不十分な場合があります。
+**Learning:** default-src 'none' を指定していても、多層防御の観点から object-src 'none' を明示的に設定することがベストプラクティスです。これにより、デフォルトのフォールバックをバイパスするブラウザのバグや仕様の違いによる影響を防ぎます。
+**Prevention:** WebViewのメタタグでCSPを設定する際は、常に default-src 'none'; object-src 'none'; を明記して、不要なプラグインの実行を強固に禁止します。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; object-src \'none\'; base-uri \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; object-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -74,6 +74,20 @@ suite("Chat View Unit Test Suite", () => {
     assert.strictEqual(isGeneratingSessionState(undefined), false);
   });
 
+  test("getChatWebviewHtml should include object-src 'none' in Content-Security-Policy", () => {
+    const extensionUri = vscode.Uri.file("/tmp/jules-extension");
+    const html = getChatWebviewHtml(
+      {
+        cspSource: "https://example.com",
+        asWebviewUri: (uri: vscode.Uri) =>
+          vscode.Uri.parse("vscode-webview-resource://" + uri.fsPath),
+      } as vscode.Webview,
+      "test-nonce-123",
+      extensionUri,
+    );
+    assert.ok(html.includes("object-src 'none'"));
+  });
+
   test("getChatWebviewHtml should include typing indicator and send flow script", () => {
     const extensionUri = vscode.Uri.file("/tmp/jules-extension");
     const html = getChatWebviewHtml(

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WebViewのCSP設定に `object-src 'none'` が欠落していました。
🎯 Impact: `default-src 'none'` が設定されていても、一部のレガシーブラウザの挙動により `<object>` などのプラグイン実行が許可され、XSS等のリスクとなる可能性があります。
🔧 Fix: `src/composer.ts` と `src/chatView.ts` のCSPメタタグに明示的に `object-src 'none'` を追加し、テストを拡充しました。
✅ Verification: 単体テスト (`xvfb-run -a pnpm run test:unit`) を実行し、メタタグが正しく出力されていることを確認しました。

---
*PR created automatically by Jules for task [9391493108512713906](https://jules.google.com/task/9391493108512713906) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

チャットおよびコンポーザー WebView の Content Security Policy に `object-src 'none'` を明示し、その出力を確認する単体テストを追加しています。
- `getChatWebviewHtml` と `getComposerHtml` の CSP を防御的に強化
- 両 WebView の生成 HTML に新しいディレクティブが含まれることをテスト
- Sentinel のセキュリティ知見を更新
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

具体的な不具合やマージを妨げる問題は確認されず、この PR は安全にマージできると考えられます。

追加された CSP ディレクティブは構文的に有効で、既存リソースの許可設定を変更せず、チャットとコンポーザーの両 WebView で対応するテストも追加されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット WebView の CSP に `object-src 'none'` を正しい区切り位置で追加しており、既存の nonce および DOMPurify 読み込み許可を維持しています。 |
| src/composer.ts | コンポーザー WebView の CSP に明示的なオブジェクト禁止を追加しており、既存の script、style、img ポリシーに影響はありません。 |
| src/test/chatView.unit.test.ts | チャット HTML に `object-src 'none'` が出力されることを確認する単体テストを追加しています。 |
| src/test/composer.unit.test.ts | コンポーザー HTML に `object-src 'none'` が出力されることを確認する単体テストを追加しています。 |
| .jules/sentinel.md | WebView CSP で `object-src 'none'` を明示する防御的なセキュリティ方針を記録しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] Add object-src &#39;n..."](https://github.com/hiroki-org/jules-extension/commit/99a45830cad8e9ac257fc0c99617de5d18d4bfc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52236877)</sub>

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->