### PR TITLE
⚡ Bolt: 正規表現マッチ結果におけるスプレッド構文と中間配列生成の排除

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 
 **Learning:** リモートブランチの存在確認を逐次実行すると、リモート数に比例して待ち時間が増加します。
 **Action:** 各Promise内でエラーを捕捉して存在確認を並列開始し、結果は優先順に個別評価します。
+
+## 2026-08-22 - [Performance] Eliminating spread operators in regex match arrays
+**Learning:** 巨大なマークダウン文書などをパースした際の大量の正規表現マッチ結果配列に対して、スプレッド構文（例: `Math.max(...matches)`）を使用すると 'Maximum call stack size exceeded' エラーが発生するリスクがあります。
+**Action:** 動的で要素数が肥大化する可能性のある配列を処理する場合は、スプレッド構文や中間配列を生成する `.map()` を避け、`for...of` ループを使用した命令的な処理に置き換えることで、コールスタックエラーを防ぎメモリ消費を抑えます。

--- a/src/markdownFencing.ts
+++ b/src/markdownFencing.ts
@@ -7,9 +7,16 @@
 export function buildFencedCodeBlock(code: string, languageId: string): string {
     // Find the longest sequence of backticks in the code
     const backtickMatches = code.match(/`+/g);
-    const longestBacktickSequence = backtickMatches 
-        ? Math.max(...backtickMatches.map(m => m.length)) 
-        : 0;
+
+    let longestBacktickSequence = 0;
+    if (backtickMatches) {
+        // パフォーマンス最適化：巨大なマークダウン文字列においてスプレッド構文による Math.max(...array) が引き起こす 'Maximum call stack size exceeded' エラーを防ぎ、.map() による中間配列のメモリ割り当てを削減します。
+        for (const match of backtickMatches) {
+            if (match.length > longestBacktickSequence) {
+                longestBacktickSequence = match.length;
+            }
+        }
+    }
     
     // Use at least 3 backticks, or one more than the longest sequence found
     const fenceLength = Math.max(3, longestBacktickSequence + 1);


### PR DESCRIPTION
💡 What: `src/markdownFencing.ts` 内の `Math.max(...backtickMatches.map(m => m.length))` を `for...of` ループに置き換えました。
🎯 Why: 巨大なマークダウン文字列をパースする際、正規表現マッチの要素数が多くなるとスプレッド構文によりコールスタックエラー（Maximum call stack size exceeded）が発生するリスクがあり、また `.map()` による中間配列の生成が不要なメモリを消費するためです。
📊 Impact: 大量のバッククォートを含む巨大な文書処理時のクラッシュを防ぎ、配列割り当てを省略することで処理速度とメモリ効率が向上します。
🔬 Measurement: 巨大な文字列を含むドキュメントに対しても、エラーが発生せず、プロファイリングにおいてメモリ割り当て量が減少していることが確認できます。

---
*PR created automatically by Jules for task [3109222098527878871](https://jules.google.com/task/3109222098527878871) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、Markdownコードフェンス内の最長バッククォート列を求める処理を、スプレッド構文と中間配列を使わない反復処理へ置き換えています。既存の出力を維持しつつ、大量のマッチがある文書でのコールスタック超過と不要なメモリ割り当てを回避します。
- `buildFencedCodeBlock` の最大長計算を `for...of` ループへ変更
- 同じ最適化方針を `.jules/bolt.md` に学習事項として記録
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

動作上の問題は確認されず、安全にマージできる変更です。

最長バッククォート列の初期値、マッチなしの場合、複数マッチの最大値という既存の計算結果を維持しながら、問題となるスプレッド展開と中間配列だけを除去しています。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/markdownFencing.ts | 最長バッククォート列の算出を、既存動作と等価な逐次比較へ安全に置き換えています。 |
| .jules/bolt.md | 大規模な動的配列に対するスプレッド構文を避ける最適化方針を追記しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: 正規表現マッチ結果におけるスプレッド構文と中間配列生成の排除"](https://github.com/hiroki-org/jules-extension/commit/5bae9ef32895eb607070ed73f36ca2bae9086cb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55867750)</sub>

<!-- /greptile_comment -->