### PR TITLE
🎨 Palette: 送信中のチェックボックス無効化時に適切なタイトルとARIAラベルを追加

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-11 - Accessible Disabled Checkboxes
+**Learning:** リンクされたラベルを持つ要素にdisabled状態を説明するaria-labelを動的に追加すると、元のラベルが上書きされてしまいます。
+**Action:** スクリーンリーダーのコンテキストを維持するために、元のラベルテキストとdisabledの説明を連結します。

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -281,9 +281,13 @@ export function getComposerHtml(
       textarea.disabled = true;
       if (createPrCheckbox) {
         createPrCheckbox.disabled = true;
+        createPrCheckbox.title = 'Create PR automatically? (Cannot change while sending)';
+        createPrCheckbox.setAttribute('aria-label', 'Create PR automatically? (Cannot change while sending)');
       }
       if (requireApprovalCheckbox) {
         requireApprovalCheckbox.disabled = true;
+        requireApprovalCheckbox.title = 'Require plan approval before execution? (Cannot change while sending)';
+        requireApprovalCheckbox.setAttribute('aria-label', 'Require plan approval before execution? (Cannot change while sending)');
       }
       const cancelButton = document.getElementById('cancel');
       if (cancelButton) {

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -672,8 +672,12 @@ suite("Composer Test Suite", () => {
       );
       assert.ok(html.includes("if (createPrCheckbox) {"));
       assert.ok(html.includes("createPrCheckbox.disabled = true;"));
+      assert.ok(html.includes("createPrCheckbox.title = 'Create PR automatically? (Cannot change while sending)';"));
+      assert.ok(html.includes("createPrCheckbox.setAttribute('aria-label', 'Create PR automatically? (Cannot change while sending)');"));
       assert.ok(html.includes("if (requireApprovalCheckbox) {"));
       assert.ok(html.includes("requireApprovalCheckbox.disabled = true;"));
+      assert.ok(html.includes("requireApprovalCheckbox.title = 'Require plan approval before execution? (Cannot change while sending)';"));
+      assert.ok(html.includes("requireApprovalCheckbox.setAttribute('aria-label', 'Require plan approval before execution? (Cannot change while sending)');"));
     });
   });
 });


### PR DESCRIPTION
💡 What: メッセージ送信時に無効化されるチェックボックス（PR自動作成、計画承認要求）に、無効化の理由を説明する title と aria-label を追加しました。
🎯 Why: スクリーンリーダーなどの支援技術を使用するユーザーが、なぜチェックボックスが操作できないのかを理解できるようにするためです。
📸 Before/After: （視覚的な変更はありません）
♿ Accessibility: aria-label を設定する際、元のラベルテキストと無効化の理由を連結することで、スクリーンリーダーのコンテキストが失われないように改善しました。

---
*PR created automatically by Jules for task [17787529257532379233](https://jules.google.com/task/17787529257532379233) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、メッセージ送信中に無効化される2つのチェックボックスへ、可視ラベルを保持した無効理由付きの `title` と `aria-label` を追加します。
- PR自動作成チェックボックスに送信中の操作制限を説明する属性を追加
- 計画承認要求チェックボックスに同等の属性を追加
- 生成HTMLに新しい属性設定が含まれることを単体テストで検証
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

到達可能な不具合や非ブロッキングの改善事項は確認されず、安全にマージできると考えます。

追加されたアクセシビリティ属性は実際の可視ラベル全文を保持し、チェックボックスが無効化される送信中だけ設定されます。また、送信後は一回限りの composer パネル自体が破棄されるため、属性が誤って残る状態もありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | 送信開始時に条件付きチェックボックスを無効化し、元の名称を維持した無効理由を支援技術へ提供する変更です。 |
| src/test/composer.unit.test.ts | 両チェックボックスの `title` と `aria-label` が生成スクリプトへ含まれることを検証しています。 |
| .jules/palette.md | `aria-label` が関連ラベルを上書きする点と、元のラベル文言を連結する対応方針を記録しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: 送信中のチェックボックス無効化時に適切なタイトルとARI..."](https://github.com/hiroki-org/jules-extension/commit/ec8347b91fab436ca1119dff49e1cd9b8f67bf36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52268186)</sub>

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->