### PR TITLE
🛡️ Sentinel: [MEDIUM] WebviewのCSPに object-src 'none' を追加

### DIFF
--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: CSPに `object-src 'none'` が明示的に指定されていません。
🎯 Impact: `default-src 'none'` が指定されていても、古いブラウザの挙動等によりプラグイン（`<object>`, `<embed>`, `<applet>`など）が実行されるリスクがあります。
🔧 Fix: Defense-in-depthのベストプラクティスに従い、WebviewのCSPに `object-src 'none'` を明示的に追加しました。
✅ Verification: 単体テストを追加し、テストが成功することを確認。

---
*PR created automatically by Jules for task [7421080765940559787](https://jules.google.com/task/7421080765940559787) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

チャットビューとコンポーザーの Content Security Policy に `object-src 'none'` を明示し、プラグインコンテンツを防御的に無効化する変更です。
- 2つの Webview の CSP を強化
- 生成された HTML に新しいディレクティブが含まれることを単体テストで検証
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は安全にマージできると判断します。

両 Webview の CSP を既存の `default-src 'none'` からさらに明示的に強化する変更であり、対象画面にはオブジェクト系コンテンツへ依存する到達可能な機能がなく、対応するテストも追加されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット Webview の CSP に `object-src 'none'` を追加しており、既存の必要なリソースを妨げる変更は確認されませんでした。 |
| src/composer.ts | コンポーザー Webview の CSP に同じ制約を追加しており、既存 UI との競合は確認されませんでした。 |
| src/test/chatView.unit.test.ts | チャット Webview の生成 HTML に `object-src 'none'` が含まれることを既存の CSP テストで検証しています。 |
| src/test/composer.unit.test.ts | コンポーザーの CSP に追加されたディレクティブを検証する単体テストを追加しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] WebviewのCSPに obje..."](https://github.com/hiroki-org/jules-extension/commit/2e98e45a450ef3dd8f574948ba5393d70ac12acc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55228481)</sub>

<!-- /greptile_comment -->