### PR TITLE
🛡️ Sentinel: [セキュリティ改善] WebView CSP に object-src 'none' を追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,7 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+## 2026-08-25 - WebView CSP に object-src 'none' を追加
+**Vulnerability:** WebViewの Content-Security-Policy において `object-src 'none'` が欠落していました。
+**Learning:** `default-src 'none'` が存在する場合でも、古いブラウザの挙動によりフォールバックがバイパスされる可能性があるため、明示的に `object-src 'none'` を設定することで多層防御になります。
+**Prevention:** WebViewの Content-Security-Policy を設定する際は、常に明示的に `object-src 'none'` を含めるようにします。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -518,13 +518,14 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes(`<script nonce="${testNonce}">`));
     });
 
-    test("should include base-uri 'none' in Content-Security-Policy", () => {
+    test("should include base-uri 'none' and object-src 'none' in Content-Security-Policy", () => {
       const html = getComposerHtml(
         mockWebview,
         { title: "Test" },
         "nonce-123"
       );
       assert.ok(html.includes("base-uri 'none'"));
+      assert.ok(html.includes("object-src 'none'"));
     });
 
     test("should set submitButton disabled state based on validation result", () => {


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: WebViewのContent-Security-Policyに `object-src 'none'` が明示的に指定されていませんでした。
🎯 Impact: `default-src 'none'` が設定されていますが、古いブラウザの挙動により、フォールバックをバイパスして悪意のあるプラグイン (例: `<object>`, `<embed>`, `<applet>`) が実行されるリスクを減らすための多層防御です。
🔧 Fix: `src/composer.ts` および `src/chatView.ts` のCSPに `object-src 'none'` を明示的に追加しました。
✅ Verification: テストを追加し、`object-src 'none'` がCSPに含まれることを確認しました。

---
*PR created automatically by Jules for task [17557326702673779296](https://jules.google.com/task/17557326702673779296) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Chat と Composer の WebView CSP に `object-src 'none'` を明示し、オブジェクト系コンテンツを多層防御として無効化する変更です。
- `src/chatView.ts` と `src/composer.ts` の CSP を強化
- 両 WebView の単体テストにディレクティブの確認を追加
- Sentinel のセキュリティ知見を更新
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

具体的な不具合やマージを妨げる問題は見つからず、安全にマージできる変更に見えます。

追加された CSP は構文上正しい位置にあり、両 WebView が必要とするスクリプト、スタイル、画像、nonce の許可を変えずにオブジェクト系コンテンツのみを明示的に禁止しています。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/chatView.ts | Chat WebView の有効な CSP ディレクティブ境界に `object-src 'none'` を追加しており、既存資産の許可設定には影響しません。 |
| src/composer.ts | Composer WebView の CSP に `object-src 'none'` を明示し、既存の nonce、画像、スタイル設定を維持しています。 |
| src/test/chatView.unit.test.ts | 生成された Chat WebView HTML に新しい CSP ディレクティブが含まれることを検証しています。 |
| src/test/composer.unit.test.ts | Composer の CSP テストを拡張し、`base-uri` と `object-src` の両方を確認しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[セキュリティ改善\] WebView CSP に o..."](https://github.com/hiroki-org/jules-extension/commit/9012b229beb2092bf385241906f22f864e670bd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56690252)</sub>

<!-- /greptile_comment -->