### PR TITLE
⚡ Bolt: マークダウンフェンシングにおけるスプレッド構文の使用を廃止

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,6 @@
 
 **Learning:** リモートブランチの存在確認を逐次実行すると、リモート数に比例して待ち時間が増加します。
 **Action:** 各Promise内でエラーを捕捉して存在確認を並列開始し、結果は優先順に個別評価します。
+## 2026-08-19 - Avoid spread operator for large dynamic arrays
+**Learning:** Using the spread operator (e.g., `Math.max(...array)`) on large dynamic arrays, such as regex match results from large documents, causes a 'Maximum call stack size exceeded' error and unnecessary memory allocations.
+**Action:** Use an imperative `for...of` loop instead of spread syntax and `.map()` to process potentially unbounded arrays safely and efficiently.

--- a/src/markdownFencing.ts
+++ b/src/markdownFencing.ts
@@ -7,9 +7,15 @@
 export function buildFencedCodeBlock(code: string, languageId: string): string {
     // Find the longest sequence of backticks in the code
     const backtickMatches = code.match(/`+/g);
-    const longestBacktickSequence = backtickMatches 
-        ? Math.max(...backtickMatches.map(m => m.length)) 
-        : 0;
+    // 巨大なマークダウン文字列での Maximum call stack size exceeded エラーと不要な配列生成を防ぐため、スプレッド構文とmapではなくfor...ofループを使用する
+    let longestBacktickSequence = 0;
+    if (backtickMatches) {
+        for (const m of backtickMatches) {
+            if (m.length > longestBacktickSequence) {
+                longestBacktickSequence = m.length;
+            }
+        }
+    }
     
     // Use at least 3 backticks, or one more than the longest sequence found
     const fenceLength = Math.max(3, longestBacktickSequence + 1);


### PR DESCRIPTION
💡 What: `Math.max(...matches.map())` の呼び出しを `for...of` ループによる最大値の計算に置き換えました。

🎯 Why: 巨大なマークダウン文字列を処理する際、正規表現による大量のバッククォートの一致結果（配列）が生成され、それをスプレッド構文で渡すと、スタックオーバーフロー（Maximum call stack size exceeded）エラーが発生し、不必要なメモリ割り当てが生じるためです。

📊 Impact: 動的で巨大な配列を処理する際のスタックオーバーフローを防ぎ、メモリ使用量を削減します。

🔬 Measurement: 大規模なマークダウン文字列を生成するベンチマークスクリプトにおいて、メモリ効率の向上とスタックオーバーフローの解消が確認できます。

---
*PR created automatically by Jules for task [242583621487512969](https://jules.google.com/task/242583621487512969) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`buildFencedCodeBlock` の最大バッククォート列長の計算を、巨大な配列でも引数上限に達しない反復処理へ変更しています。
- `Math.max(...matches.map(...))` を追加配列や大量の関数引数を生成しない `for...of` ループへ置換
- 大規模な Markdown 入力に関する知見と対応方針を `.jules/bolt.md` に記録
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

ブロッキングとなる問題は確認されず、この PR は安全にマージできると判断します。

新しいループは従来と同じ最長バッククォート列長を算出し、最低3文字かつ内部の最長列より1文字長いフェンスを生成する既存契約を維持しながら、巨大入力でのスプレッド構文の失敗を回避しています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/markdownFencing.ts | フェンス長の算出結果を維持しながら、大量のバッククォート列による引数上限エラーと中間配列の生成を回避しています。 |
| .jules/bolt.md | 大規模な動的配列にスプレッド構文を使用しないという、今回の最適化で得られた知見を追記しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: マークダウンフェンシングにおけるスプレッド構文の使用を廃止"](https://github.com/hiroki-org/jules-extension/commit/b3a16331df6879f043f78ce94fb0a07f9e3a3537) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54836697)</sub>

**Context used:**

- Knowledge Base — [Session Artifacts and Patches](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/session-artifacts-and-patches.md)

<!-- /greptile_comment -->