### PR TITLE
🛡️ Sentinel: [Medium] Webview の CSP における object-src の明示的設定

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+
+## 2026-08-15 - [WebviewのCSPにおけるobject-srcの明示的設定]
+**Vulnerability:** `default-src 'none'` が設定されている場合でも、古いブラウザの挙動や特定のプラグイン実行のフォールバックとして `<object>` などの要素が実行されるリスクがあります。
+**Learning:** Webviewに適用する Content-Security-Policy (CSP) においては、多層防御のベストプラクティスとして `object-src 'none'` を明示的に設定するべきです。
+**Prevention:** CSPのメタタグには、デフォルトの設定に加え常に `object-src 'none'` を含めるようにします。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -518,13 +518,14 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes(`<script nonce="${testNonce}">`));
     });
 
-    test("should include base-uri 'none' in Content-Security-Policy", () => {
+    test("should include base-uri 'none' and object-src 'none' in Content-Security-Policy", () => {
       const html = getComposerHtml(
         mockWebview,
         { title: "Test" },
         "nonce-123"
       );
       assert.ok(html.includes("base-uri 'none'"));
+      assert.ok(html.includes("object-src 'none'"));
     });
 
     test("should set submitButton disabled state based on validation result", () => {


### PR DESCRIPTION
🚨 Severity: Medium
💡 Vulnerability: Webview の Content-Security-Policy (CSP) において、`default-src 'none'` が設定されていますが、`object-src 'none'` が明示的に設定されていませんでした。これにより、レガシーブラウザの挙動により `<object>`, `<embed>`, `<applet>` 要素を通じたプラグインの実行を許すリスクがあります。
🎯 Impact: XSSやその他の悪意のあるコード実行の可能性があります。
🔧 Fix: `src/composer.ts` と `src/chatView.ts` の CSP に `object-src 'none'` ディレクティブを追加しました。
✅ Verification: 単体テストを実行し、CSP に `object-src 'none'` が含まれていることを確認しました。

---
*PR created automatically by Jules for task [12733630553817430181](https://jules.google.com/task/12733630553817430181) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Webview の CSP を強化し、チャット画面とコンポーザー画面でプラグインコンテンツの読み込みを明示的に禁止する変更です。
- `src/chatView.ts` と `src/composer.ts` の CSP に `object-src 'none'` を追加
- 両 Webview の単体テストに CSP の検証を追加
- セキュリティ上の知見を Sentinel ドキュメントに記録
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は安全にマージできると考えられます。

変更は既存 CSP に明示的な制限を追加する防御的なものであり、既存の許可ディレクティブや Webview のリソース読み込みを変更せず、両適用箇所に対応するテストも追加されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット Webview の既存 CSP に `object-src 'none'` を正しく追加しており、既存の nonce やリソース許可には影響しません。 |
| src/composer.ts | コンポーザー Webview の CSP に同じ制限を追加しており、既存の画像・スクリプト・スタイル設定を維持しています。 |
| src/test/chatView.unit.test.ts | 生成されたチャット HTML に `object-src 'none'` が含まれることを検証するテストを追加しています。 |
| src/test/composer.unit.test.ts | コンポーザーの CSP テストを拡張し、`base-uri` と `object-src` の両方を検証しています。 |
| .jules/sentinel.md | 今回の CSP 強化方針と再発防止策をセキュリティ知見として追記しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Sentinel: CSP enhancements"](https://github.com/hiroki-org/jules-extension/commit/4ec72c075e4b7c878d22450a2614cedc341ab54e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53625651)</sub>

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->