### PR TITLE
🛡️ Sentinel: [MEDIUM] Content-Security-Policy に object-src 'none' を追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+
+## 2024-05-24 - [Content-Security-Policy の object-src 設定]
+**Vulnerability:** WebViewのCSPに `object-src 'none'` が明示的に設定されていない場合、レガシーブラウザの挙動等で `<object>` などのプラグインを介した攻撃を許す可能性があります。
+**Learning:** `default-src 'none'` がある場合でも、多層防御として `object-src 'none'` を明示的に設定することがベストプラクティスです。
+**Prevention:** 常に `object-src 'none'` をCSPヘッダーに含めるようにします。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WebViewの Content-Security-Policy (CSP) において、`object-src 'none'` が明示的に指定されていません。
🎯 Impact: `default-src 'none'` が存在しても、レガシーなブラウザ環境などで `<object>`, `<embed>`, `<applet>` を通じた攻撃（プラグインの実行による防御迂回）を許すリスクがあります。
🔧 Fix: `src/composer.ts` および `src/chatView.ts` の CSP 定義に `object-src 'none';` を追加しました。
✅ Verification: 修正後の CSP に `object-src 'none'` が含まれることを自動テスト (`pnpm test`) で確認済みです。

---
*PR created automatically by Jules for task [6008078295939708747](https://jules.google.com/task/6008078295939708747) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Chat と Composer の WebView に対する CSP を強化し、プラグイン系コンテンツを明示的に禁止します。
- 両 WebView の CSP に `object-src 'none'` を追加
- 生成 HTML に新しいディレクティブが含まれることを単体テストで確認
- Sentinel のセキュリティ知見を更新
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は安全にマージできると判断します。

現行の Chat および Composer の HTML はオブジェクト系コンテンツに依存しておらず、追加されたディレクティブは構文的に正しく、既存リソースに必要な CSP 許可も維持されています。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/chatView.ts | Chat WebView の既存 CSP を壊さずに `object-src 'none'` を追加している。 |
| src/composer.ts | Composer WebView の CSP に同じ制限を追加し、既存の画像・スクリプト・スタイル許可を維持している。 |
| src/test/chatView.unit.test.ts | Chat WebView の生成 HTML に新しい CSP ディレクティブが含まれることを検証している。 |
| src/test/composer.unit.test.ts | Composer の CSP に `object-src 'none'` が含まれることを検証するテストを追加している。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Security: Add object-src &#39;none&#39; to CSP"](https://github.com/hiroki-org/jules-extension/commit/67862d4e0869c1672058606a94a7d8a043ab323a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56299178)</sub>

<!-- /greptile_comment -->