### PR TITLE
🎨 Palette: 送信中のチェックボックス無効化時にコンテキストを明示するARIAラベルを追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,6 @@
 ## 2026-07-30 - 無効化状態の理由の明示
 **Learning:** 非同期処理中にインタラクティブな要素（ボタンなど）を無効にする際、単に disabled 属性に頼るだけではスクリーンリーダーなどの支援技術ユーザーにコンテキストが伝わらない。
 **Action:** 無効化する際は常に title および aria-label 属性を設定し、なぜ無効化されているのか（例：'Cannot cancel while sending'）をすべてのユーザーに明示的に説明する。
+## 2025-05-12 - チェックボックス無効化時のARIAラベル結合
+**Learning:** 紐付いた <label> をアクセシブルネームとして依存しているチェックボックスに動的に aria-label を追加すると、新しい aria-label が <label> の内容を完全に上書きしてしまいます。
+**Action:** スクリーンリーダーへのコンテキストを維持するため、元のラベルテキストと無効化の理由を結合した文字列（例：'Create PR automatically? (Cannot change while sending)'）を aria-label に設定すること。

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -281,9 +281,13 @@ export function getComposerHtml(
       textarea.disabled = true;
       if (createPrCheckbox) {
         createPrCheckbox.disabled = true;
+        createPrCheckbox.title = 'Cannot change while sending';
+        createPrCheckbox.setAttribute('aria-label', 'Create PR automatically? (Cannot change while sending)');
       }
       if (requireApprovalCheckbox) {
         requireApprovalCheckbox.disabled = true;
+        requireApprovalCheckbox.title = 'Cannot change while sending';
+        requireApprovalCheckbox.setAttribute('aria-label', 'Require plan approval before execution? (Cannot change while sending)');
       }
       const cancelButton = document.getElementById('cancel');
       if (cancelButton) {

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -672,8 +672,12 @@ suite("Composer Test Suite", () => {
       );
       assert.ok(html.includes("if (createPrCheckbox) {"));
       assert.ok(html.includes("createPrCheckbox.disabled = true;"));
+      assert.ok(html.includes("createPrCheckbox.title = 'Cannot change while sending';"));
+      assert.ok(html.includes("createPrCheckbox.setAttribute('aria-label', 'Create PR automatically? (Cannot change while sending)');"));
       assert.ok(html.includes("if (requireApprovalCheckbox) {"));
       assert.ok(html.includes("requireApprovalCheckbox.disabled = true;"));
+      assert.ok(html.includes("requireApprovalCheckbox.title = 'Cannot change while sending';"));
+      assert.ok(html.includes("requireApprovalCheckbox.setAttribute('aria-label', 'Require plan approval before execution? (Cannot change while sending)');"));
     });
   });
 });


### PR DESCRIPTION
💡 What: コンポーザーで送信処理中、無効化されたチェックボックスに `title` と元のラベルテキストを付加した `aria-label` を動的に設定するようにしました。
🎯 Why: フォーム送信中になぜチェックボックスが操作できないのか、元のラベルのコンテキストを維持したまま、スクリーンリーダーユーザーおよびマウス・キーボード操作ユーザーに明確な理由（'Cannot change while sending'）を伝えるためです。
📸 Before/After: 非視覚的な変更およびツールチップの追加
♿ Accessibility: 依存する `<label>` のテキストが新しい動的 `aria-label` により上書きされてしまう問題を防ぐため、元のラベルと無効化の理由を結合することで、支援技術を利用するユーザーへのコンテキスト喪失を防止しました。

---
*PR created automatically by Jules for task [1342298802343740019](https://jules.google.com/task/1342298802343740019) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

送信中に無効化される2つのコンポーザーチェックボックスへ、元のラベル文脈を維持した `aria-label` と無効化理由の `title` を追加します。

- Create PR と plan approval の両チェックボックスに送信中の説明を設定
- 生成HTMLに追加された属性を確認するユニットテストを追加
- アクセシビリティ上の学習事項を Palette 文書へ追記
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる問題はありませんが、追加した無効化理由をキーボード利用者が実際に確認できる提示方法へ変更することを推奨します。

チェックボックスのラベル文脈は正しく維持されていますが、説明がタブフォーカスを受け取れない disabled 要素だけに置かれているため、意図したキーボード向け案内が十分に機能しません。

**Files Needing Attention:** src/composer.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/composer.ts | チェックボックスの無効化理由を追加しているが、disabled 要素自体にのみ設定しているためキーボードから理由へ到達できない。 |
| src/test/composer.unit.test.ts | 追加された title と aria-label の生成コードを文字列アサーションで検証している。 |
| .Jules/palette.md | label 由来の文脈を aria-label に含めるアクセシビリティ方針を追記している。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/composer.ts:283-285
**無効化理由へフォーカスできない**

送信時の理由は `disabled` にしたチェックボックス自体の `title` と `aria-label` にだけ設定されています。ネイティブの無効なチェックボックスはタブ順序から外れるため、キーボード利用者はこの説明へフォーカスして確認できません。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ARIA labels to disabled checkboxes"](https://github.com/hiroki-org/jules-extension/commit/baee5f54ba79c8f45d7c43b82f391c734acebb5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53400540)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->