### PR TITLE
🛡️ Sentinel: [MEDIUM] WebViewのCSPにobject-src 'none'を追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+
+## 2026-08-13 - [CSP object-src 'none' 設定]
+**Vulnerability:** WebViewのContent-Security-Policyにおいて、`default-src 'none'`が設定されていても、古いブラウザの挙動やプラグイン（`<object>`, `<embed>`, `<applet>`など）を通じて悪意のあるスクリプトが実行されるXSSリスクがあります。
+**Learning:** 多層防御（Defense in depth）の観点から、プラグインを利用しない場合は明示的に`object-src 'none'`を指定することが推奨されます。
+**Prevention:** WebviewのCSPを設定する際は、常に`default-src 'none'`と共に`object-src 'none'`を明示的に含めるようにします。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; object-src \'none\'; base-uri \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; object-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WebViewのContent-Security-Policyにおいて、`default-src 'none'`に加えて`object-src 'none'`が明示的に設定されておらず、古いブラウザや特定のプラグイン実行を介したXSSの回避リスクがありました。
🎯 Impact: プラグイン（`<object>`, `<embed>`, `<applet>`など）を経由した悪意のあるコード実行によるXSS攻撃の可能性があります。
🔧 Fix: `src/composer.ts` および `src/chatView.ts` のCSPメタタグに `object-src 'none'` ディレクティブを追加し、防御の層を厚くしました。
✅ Verification: 単体テストを追加し、CSPに `object-src 'none'` が含まれていることを確認しました。

---
*PR created automatically by Jules for task [11158411725309187230](https://jules.google.com/task/11158411725309187230) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

チャットおよび Composer WebView の CSP に `object-src 'none'` を明示し、プラグイン形式のリソースを防御的に禁止する変更です。
- `src/chatView.ts` と `src/composer.ts` の CSP を強化
- Composer 用の CSP 回帰テストを追加
- Sentinel のセキュリティ学習記録を更新
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる不具合は見当たりませんが、チャット WebView 側にも CSP の回帰テストを追加することを推奨します。

CSP の追加は既存の default-src 'none' と整合し、必要なスクリプト、スタイル、画像の経路を壊しませんが、同一変更を行ったチャット側だけ object-src のテストが欠けています。

**Files Needing Attention:** src/chatView.ts, src/test/chatView.unit.test.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット WebView の CSP 強化自体は安全だが、追加ディレクティブを固定する回帰テストがない。 |
| src/composer.ts | Composer の CSP に object-src 'none' を追加しており、既存リソースの読み込みには影響しない。 |
| src/test/composer.unit.test.ts | Composer が強化後の CSP を生成することを確認する単体テストを追加している。 |
| .jules/sentinel.md | 今回の CSP 防御策と今後の予防方針を記録している。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/chatView.ts:507
**チャット側の CSP テスト不足**

チャット WebView にも `object-src 'none'` を追加していますが、追加された回帰テストは Composer 側だけを検証しています。既存の `getChatWebviewHtml` テストにも同じアサーションを追加しないと、チャット側からこのディレクティブが削除されても検出できません。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add object-src &#39;none&#39; to WebView CSP"](https://github.com/hiroki-org/jules-extension/commit/eb5f10fcfd1023000723bc65410f26ded68d0111) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52996898)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))
- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->