### PR TITLE
🛡️ Sentinel: [MEDIUM] Content-Security-Policyにobject-src 'none'を追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,7 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+## 2026-08-12 - Add object-src 'none' to Content-Security-Policy
+**Vulnerability:** The Content-Security-Policy in webviews was missing the `object-src 'none'` directive.
+**Learning:** Relying solely on `default-src 'none'` can be bypassed by legacy browser quirks that allow execution of plugins via tags like `<object>`, `<embed>`, or `<applet>`.
+**Prevention:** Explicitly include `object-src 'none'` alongside `default-src 'none'` in Webview CSPs as a defense-in-depth best practice.

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; object-src \'none\'; base-uri \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; object-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WebviewのContent-Security-Policyにおいて、`default-src 'none'`のみではレガシーブラウザの挙動により`<object>`や`<embed>`タグからプラグインが実行される可能性がある脆弱性が存在しました。
🎯 Impact: XSSや予期せぬプラグインの実行を許す可能性があります。
🔧 Fix: `chatView.ts`および`composer.ts`のCSPメタタグに、防御的措置として明示的に`object-src 'none'`を追加しました。
✅ Verification: 単体テストを追加し、出力されるHTMLに`object-src 'none'`が含まれることを確認しました。`pnpm test:coverage`がパスすることを確認しました。

---
*PR created automatically by Jules for task [2784588127964546956](https://jules.google.com/task/2784588127964546956) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Webview の CSP を防御的に強化し、`<object>` などのプラグイン系コンテンツを明示的に禁止する変更です。
- チャットおよびコンポーザーの CSP に `object-src 'none'` を追加
- 両方の HTML 生成テストに CSP ディレクティブの検証を追加
- Sentinel の脆弱性履歴に今回の対策を追記
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

CSP の変更自体は安全にマージできそうですが、Sentinel の追記を日本語へ統一する非ブロッキングな修正が必要です。

Webview の既存リソース許可を維持したまま object 系コンテンツを禁止できていますが、変更されたドキュメントにはリポジトリの言語規約違反が残っています。

**Files Needing Attention:** .jules/sentinel.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット Webview の既存 CSP に `object-src 'none'` を追加しており、既存の nonce ベースの script/style 読み込みには影響しません。 |
| src/composer.ts | コンポーザー Webview の CSP に同じ制限を追加しており、既存の script/style/img ディレクティブは維持されています。 |
| src/test/chatView.unit.test.ts | 生成されたチャット HTML に `object-src 'none'` が含まれることを既存の CSP テストで確認しています。 |
| src/test/composer.unit.test.ts | コンポーザー HTML の新しい CSP ディレクティブを検証する単体テストを追加しています。 |
| .jules/sentinel.md | 対策内容は記録されていますが、日本語で統一するリポジトリ規約に反して追記部分が英語です。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/sentinel.md:38-41
**Sentinel の記録が英語表記**

追加された脆弱性記録が英語で記述されているため、ドキュメントを日本語で統一するリポジトリ規約に反し、履歴の言語が不統一になります。

```suggestion
## 2026-08-12 - Content-Security-Policy に object-src 'none' を追加
**Vulnerability:** Webview の Content-Security-Policy に `object-src 'none'` ディレクティブがありませんでした。
**Learning:** `default-src 'none'` のみに依存すると、レガシーブラウザの挙動により `<object>`、`<embed>`、`<applet>` などのタグからプラグインが実行される可能性があります。
**Prevention:** 多層防御のため、Webview の CSP では `default-src 'none'` と併せて `object-src 'none'` を明示的に指定します。
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): add object-src &#39;none&#39; to ..."](https://github.com/hiroki-org/jules-extension/commit/4d9cc439615ec47990a4f140231c192388f6ce99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52630690)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))
- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->