### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Webview CSP to explicitly forbid objects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,7 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+## 2026-08-22 - [WebView CSPに object-src 'none' を追加]
+**Vulnerability:** WebViewのCSPで default-src 'none' を指定していても、レガシーブラウザの挙動によりプラグイン（<object>, <embed>, <applet>など）の実行を許してしまう可能性があります。
+**Learning:** 防御の多層化（defense-in-depth）のベストプラクティスとして、WebViewのCSPを設定する際は default-src 'none' に加えて object-src 'none' を明示的に指定する必要があります。
+**Prevention:** 常に CSP ディレクティブに object-src 'none' を含めるようにします。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WebViewのCSPで `default-src 'none'` を指定していても、レガシーブラウザの挙動によりプラグインの実行を許してしまう可能性があります。
🎯 Impact: プラグイン（`<object>`, `<embed>`, `<applet>`など）を通じた攻撃を許す可能性があります。
🔧 Fix: WebViewのCSPに `object-src 'none'` を明示的に追加し、防御の多層化（defense-in-depth）を実装しました。
✅ Verification: ユニットテストを追加し、`pnpm test` が通過することを確認しました。

---
*PR created automatically by Jules for task [15592618961717610422](https://jules.google.com/task/15592618961717610422) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Webview の CSP に `object-src 'none'` を明示し、オブジェクトやプラグインの読み込みを多層防御として禁止する変更です。
- チャット Webview とメッセージコンポーザーの CSP を強化
- 両方の HTML 生成テストに CSP ディレクティブの検証を追加
- セキュリティ上の知見を Sentinel 文書へ記録
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は安全にマージできると考えられます。

`object-src 'none'` の追加は既存の Webview リソース許可や nonce を変更せず、チャットとコンポーザーの双方で意図した CSP 強化がテストされています。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット Webview の CSP に `object-src 'none'` を追加しており、既存のスクリプト、スタイル、nonce、ローカルリソースの契約は維持されています。 |
| src/composer.ts | コンポーザーの CSP に同じ制限を追加しており、既存の画像、スクリプト、スタイル設定には影響しません。 |
| src/test/chatView.unit.test.ts | 生成されたチャット HTML に新しい CSP ディレクティブが含まれることを検証しています。 |
| src/test/composer.unit.test.ts | 生成されたコンポーザー HTML に新しい CSP ディレクティブが含まれることを検証しています。 |
| .jules/sentinel.md | 今回の CSP 強化の目的と再発防止策を記録しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] Fix Webview CSP t..."](https://github.com/hiroki-org/jules-extension/commit/bc592a47c1ccb490855d3677b5f7fe8877447b98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55888510)</sub>

<!-- /greptile_comment -->