### PR TITLE
🛡️ Sentinel: [MEDIUM] Content-Security-Policyにobject-src 'none'を追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+
+## 2024-08-19 - [Content-Security-Policy Defense-in-Depth]
+**Vulnerability:** Even with default-src 'none', legacy browser quirks might bypass defaults and execute malicious plugins via object tags.
+**Learning:** Explicitly setting object-src 'none' acts as a defense-in-depth best practice against plugin-based XSS.
+**Prevention:** Always explicitly define object-src 'none' in Content-Security-Policy for WebViews.

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: default-src 'none'が設定されていても、古いブラウザの仕様により<object>タグ等を通じた悪意あるプラグインの実行を許容する可能性があります。
🎯 Impact: コンテキスト内での予期せぬスクリプト実行やXSS
🔧 Fix: Content-Security-Policyヘッダーに明示的に \`object-src 'none'\` を追加し、多層防御（Defense in Depth）を強化しました。
✅ Verification: 生成されるHTMLのCSPタグに \`object-src 'none'\` が含まれていることをテストで確認しました。

---
*PR created automatically by Jules for task [3852259871902835932](https://jules.google.com/task/3852259871902835932) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

チャットとコンポーザーの Webview CSP に `object-src 'none'` を明示し、プラグイン経由のコンテンツ実行に対する多層防御を追加します。

- 2つの Webview HTML 生成処理に `object-src 'none'` を追加
- 生成された CSP を確認するユニットテストを追加
- Sentinel のセキュリティ知識を更新
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

CSP の変更は安全にマージできると見られますが、Sentinel の新規記録はリポジトリ規約に合わせて日本語へ修正してください。

`object-src 'none'` は既存の Webview リソース許可を壊さず、対応するテストも追加されています。残る指摘は新規ドキュメントの言語規約違反のみです。

**Files Needing Attention:** .jules/sentinel.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット Webview の CSP に `object-src 'none'` を追加しており、既存の nonce 付きスクリプトおよびスタイル許可への影響はありません。 |
| src/composer.ts | コンポーザー Webview の CSP に `object-src 'none'` を追加しており、既存の画像・スクリプト・スタイル許可は維持されています。 |
| src/test/chatView.unit.test.ts | チャット Webview の生成 HTML に `object-src 'none'` が含まれることを検証しています。 |
| src/test/composer.unit.test.ts | コンポーザーの CSP に `object-src 'none'` が含まれることを検証するテストを追加しています。 |
| .jules/sentinel.md | CSP 強化の知識を追加していますが、新規記述がリポジトリの日本語規約に従っていません。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/sentinel.md:39-42
**セキュリティ記録の言語混在**

新しく追加された CSP の記録が英語で記述されており、ドキュメントを日本語で記述するリポジトリ規約に反しています。同一ファイル内で言語が混在し、セキュリティ知識の保守性が低下するため、日本語に統一してください。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] Content-Security-..."](https://github.com/hiroki-org/jules-extension/commit/44f3e5055c9fb6bd59b377b0a19ee3c3adbc4706) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54818278)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))
- Knowledge Base — [Chat and Composer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/chat-and-composer.md)

<!-- /greptile_comment -->