### PR TITLE
🛡️ Sentinel: [MEDIUM] WebViewのCSPにobject-src 'none'を追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+
+## 2024-08-23 - Defense-in-depth Content Security Policy
+**Vulnerability:** WebView CSP headers missing `object-src 'none'` directive.
+**Learning:** Despite `default-src 'none'`, legacy browser quirks might bypass fallback and execute malicious plugins via `<object>`, `<embed>`, or `<applet>` tags.
+**Prevention:** Always explicitly include `object-src 'none'` in WebViews CSP as a defense-in-depth measure.

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -518,13 +518,14 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes(`<script nonce="${testNonce}">`));
     });
 
-    test("should include base-uri 'none' in Content-Security-Policy", () => {
+    test("should include base-uri 'none' and object-src 'none' in Content-Security-Policy", () => {
       const html = getComposerHtml(
         mockWebview,
         { title: "Test" },
         "nonce-123"
       );
       assert.ok(html.includes("base-uri 'none'"));
+      assert.ok(html.includes("object-src 'none'"));
     });
 
     test("should set submitButton disabled state based on validation result", () => {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WebViewのContent-Security-Policy (CSP) において、`object-src 'none'`ディレクティブが欠落していました。
🎯 Impact: `default-src 'none'`が存在していても、レガシーブラウザの挙動によりフォールバックがバイパスされ、`<object>`、`<embed>`、または`<applet>`を介して悪意のあるプラグインが実行されるリスクがあります。
🔧 Fix: 防御的プログラミングの観点から、CSPヘッダーに明示的に`object-src 'none'`ディレクティブを追加しました。
✅ Verification: `pnpm run test`により、テストスイートが正常に実行されることを確認しました。

---
*PR created automatically by Jules for task [11084159601982509757](https://jules.google.com/task/11084159601982509757) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

WebView の Content Security Policy を防御的に強化し、チャットビューとコンポーザーでプラグイン由来コンテンツを明示的に無効化する変更です。
- 両 WebView の CSP に `object-src 'none'` を追加
- CSP ディレクティブの存在を確認する単体テストを追加
- セキュリティ上の学びと再発防止策を Sentinel 文書へ追記
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は安全にマージできると考えられ、変更による機能上またはセキュリティ上の問題は確認されませんでした。

既存 CSP に制限を追加するだけの局所的な変更であり、チャットビューとコンポーザーの双方に対応する回帰テストも追加されています。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット WebView の既存 CSP に `object-src 'none'` を正しく追加しており、既存の nonce およびリソース許可設定を壊していません。 |
| src/composer.ts | コンポーザー WebView の CSP に同じ防御的ディレクティブを追加しており、既存機能への影響は見当たりません。 |
| src/test/chatView.unit.test.ts | 生成されたチャット HTML に新しい CSP ディレクティブが含まれることを検証しています。 |
| src/test/composer.unit.test.ts | コンポーザー HTML に `base-uri` と `object-src` の両制約が含まれることを検証しています。 |
| .jules/sentinel.md | 今回の防御的 CSP 強化について、脆弱性の背景と再発防止策を記録しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[MEDIUM\] Add object-src &#39;n..."](https://github.com/hiroki-org/jules-extension/commit/c59eac19d4f68df8cc1d62c8a8bb343066627e9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56017358)</sub>

<!-- /greptile_comment -->