### PR TITLE
⚡ Bolt: 正規表現マッチ結果における .map() とスプレッド構文(...)の排除

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 
 **Learning:** リモートブランチの存在確認を逐次実行すると、リモート数に比例して待ち時間が増加します。
 **Action:** 各Promise内でエラーを捕捉して存在確認を並列開始し、結果は優先順に個別評価します。
+
+## 2026-08-18 - [Performance] Avoiding map() and spread operator for dynamic arrays
+**Learning:** Using `Math.max(...array.map(...))` on unbounded or potentially very large dynamic arrays (like regex match results from parsing large markdown documents) can throw 'Maximum call stack size exceeded' errors because all elements are passed as arguments. It also wastes memory by allocating intermediate arrays.
+**Action:** When calculating maximums or aggregating data over large dynamic collections, replace `.map()` and the spread operator `...` with an imperative `for...of` loop to ensure robust, O(N) performance without stack overflows.

--- a/src/markdownFencing.ts
+++ b/src/markdownFencing.ts
@@ -7,9 +7,17 @@
 export function buildFencedCodeBlock(code: string, languageId: string): string {
     // Find the longest sequence of backticks in the code
     const backtickMatches = code.match(/`+/g);
-    const longestBacktickSequence = backtickMatches 
-        ? Math.max(...backtickMatches.map(m => m.length)) 
-        : 0;
+
+    // ⚡ Bolt 最適化: 長大なマークダウン等で 'Maximum call stack size exceeded' エラーや
+    // 中間配列の生成を防ぐため、スプレッド構文 (...) と .map() の連鎖を避け for...of ループを使用
+    let longestBacktickSequence = 0;
+    if (backtickMatches) {
+        for (const match of backtickMatches) {
+            if (match.length > longestBacktickSequence) {
+                longestBacktickSequence = match.length;
+            }
+        }
+    }
     
     // Use at least 3 backticks, or one more than the longest sequence found
     const fenceLength = Math.max(3, longestBacktickSequence + 1);


### PR DESCRIPTION
💡 What: `src/markdownFencing.ts` の `buildFencedCodeBlock` 関数内において、`Math.max(...backtickMatches.map(m => m.length))` を `for...of` ループに置き換えました。
🎯 Why: 長大なマークダウンテキストを処理する際、マッチしたバッククォートの数が非常に多いとスプレッド構文によって `Maximum call stack size exceeded` エラーが発生するリスクがあります。また、`.map()` の呼び出しは不要な中間配列を生成し、メモリ割り当てのオーバーヘッドをもたらします。
📊 Impact: 大量のコードブロックやバッククォートを含むドキュメントの処理時のスタックオーバーフローを完全に防止し、実行速度を向上させ、メモリ使用量を削減します。
🔬 Measurement: 各種ユニットテストが通過し、特に大きな文字列が渡された場合にもクラッシュしないことでパフォーマンスと安定性の向上を確認します。

---
*PR created automatically by Jules for task [17943706958998142781](https://jules.google.com/task/17943706958998142781) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

正規表現で検出したバッククォート列の最大長を、中間配列や可変長引数を使わずループで計算するよう変更しています。長大なコード断片をMarkdownへ埋め込む際の安定性とメモリ効率を改善する変更です。
- `buildFencedCodeBlock`の最大値計算を`for...of`へ置換
- パフォーマンス上の学びを`.jules/bolt.md`へ追記
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

実装変更は安全にマージできると見られますが、追加した学習記録は日本語へ直すことを推奨します。

最大値計算は従来と同じ結果を保ちながら、大量のマッチを可変長引数として展開する処理を除去しています。確認された問題はドキュメント言語の不統一のみで、実行時の動作を妨げません。

**Files Needing Attention:** .jules/bolt.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/markdownFencing.ts | 最大バッククォート長の計算を出力互換なループへ変更しており、フェンス生成の契約は維持されています。 |
| .jules/bolt.md | 最適化方針を記録していますが、追加部分がリポジトリの日本語ドキュメント規約に反しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/bolt.md:62-64
**学習記録が英語表記です**

追加された見出し、Learning、Actionが英語で記述されているため、日本語でドキュメントを記述するリポジトリ規約との一貫性が失われています。追加部分を日本語へ統一してください。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Optimize buildFencedCodeBlock performanc..."](https://github.com/hiroki-org/jules-extension/commit/f27bff256aafb74e5d61c69603db247bc610d6c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54391171)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))
- Knowledge Base — [Session Artifacts and Patches](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/session-artifacts-and-patches.md)

<!-- /greptile_comment -->