### PR TITLE
🛡️ Sentinel: [Medium] Webview CSPsにobject-src 'none'を追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+
+## 2024-08-26 - WebviewのCSPにobject-src 'none'を追加
+**Vulnerability:** WebviewのContent-Security-Policy (CSP) に `object-src 'none'` が欠落していた。
+**Learning:** `default-src 'none'` が設定されていても、古いブラウザの挙動やプラグイン（<object>、<embed>など）の実行を防ぐための多層防御として `object-src 'none'` を明示的に指定する必要がある。
+**Prevention:** 新しくWebviewやHTMLを生成する際は、常にCSPに `object-src 'none'` を含めること。

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; object-src \'none\'; base-uri \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; object-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -86,6 +86,7 @@ suite("Chat View Unit Test Suite", () => {
       extensionUri,
     );
     assert.ok(html.includes('id="typing"'));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(html.includes('type:"sendMessage"') || html.includes('type: "sendMessage"'));
     assert.ok(html.includes("requestInitialState"));
     assert.ok(html.includes("copy-code-button"));

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WebviewのCSPに `object-src 'none'` が欠落していた。
🎯 Impact: レガシーブラウザの挙動やプラグインを悪用されるリスクがある。
🔧 Fix: `src/composer.ts` と `src/chatView.ts` のCSPに明示的に `object-src 'none'` を追加した。
✅ Verification: 各ユニットテストでCSPに `object-src 'none'` が含まれることを確認。

---
*PR created automatically by Jules for task [8427390791914029692](https://jules.google.com/task/8427390791914029692) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

チャットおよびコンポーザー Webview の CSP に `object-src 'none'` を追加し、プラグイン系コンテンツの読み込みを明示的に禁止しています。
- `src/chatView.ts` と `src/composer.ts` の CSP を強化
- 両 Webview の生成 HTML に新しいディレクティブが含まれることを単体テストで確認
- 今後の Webview にも同じ制約を適用するためのセキュリティ知見を記録
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

具体的な不具合や既存 Webview 機能への回帰は確認されず、この PR はマージして問題ないと考えられます。

追加された CSP ディレクティブは構文上既存ポリシーと整合し、現在のチャットおよびコンポーザーが利用するスクリプト、スタイル、画像、ローカルリソースの許可条件を変更しません。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャット Webview の既存 CSP に、現在のスクリプト・スタイル読み込みへ影響しない `object-src 'none'` を追加しています。 |
| src/composer.ts | コンポーザー Webview の CSP に `object-src 'none'` を追加し、既存ディレクティブと nonce の構成を維持しています。 |
| src/test/chatView.unit.test.ts | 生成されたチャット HTML に `object-src 'none'` が含まれることを既存の CSP テストへ追加しています。 |
| src/test/composer.unit.test.ts | コンポーザー HTML の新しい CSP ディレクティブを検証する単体テストを追加しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[Medium\] Add object-src &#39;n..."](https://github.com/hiroki-org/jules-extension/commit/4bfbd40a5cd0920105445914b18ff9d4f30e5997) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57139425)</sub>

<!-- /greptile_comment -->