### PR TITLE
🛡️ Sentinel: [MEDIUM] Content-Security-Policyの多層防御強化

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,7 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+## 2025-01-01 - Content-Security-Policyにおけるobject-src 'none'の追加
+**Vulnerability:** レガシーブラウザの挙動により、default-src 'none' が設定されていても、<object>, <embed>, <applet> 等を経由して悪意のあるプラグインが実行される可能性がある問題。
+**Learning:** default-src 'none' に依存するだけでは不十分であり、多層防御 (Defense in Depth) として特定のディレクティブを明示的に無効化する必要がある。
+**Prevention:** WebviewでContent-Security-Policyを設定する際は、常に `object-src 'none'` を明示的に追加し、不要なプラグイン実行を完全に遮断する。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: レガシーブラウザの仕様やquirksにより、`default-src 'none'` が設定されていても `<object>`, `<embed>`, `<applet>` タグを経由して悪意のあるプラグインが実行される可能性がある脆弱性。
🎯 Impact: 攻撃者がWebview内で任意のプラグインを実行し、クロスサイトスクリプティング（XSS）やその他の攻撃に繋がる恐れがある。
🔧 Fix: `src/composer.ts` および `src/chatView.ts` のCSPヘッダーに `object-src 'none'` ディレクティブを明示的に追加し、多層防御（Defense in depth）を実装。
✅ Verification: ユニットテストを追加し、出力されるHTMLに `object-src 'none'` が含まれることを確認。また、`xvfb-run -a pnpm test` にて全テストが成功することを検証。

---
*PR created automatically by Jules for task [12044998475827627748](https://jules.google.com/task/12044998475827627748) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

WebviewのContent Security Policyを多層防御として強化する変更です。
- チャットおよびコンポーザーのCSPへ `object-src 'none'` を追加
- 両方のHTML生成処理に対するユニットテストを追加
- Sentinelのセキュリティ知見を更新
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは既存のWebview機能を損なわずにCSPを強化しており、安全にマージできると判断します。

新しいディレクティブは既存のスクリプト、スタイル、画像に対する許可を変更せず、チャットとコンポーザーが必要とするリソースの読み込み経路にも影響しません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャットWebviewの既存CSPを維持したまま、オブジェクトコンテンツを明示的に禁止しています。 |
| src/composer.ts | コンポーザーWebviewのCSPへ、構文上正しい `object-src 'none'` を追加しています。 |
| src/test/chatView.unit.test.ts | 生成HTMLに新しいCSPディレクティブが含まれることを既存テスト内で検証しています。 |
| src/test/composer.unit.test.ts | コンポーザーの生成HTMLに新しいCSPディレクティブが含まれることを検証するテストを追加しています。 |
| .jules/sentinel.md | CSPの多層防御に関する脆弱性、学び、予防策を記録しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] Content-Security-..."](https://github.com/hiroki-org/jules-extension/commit/cc7bbefe94aa563de51c6bb3fd202075fbea686c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53798900)</sub>

<!-- /greptile_comment -->