### PR TITLE
🛡️ Sentinel: [MEDIUM] CSPにobject-src 'none'を追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,7 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+## 2026-08-17 - CSPでのobject-src 'none'の明示的な設定
+**Vulnerability:** WebViewでのContent-Security-Policy (CSP) において、`default-src 'none'` が設定されていても、古いブラウザの挙動により `<object>`, `<embed>`, `<applet>` を通じて悪意のあるプラグインが実行されるリスクがあります。
+**Learning:** 防御の多層化（defense-in-depth）のベストプラクティスとして、フォールバックのバイパスを防ぐために `object-src 'none'` を明示的に設定する必要があります。
+**Prevention:** CSPを設定する際は、常に `object-src 'none'` を明示的に追加します。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; object-src \'none\'; base-uri \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; object-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
## 🚨 Severity: MEDIUM

## 💡 Vulnerability
WebViewでのContent-Security-Policy (CSP) において、`default-src 'none'` が設定されていても、古いブラウザの挙動により `<object>`, `<embed>`, `<applet>` を通じて悪意のあるプラグインが実行されるリスクがありました。

## 🎯 Impact
悪意のあるコンテンツがプラグインを通じて実行される可能性があります。

## 🔧 Fix
CSPのメタタグに明示的に `object-src 'none'` を追加し、レガシーブラウザのバイパスを防ぐようにしました。

## ✅ Verification
テストを実行して、生成されるHTMLのCSPメタタグに `object-src 'none'` が含まれていることを確認しました。

---
*PR created automatically by Jules for task [818505128039953520](https://jules.google.com/task/818505128039953520) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CSP を強化し、chat と composer の両 Webview でプラグイン系埋め込みリソースを明示的に禁止する変更です。
- `getChatWebviewHtml` と `getComposerHtml` の CSP に `object-src 'none'` を追加
- composer の生成 HTML に対する単体テストを追加
- Sentinel のセキュリティ知見を更新
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる不具合は見当たりませんが、chat Webview 側にも `object-src 'none'` の回帰テストを追加することを推奨します。

CSP の追加は既存の script、style、image リソースを阻害せず意図した防御を実現していますが、同じ変更を行った二つの Webview のうち chat 側だけ新しい制約がテストで固定されていません。

**Files Needing Attention:** src/chatView.ts, src/test/chatView.unit.test.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | chat Webview の CSP は適切に強化されていますが、新しいディレクティブを固定する chat 側テストがありません。 |
| src/composer.ts | composer Webview の CSP に `object-src 'none'` を追加しており、既存リソースとの競合は確認されません。 |
| src/test/composer.unit.test.ts | composer の生成 HTML に新しい CSP ディレクティブが含まれることを検証しています。 |
| .jules/sentinel.md | 今回の CSP 強化について脆弱性、知見、予防策を記録しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/chatView.ts:507
**Chat 側の CSP テスト不足**

`getChatWebviewHtml` に追加した `object-src 'none'` は既存の chat 側 CSP テストで検証されていないため、この制約が後から欠落・誤記されてもテストが検出しません。composer と同様に、chat の生成 HTML でも新しいディレクティブを固定してください。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] CSPにobject-src &#39;n..."](https://github.com/hiroki-org/jules-extension/commit/98eb5e1e8a50253f9f62c3a3a6a249b612329536) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54091981)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->