### PR TITLE
⚡ Bolt: 正規表現マッチ結果でのスプレッド構文排除によるメモリ最適化とクラッシュ防止

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 
 **Learning:** リモートブランチの存在確認を逐次実行すると、リモート数に比例して待ち時間が増加します。
 **Action:** 各Promise内でエラーを捕捉して存在確認を並列開始し、結果は優先順に個別評価します。
+
+## 2026-08-27 - [Performance] Eliminating spread operators for large regex match arrays
+**Learning:** When processing regex match results from parsing large markdown documents, passing the array to functions using the spread syntax (e.g., `Math.max(...matches)`) causes a 'Maximum call stack size exceeded' error and unnecessary memory allocations.
+**Action:** Use an imperative `for...of` loop instead of spread syntax and `.map()` to prevent crashes on large inputs and eliminate intermediate array overhead.

--- a/src/markdownFencing.ts
+++ b/src/markdownFencing.ts
@@ -7,9 +7,15 @@
 export function buildFencedCodeBlock(code: string, languageId: string): string {
     // Find the longest sequence of backticks in the code
     const backtickMatches = code.match(/`+/g);
-    const longestBacktickSequence = backtickMatches 
-        ? Math.max(...backtickMatches.map(m => m.length)) 
-        : 0;
+    // パフォーマンス改善: 大規模ファイルでのメモリエラーを防ぐため、スプレッド構文とmapではなくfor...ofループを使用する
+    let longestBacktickSequence = 0;
+    if (backtickMatches) {
+        for (const m of backtickMatches) {
+            if (m.length > longestBacktickSequence) {
+                longestBacktickSequence = m.length;
+            }
+        }
+    }
     
     // Use at least 3 backticks, or one more than the longest sequence found
     const fenceLength = Math.max(3, longestBacktickSequence + 1);


### PR DESCRIPTION
💡 What: `Math.max(...backtickMatches.map(...))` を `for...of` ループに置き換えました。
🎯 Why: 大きなマークダウンファイルで大量のバッククォートが存在する場合、スプレッド構文による「Maximum call stack size exceeded」エラーを防ぐとともに、中間配列の生成をなくしてメモリ効率を上げるためです。
📊 Impact: 巨大な入力に対するクラッシュを防止し、不要なメモリ割り当てを削減します。
🔬 Measurement: 既存のテストスイートが全てパスすることを確認し、処理速度への悪影響がないことを検証します。

---
*PR created automatically by Jules for task [14590485606431725760](https://jules.google.com/task/14590485606431725760) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

正規表現の一致結果をスプレッドして最大値を求める処理を反復処理へ置き換え、大量のバッククォートを含む入力での引数上限エラーと中間配列の割り当てを回避します。
- `buildFencedCodeBlock` の最長バッククォート列計算を `for...of` ループへ変更
- パフォーマンス改善の学習記録を `.jules/bolt.md` に追加
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

実装変更は安全にマージできると考えられますが、学習ドキュメントはリポジトリ規約に従って日本語へ修正してください。

最大値計算の反復処理は既存のフェンス選択結果を維持しており、確認された問題は追加ドキュメントの言語規約違反のみです。

**Files Needing Attention:** .jules/bolt.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/markdownFencing.ts | 最長バッククォート列の計算は旧実装と等価であり、大量一致時のスプレッド構文によるクラッシュ要因を解消しています。 |
| .jules/bolt.md | 改善内容を学習記録へ追加していますが、本文が英語でリポジトリの日本語記述規約に反しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/bolt.md:64-65
**学習記録の言語不整合**

追加された Learning と Action が英語で記述されており、ドキュメントを日本語で記述するリポジトリ規約と不整合です。学習記録の一貫性を保つため、日本語へ統一してください。

```suggestion
**Learning:** 大規模な Markdown ドキュメントの正規表現マッチ結果をスプレッド構文で関数へ渡すと（例: `Math.max(...matches)`）、`Maximum call stack size exceeded` エラーと不要なメモリ割り当てが発生します。
**Action:** 大規模入力でのクラッシュと中間配列の生成を防ぐため、スプレッド構文と `.map()` の代わりに命令的な `for...of` ループを使用します。
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Optimize markdownFencing to prevent call..."](https://github.com/hiroki-org/jules-extension/commit/6899ddc045f85942b1f46514c15ea5e39d73e652) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57550829)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))

<!-- /greptile_comment -->