### PR TITLE
⚡ Bolt: [パフォーマンス改善] マークダウンパース時のスプレッド演算子を排除

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 
 **Learning:** リモートブランチの存在確認を逐次実行すると、リモート数に比例して待ち時間が増加します。
 **Action:** 各Promise内でエラーを捕捉して存在確認を並列開始し、結果は優先順に個別評価します。
+
+## 2026-08-26 - [Performance] Eliminating spread operators for unbounded dynamic arrays
+**Learning:** Using spread syntax (...array) with dynamically sized arrays (like regex match results from large markdown files) can cause "Maximum call stack size exceeded" errors and unnecessary memory allocations via intermediate mapping.
+**Action:** Use an imperative for...of loop instead of Math.max(...matches.map()) when finding the maximum length in potentially unbounded dynamic string matches.

--- a/src/markdownFencing.ts
+++ b/src/markdownFencing.ts
@@ -7,9 +7,15 @@
 export function buildFencedCodeBlock(code: string, languageId: string): string {
     // Find the longest sequence of backticks in the code
     const backtickMatches = code.match(/`+/g);
-    const longestBacktickSequence = backtickMatches 
-        ? Math.max(...backtickMatches.map(m => m.length)) 
-        : 0;
+    let longestBacktickSequence = 0;
+    // パフォーマンス最適化: 大きなマークダウンドキュメントでのメモリ割り当てとスプレッド構文によるスタックオーバーフローを防ぐため、map()とスプレッド演算子の代わりにループを使用します
+    if (backtickMatches) {
+        for (const match of backtickMatches) {
+            if (match.length > longestBacktickSequence) {
+                longestBacktickSequence = match.length;
+            }
+        }
+    }
     
     // Use at least 3 backticks, or one more than the longest sequence found
     const fenceLength = Math.max(3, longestBacktickSequence + 1);


### PR DESCRIPTION
💡 What: マークダウンのコードブロックを生成する際のバッククォート長計算から、\`.map()\`とスプレッド演算子（\`Math.max(...)\`）を削除し、\`for...of\`ループに置き換えました。

🎯 Why: 非常に大きなマークダウンドキュメントをパースする際、多数のバッククォートマッチ結果が生成され、スプレッド演算子によって「Maximum call stack size exceeded」エラーが発生するリスクがあります。また、中間の配列割り当てが不要になるためメモリ効率が向上します。

📊 Impact: 大きな入力に対してコールスタックオーバーフローを完全に防止し、余分な配列割り当てと反復処理を削減します。

🔬 Measurement: 大量のバッククォートを含む巨大な文字列を\`buildFencedCodeBlock\`に渡した際の実行時間・メモリ使用量の改善およびスタックオーバーフローの解消。

---
*PR created automatically by Jules for task [11921565379094050356](https://jules.google.com/task/11921565379094050356) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

バッククォート列の最大長を求める処理を、配列生成とスプレッド構文を使わない反復処理へ変更しています。既存のフェンス生成規則を維持しながら、大規模な入力でのスタックオーバーフローと不要なメモリ割り当てを回避します。
- `buildFencedCodeBlock` の最大長計算を `for...of` ループへ置換
- 大規模な動的配列へスプレッド構文を適用しない方針を `.jules/bolt.md` に記録
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は安全にマージできると判断します。

変更後のループは到達可能なすべての文字列入力で従来と同じ最大バッククォート長を算出し、3 文字以上かつ入力中の最長列より長いフェンスを生成する契約を維持しながら、従来のスプレッド構文による例外経路を除去しています。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/markdownFencing.ts | 最大バッククォート長の計算を意味的に等価なループへ変更し、既存の安全なフェンス生成契約を維持しています。 |
| .jules/bolt.md | 大規模な動的配列に対するスプレッド構文を避けるパフォーマンス上の学びを追記しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ Bolt: \[パフォーマンス改善\] マークダウンパース時のスプレッド演算子を..."](https://github.com/hiroki-org/jules-extension/commit/beaf2d41706888d2c398489c799d46768836c7ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57123442)</sub>

**Context used:**

- Knowledge Base — [Prompt construction and inline commands](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/jules-extension/-/docs/prompt-construction-and-inline-commands.md)

<!-- /greptile_comment -->