### PR TITLE
⚡ Bolt: [パフォーマンス改善] Math.maxのスプレッド展開によるコールスタック超過の防止

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 
 **Learning:** リモートブランチの存在確認を逐次実行すると、リモート数に比例して待ち時間が増加します。
 **Action:** 各Promise内でエラーを捕捉して存在確認を並列開始し、結果は優先順に個別評価します。
+
+## 2025-05-13 - Avoid Math.max(...array) with large dynamic arrays
+**Learning:** Using `Math.max(...array.map(...))` on the results of a global regex match causes a "Maximum call stack size exceeded" error if the matched items exceed engine limits (usually ~100k items), and causes O(N) intermediate memory allocation.
+**Action:** Use a `for...of` loop to iterate and find the maximum value to avoid call stack limits and intermediate array allocations when dealing with regex match arrays or unbounded dynamically generated data.

--- a/src/markdownFencing.ts
+++ b/src/markdownFencing.ts
@@ -7,9 +7,15 @@
 export function buildFencedCodeBlock(code: string, languageId: string): string {
     // Find the longest sequence of backticks in the code
     const backtickMatches = code.match(/`+/g);
-    const longestBacktickSequence = backtickMatches 
-        ? Math.max(...backtickMatches.map(m => m.length)) 
-        : 0;
+    // ⚡ Bolt: 大規模配列での「Maximum call stack size exceeded」エラーと中間配列のメモリ割り当てを防止
+    let longestBacktickSequence = 0;
+    if (backtickMatches) {
+        for (const match of backtickMatches) {
+            if (match.length > longestBacktickSequence) {
+                longestBacktickSequence = match.length;
+            }
+        }
+    }
     
     // Use at least 3 backticks, or one more than the longest sequence found
     const fenceLength = Math.max(3, longestBacktickSequence + 1);


### PR DESCRIPTION
💡 What: `markdownFencing.ts`内の`buildFencedCodeBlock`関数において、`Math.max(...array)`による最大値取得を`for...of`ループに置き換えました。
🎯 Why: 非常に長い文字列から生成された配列を展開する際、「Maximum call stack size exceeded」エラーが発生するリスクがあり、かつ`.map()`による中間配列のメモリ割り当てを回避するためです。
📊 Impact: 大規模なコードブロック処理時のクラッシュを防ぎ、メモリ使用量を削減し、実行速度を向上させます。
🔬 Measurement: `pnpm test`による単体テストパスで機能に変更がないことを確認済みです。

---
*PR created automatically by Jules for task [17506848779820855408](https://jules.google.com/task/17506848779820855408) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`buildFencedCodeBlock`の最大バッククォート列計算を、巨大配列で引数展開の上限に達し得る`Math.max(...array)`から単一パスのループへ変更しています。
- 中間配列の生成とスプレッド展開をなくし、大規模なコード断片の処理を安定化
- 最低3文字、またはコード内の最長バッククォート列より1文字長いフェンスを生成する既存仕様を維持
- 最適化の知見を`.jules/bolt.md`へ追記
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

実装上の阻害要因はなくマージ可能ですが、追加した学習記録は日本語へ統一してください。

最大長計算の変更は既存の出力を維持しながら巨大入力時のスプレッド展開を除去していますが、ドキュメントの追加部分には言語規約上の修正が必要です。

**Files Needing Attention:** .jules/bolt.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/markdownFencing.ts | 最大長の算出を意味的に等価な単一パスのループへ置き換えており、既存のフェンス生成契約を維持しています。 |
| .jules/bolt.md | 最適化の知見を追加していますが、追加部分がリポジトリの日本語ドキュメント規約に従っていません。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/bolt.md:62-64
**学習記録が英語表記**

今回追加された見出しと `Learning`・`Action` は英語で記述されており、ドキュメントを日本語で統一するリポジトリ規約に反するため、保守時に翻訳の負担が生じます。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: Optimize Math.max in buildFenced..."](https://github.com/hiroki-org/jules-extension/commit/2ffd51be2a783b61fab8bb402e93e75c17b7ab6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54021166)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))
- Knowledge Base — [Session Artifacts and Patches](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/session-artifacts-and-patches.md)

<!-- /greptile_comment -->