### PR TITLE
⚡ Bolt: パフォーマンス向上: リモートブランチチェック時の中間Set生成を回避

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 
 **Learning:** リモートブランチの存在確認を逐次実行すると、リモート数に比例して待ち時間が増加します。
 **Action:** 各Promise内でエラーを捕捉して存在確認を並列開始し、結果は優先順に個別評価します。
+
+## 2024-05-15 - [Set vs includes on Single-use checks]
+**Learning:** Instantiating `new Set(array)` just to check if it `.has(item)` allocates memory for the Set and the internal hash table. For single use or short arrays, `array.includes(item)` avoids the intermediate allocation and has significantly less overhead, acting as an effective micro-optimization.
+**Action:** Use `.includes()` instead of creating temporary Sets when performing single-use membership tests on simple arrays.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3260,7 +3260,8 @@ export function activate(context: vscode.ExtensionContext) {
         // キャッシュが古い場合、リモートに存在するブランチが見つからないことがあるため、
         // キャッシュにないブランチが選択された場合は最新のリモートブランチを再取得する
         let currentRemoteBranches = remoteBranches;
-        if (!new Set(remoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: 中間Setの生成を避けるためincludesを使用
+        if (!remoteBranches.includes(startingBranch)) {
           logChannel.appendLine(
             `[Jules] Branch "${startingBranch}" not found in cached remote branches, re-fetching...`,
           );
@@ -3280,7 +3281,8 @@ export function activate(context: vscode.ExtensionContext) {
           );
         }
 
-        if (!new Set(currentRemoteBranches).has(startingBranch)) {
+        // パフォーマンス最適化: 中間Setの生成を避けるためincludesを使用
+        if (!currentRemoteBranches.includes(startingBranch)) {
           // ローカル専用ブランチの場合
           logChannel.appendLine(
             `[Jules] Warning: Branch "${startingBranch}" not found on remote`,


### PR DESCRIPTION
💡 What: `src/extension.ts`内でのブランチ存在チェックにおいて、`new Set(array).has()`を`array.includes()`に置き換えました。
🎯 Why: `new Set()`の呼び出しは中間配列/Setの割り当てを伴うため、単発のチェックにおいてはオーバーヘッドとなります。静的な配列やループでない限り、`includes`を用いた方がメモリ効率と実行速度の観点で優れています。
📊 Impact: 中間オブジェクトの生成が減少し、ガベージコレクションの負荷がわずかに低減します。特にブランチリストが長大になった際のパフォーマンス低下を防ぎます。
🔬 Measurement: ローカルでの単体テストおよび`pnpm run test:coverage`が正常にパスすることを確認しました。

---
*PR created automatically by Jules for task [10688348373596484506](https://jules.google.com/task/10688348373596484506) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`src/extension.ts`の単発のリモートブランチ存在確認を、一時的な`Set`の生成から配列の`includes`呼び出しへ変更しています。
- キャッシュ済みおよび再取得後のブランチ判定に同じ最適化を適用
- 最適化方針を`.jules/bolt.md`へ追記
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

実行時の変更は安全にマージできると見られますが、追加された開発者向け文書は日本語へ統一してください。

ブランチ判定の変更は文字列配列上で従来と同じ結果になりますが、追記されたLearningとActionだけがリポジトリで指定された記述言語と一致していません。

**Files Needing Attention:** .jules/bolt.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/extension.ts | 文字列配列に対する2つの単発メンバーシップ判定を、同等の比較セマンティクスを持つ`includes`へ変更しています。 |
| .jules/bolt.md | 最適化の学習事項を追記していますが、新規本文がリポジトリの日本語記述ルールに違反しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/bolt.md:62-63
**学習メモの言語不統一**

新しく追加されたLearningとActionだけが英語で記述されており、ドキュメントを原則として日本語で記述するリポジトリ規約に反しています。日本語を前提とする読者の理解を妨げるため、本文を日本語へ統一してください。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: パフォーマンス向上: リモートブランチチェック時の中間Set生成..."](https://github.com/hiroki-org/jules-extension/commit/1c5ece65655fb3ad2da8500c4c9ba9a910f3554e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53380592)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))
- Knowledge Base — [Extension Entrypoint (activate/deactivate)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/extension-entrypoint.md)

<!-- /greptile_comment -->