### PR TITLE
🛡️ Sentinel: [MEDIUM] WebViewのCSPに object-src 'none' を追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+
+## 2026-08-14 - WebViewのCSPにおけるobject-src 'none'の追加
+**Vulnerability:** default-src 'none' を指定していても、レガシーブラウザの挙動により、悪意のあるプラグイン（<object>, <embed>, <applet>等）が実行されるリスクが存在します。
+**Learning:** 防御的アプローチ (defense-in-depth) として、WebViewのCSP (Content-Security-Policy) には default-src 'none' に加えて、明示的に object-src 'none' を指定する必要があります。
+**Prevention:** 新規および既存の WebView CSP を設定する際は、必ず object-src 'none' のディレクティブを含めます。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; object-src \'none\'; base-uri \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; object-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: default-src 'none' を指定していても、一部の環境やレガシーな挙動によりプラグインによるリスク（<object>など）が残る可能性がありました。
🎯 Impact: 悪意のあるコンテンツが含まれた場合に、予期せずプラグインがロード・実行されるリスクを低減します。
🔧 Fix: src/composer.ts と src/chatView.ts の CSP に object-src 'none'; を明示的に追加しました。
✅ Verification: pnpm run lint と xvfb-run -a pnpm test が正常に通過することを確認済みです。

---
*PR created automatically by Jules for task [8126503120833241264](https://jules.google.com/task/8126503120833241264) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

WebView の CSP を防御的に強化し、オブジェクト形式のプラグインコンテンツを明示的に禁止する変更です。
- チャット WebView の CSP に `object-src 'none'` を追加
- コンポーザー WebView の CSP に `object-src 'none'` を追加
- Sentinel のセキュリティ知見へ今回の対策を記録
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は安全にマージできると判断します。

変更は既存の CSP に制限的なディレクティブを明示追加するものであり、チャットおよびコンポーザー WebView の既存リソース許可や nonce の動作を壊す問題は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット WebView の既存 CSP に制限的な `object-src 'none'` を追加しており、既存リソースの読み込みには影響しません。 |
| src/composer.ts | コンポーザー WebView の既存 CSP に同じオブジェクト読み込み禁止を追加しており、インラインスクリプトおよびスタイルの nonce 設定を維持しています。 |
| .jules/sentinel.md | CSP の防御的要件と今回の対策内容をセキュリティ知見として追記しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix: Add object-src &#39;none&#39; to WebView CS..."](https://github.com/hiroki-org/jules-extension/commit/513c003110523363a7ebdc008470836d09b08292) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53368644)</sub>

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->