### PR TITLE
🛡️ Sentinel: [MEDIUM] Content-Security-Policyでの object-src 'none' の強制

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+
+## 2026-08-18 - CSPにおける object-src 'none' の強制
+**Vulnerability:** WebView における Content-Security-Policy にて `default-src 'none'` を設定している場合でも、レガシーブラウザの挙動により `<object>`、`<embed>`、`<applet>` などのタグを通じて悪意のあるプラグインが実行されるリスクがあります。
+**Learning:** `default-src 'none'` が存在しても、多層防御のベストプラクティスとして `object-src 'none'` ディレクティブを明示的に含める必要があります。
+**Prevention:** WebViewのHTMLを生成する際は、常に `object-src 'none'` をCSPに含めて設定します。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WebViewの Content-Security-Policy (CSP) において `default-src 'none'` を指定していますが、レガシーブラウザにおけるプラグイン実行（`<object>`, `<embed>`, `<applet>`など）のフォールバック動作を悪用されるリスクがありました。
🎯 Impact: プラグインを介した予期しないコンテンツのロードや、潜在的なコード実行に繋がる可能性があります。
🔧 Fix: CSPのメタタグに `object-src 'none'` を明示的に追加し、多層防御（Defense-in-depth）を強化しました。
✅ Verification: 自動テストを追加し、出力されるHTMLに `object-src 'none'` が含まれることを確認しました。

---
*PR created automatically by Jules for task [8052258371696943295](https://jules.google.com/task/8052258371696943295) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

WebView の CSP を多層防御の観点から強化する変更です。
- チャットおよびコンポーザーの CSP に `object-src 'none'` を追加
- 両方の生成 HTML に新しいディレクティブが含まれることを単体テストで検証
- セキュリティ上の学びを Sentinel 文書へ追記
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は安全にマージできると考えられ、変更によるブロッキングな問題や具体的な非ブロッキング問題は確認されませんでした。

追加された CSP ディレクティブは有効な構文であり、チャットとコンポーザーはいずれもオブジェクト／プラグインリソースを使用していないため、既存機能を遮断せずにポリシーを強化しています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット WebView の有効な CSP に `object-src 'none'` を追加しており、既存のスクリプトおよびスタイル読み込みとの競合はありません。 |
| src/composer.ts | コンポーザー WebView の CSP に同じ制限を追加しており、現在使用されるリソースを遮断しません。 |
| src/test/chatView.unit.test.ts | 生成されたチャット HTML に `object-src 'none'` が含まれることを既存の CSP テスト内で検証しています。 |
| src/test/composer.unit.test.ts | コンポーザー HTML の新しい CSP ディレクティブを対象とする単体テストを追加しています。 |
| .jules/sentinel.md | WebView CSP で `object-src 'none'` を明示する予防方針を記録しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: Content-Security-Policyでの ..."](https://github.com/hiroki-org/jules-extension/commit/0ea1f931db729d3f0cd53ce5b48ac2af58a8307c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54403525)</sub>

**Context used:**

- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->