### PR TITLE
⚡ Bolt: [Performance] markdownFencingで巨大な文字列に対するMath.maxとspread演算子によるエラーとメモリ確保を回避

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 
 **Learning:** リモートブランチの存在確認を逐次実行すると、リモート数に比例して待ち時間が増加します。
 **Action:** 各Promise内でエラーを捕捉して存在確認を並列開始し、結果は優先順に個別評価します。
+
+## 2026-08-25 - [Performance] Avoid spread operator with Math.max on large arrays
+**Learning:** Using `Math.max(...array.map(...))` on potentially very large dynamically generated arrays (like regex matches on large markdown contents) causes unnecessary intermediate array allocations and "Maximum call stack size exceeded" errors.
+**Action:** Iterate through the array using a `for...of` loop to find the maximum value, which avoids call stack limits and reduces memory footprint.

--- a/src/markdownFencing.ts
+++ b/src/markdownFencing.ts
@@ -7,9 +7,15 @@
 export function buildFencedCodeBlock(code: string, languageId: string): string {
     // Find the longest sequence of backticks in the code
     const backtickMatches = code.match(/`+/g);
-    const longestBacktickSequence = backtickMatches 
-        ? Math.max(...backtickMatches.map(m => m.length)) 
-        : 0;
+    let longestBacktickSequence = 0;
+    // メモリ割り当てとMaximum call stack size exceededエラーを防ぐため、スプレッド構文と.mapを避ける
+    if (backtickMatches) {
+        for (const match of backtickMatches) {
+            if (match.length > longestBacktickSequence) {
+                longestBacktickSequence = match.length;
+            }
+        }
+    }
     
     // Use at least 3 backticks, or one more than the longest sequence found
     const fenceLength = Math.max(3, longestBacktickSequence + 1);


### PR DESCRIPTION
💡 What: `Math.max(...array.map(...))` を `for...of` ループによる最大値探索に置き換えました。
🎯 Why: 巨大なMarkdownを処理する際にバッククォートの数が非常に多いと、スプレッド演算子によってスタックサイズ超過エラー（Maximum call stack size exceeded）が発生し、中間配列生成によるメモリの無駄遣いが発生するため。
📊 Impact: 大規模な文字列でのクラッシュを防止し、配列の割り当てを減らすことでメモリ使用量と実行速度を改善します。
🔬 Measurement: `src/markdownFencing.ts` に処理を通すか、単体テスト `pnpm test` で正常動作することを確認できます。

---
*PR created automatically by Jules for task [9007695035414516769](https://jules.google.com/task/9007695035414516769) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`markdownFencing`の最大バッククォート連続数の探索を、スプレッド構文と中間配列を使う処理から反復処理へ置き換えています。
- 巨大な一致配列を関数引数として展開することによる実行時エラーを回避
- `.map()`による追加の中間配列確保を削減
- 変更の背景と対応方針をBolt学習記録へ追記
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

実装変更は安全にマージできると見られますが、追加された学習記録はリポジトリ規約に合わせて日本語へ修正してください。

最大バッククォート長の計算は従来と等価で、変更目的の大量引数展開も解消されています。残る指摘は文書の言語規約違反のみで、実行時動作を妨げません。

**Files Needing Attention:** .jules/bolt.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/markdownFencing.ts | 最大値探索を等価な反復処理へ置き換えており、フェンス生成の既存動作を維持しながら大量引数展開を解消しています。 |
| .jules/bolt.md | 最適化の学びと対応方針を追加していますが、リポジトリの日本語記述ルールに反して英語で記載されています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/bolt.md:62-65
**学習記録が英語表記です**

新しく追加された見出し、Learning、Actionが英語で記述されており、出力、コメント、ドキュメントを原則として日本語で記述するリポジトリ規約および周囲の記録と不整合になっています。内容を日本語へ統一してください。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: Avoid spread operator in markdow..."](https://github.com/hiroki-org/jules-extension/commit/c1146582d28f0e7d8884e5f01a32dce4813937fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56722538)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))

<!-- /greptile_comment -->