### PR TITLE
⚡ Bolt: [パフォーマンス改善] マークダウンフェンシングの配列展開によるコールスタック超過エラーを防止

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 
 **Learning:** リモートブランチの存在確認を逐次実行すると、リモート数に比例して待ち時間が増加します。
 **Action:** 各Promise内でエラーを捕捉して存在確認を並列開始し、結果は優先順に個別評価します。
+
+## 2026-08-23 - [Performance] Eliminating spread operators on unbounded arrays
+**Learning:** Using spread syntax (`...`) on potentially unbounded dynamic arrays (like regex match results from parsing large text) can cause 'Maximum call stack size exceeded' errors because engine argument limits are exceeded. Additionally, chained `.map()` calls create unnecessary intermediate array allocations.
+**Action:** Use a single-pass `for...of` loop instead of `Math.max(...array.map())` when processing dynamically sized arrays that could potentially be very large.

--- a/src/markdownFencing.ts
+++ b/src/markdownFencing.ts
@@ -7,9 +7,16 @@
 export function buildFencedCodeBlock(code: string, languageId: string): string {
     // Find the longest sequence of backticks in the code
     const backtickMatches = code.match(/`+/g);
-    const longestBacktickSequence = backtickMatches 
-        ? Math.max(...backtickMatches.map(m => m.length)) 
-        : 0;
+    let longestBacktickSequence = 0;
+
+    if (backtickMatches) {
+        // パフォーマンス最適化: spread演算子や.map()による配列アロケーションと "Maximum call stack size exceeded" エラーを防ぐため、for...of ループを使用
+        for (const match of backtickMatches) {
+            if (match.length > longestBacktickSequence) {
+                longestBacktickSequence = match.length;
+            }
+        }
+    }
     
     // Use at least 3 backticks, or one more than the longest sequence found
     const fenceLength = Math.max(3, longestBacktickSequence + 1);


### PR DESCRIPTION
💡 What: `Math.max(...array.map())` を `for...of` ループによる最大値算出に置き換えました。
🎯 Why: 大きなマークダウンファイル等のパース時に、大量の正規表現マッチ結果をスプレッド演算子で展開すると `Maximum call stack size exceeded` エラーが発生し、中間配列によるメモリ割り当てのオーバーヘッドが生じるため。
📊 Impact: 大量のバッククォートを含む巨大な文字列の処理時におけるクラッシュを完全に防ぎ、中間配列のアロケーションを削減します。
🔬 Measurement: `benchmark.js` の実行でコールスタック超過エラーが解消され、正常終了することを確認済み。

---
*PR created automatically by Jules for task [15190094526258834793](https://jules.google.com/task/15190094526258834793) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

巨大な Markdown 入力で引数展開の上限を超えないよう、バッククォートの最大連続長を単一パスのループで算出する変更です。
- `Math.max(...array.map())` を定数領域の `for...of` ループへ置き換えています。
- フェンスを最長のバッククォート列より1文字長くする既存仕様は維持されています。
- パフォーマンス上の学習事項を `.jules/bolt.md` に追記しています。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

実装変更は安全にマージできると見られますが、追加ドキュメントは日本語へ修正することを推奨します。

最大長計算は既存のフェンス生成仕様を維持したままスタック超過要因を除去しており、確認された問題はドキュメント言語規約への違反のみです。

**Files Needing Attention:** .jules/bolt.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/markdownFencing.ts | 最大バッククォート長の計算を挙動等価なループへ置き換え、巨大なマッチ配列の展開によるクラッシュを回避しています。 |
| .jules/bolt.md | 最適化の学習記録を追加していますが、本文がリポジトリの日本語ドキュメント規約に準拠していません。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/bolt.md:63-65
**学習記録が言語規約に違反**

追加された見出し、Learning、Action が英語で記述されており、ドキュメントを日本語で記述するリポジトリ規約に違反しています。

```suggestion
## 2026-08-23 - [パフォーマンス] サイズが不定な配列でのスプレッド演算子を排除
**Learning:** 大きなテキストの正規表現マッチ結果など、サイズが不定な動的配列でスプレッド構文（`...`）を使用すると、エンジンの引数上限を超えて `Maximum call stack size exceeded` エラーが発生する場合があります。また、連鎖した `.map()` は不要な中間配列を生成します。
**Action:** 非常に大きくなる可能性がある動的配列を処理する場合は、`Math.max(...array.map())` の代わりに単一パスの `for...of` ループを使用します。
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: \[パフォーマンス改善\] マークダウンフェンシングの配列展開による..."](https://github.com/hiroki-org/jules-extension/commit/3e2f98f18eb8de5293cb8936dd549428cabed6f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56045938)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))
- Knowledge Base — [Prompt construction and inline commands](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/prompt-construction-and-inline-commands.md)

<!-- /greptile_comment -->