### PR TITLE
⚡ Bolt: Array includes によるパフォーマンス最適化

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,6 @@
 
 **Learning:** リモートブランチの存在確認を逐次実行すると、リモート数に比例して待ち時間が増加します。
 **Action:** 各Promise内でエラーを捕捉して存在確認を並列開始し、結果は優先順に個別評価します。
+## 2026-08-13 - [Array includes Optimization]
+**Learning:** [Using `new Set(array).has()` for simple membership checks on arrays generates unnecessary intermediate Set objects and incurs an O(N) space and allocation penalty. `array.includes()` is much more efficient for this use case.]
+**Action:** [Always use `array.includes()` over `new Set().has()` for single array membership checks to avoid memory overhead.]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3260,7 +3260,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // 中間オブジェクトの生成を防ぐため includes を使用
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3280,7 +3281,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // 中間オブジェクトの生成を防ぐため includes を使用
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `new Set(array).has()` を `array.includes()` にリファクタリング
🎯 Why: 包含判定のためだけに一時的な Set オブジェクトを生成・破棄するオーバーヘッドを削減するため
📊 Impact: オブジェクト割り当てとガベージコレクションの頻度を低減
🔬 Measurement: `pnpm run test` がすべてパスすること

---
*PR created automatically by Jules for task [3195055679993565926](https://jules.google.com/task/3195055679993565926) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

リモートブランチの包含判定を、一時的な Set を生成する実装から Array.includes を使う実装へ変更しています。文字列配列に対する判定結果は従来と同等です。
- キャッシュ済みリモートブランチの判定を Array.includes に変更
- 再取得後のリモートブランチの判定も同様に変更
- 最適化に関する Learning と Action を `.jules/bolt.md` に追加
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

実装変更は安全にマージできると考えられますが、追加ドキュメントの英語部分はリポジトリ規約に合わせて日本語へ修正してください。

ブランチ存在判定の置換は文字列に対して従来と同じ結果になりますが、追加された Learning と Action の本文だけが日本語記述の規約に適合していません。

**Files Needing Attention:** .jules/bolt.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 2箇所の文字列配列の包含判定を、同等の比較 semantics を持つ Array.includes に置き換えており、機能上の問題は確認されませんでした。 |
| .jules/bolt.md | 最適化の知見を追加していますが、本文が英語であり、日本語で記述するリポジトリ規約に違反しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/bolt.md:63-64
**追加ドキュメントが英語表記**

追加された Learning と Action の本文が英語であり、ドキュメントを日本語で記述するリポジトリ規約および既存エントリと不整合になっています。本文を日本語へ変更してください。

```suggestion
**Learning:** 配列に対する単純な包含判定で `new Set(array).has()` を使用すると、不要な中間 Set オブジェクトが生成され、O(N) の領域確保が発生します。この用途では `array.includes()` の方が効率的です。
**Action:** 単一の配列包含判定では、メモリのオーバーヘッドを避けるため `new Set().has()` ではなく `array.includes()` を使用します。
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: Array includes によるパフォーマンス最適化"](https://github.com/hiroki-org/jules-extension/commit/4a698703a8e875a06cfdc58fc0bd680ebb1c7478) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53010534)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))

<!-- /greptile_comment -->