### PR TITLE
🛡️ Sentinel: [Enhancement] CSPに object-src 'none' を追加

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,7 @@
 **Vulnerability:** コンポーザーWebviewが `localResourceRoots` を設定せずに初期化されており、Webviewにローカルファイルパスが露出する可能性がありました。
 **Learning:** ローカルリソースへの依存がない `createWebviewPanel` を使用する場合、アクセスを制限するために常に `localResourceRoots: []` を強制する必要があります。
 **Prevention:** すべての `vscode.window.createWebviewPanel` 呼び出しで明示的に `localResourceRoots` を設定します。
+## 2026-08-27 - [CSP Object-Src Enhancement]
+**Vulnerability:** CSP configurations relying on `default-src 'none'` can occasionally leave gaps for legacy plugins via `<object>`, `<embed>`, or `<applet>` tags due to browser quirks or bypasses.
+**Learning:** Explicitly declaring `object-src 'none'` even when `default-src 'none'` is present acts as defense-in-depth.
+**Prevention:** Always explicitly define `object-src 'none'` in all VS Code Webview CSP configurations.

--- a/src/chatView.ts
+++ b/src/chatView.ts
@@ -504,7 +504,7 @@ export function getChatWebviewHtml(
 ): string {
   const domPurifyScriptUri = getDOMPurifyScriptUri(webview, extensionUri);
   return (
-    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; style-src ' +
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; object-src \'none\'; style-src ' +
     webview.cspSource +
     " 'nonce-" +
     nonce +

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -90,7 +90,7 @@ export function getComposerHtml(
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; img-src ${webview.cspSource}; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'nonce-${nonce}';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <style nonce="${nonce}">

--- a/src/test/chatView.unit.test.ts
+++ b/src/test/chatView.unit.test.ts
@@ -96,6 +96,7 @@ suite("Chat View Unit Test Suite", () => {
     );
     assert.ok(html.includes("script-src 'nonce-nonce-123'"));
     assert.ok(html.includes("base-uri 'none'"));
+    assert.ok(html.includes("object-src 'none'"));
     assert.ok(!html.includes("script-src https://example.com"));
     assert.ok(!html.includes("DOMPURIFY_SOURCE"));
   });

--- a/src/test/composer.unit.test.ts
+++ b/src/test/composer.unit.test.ts
@@ -527,6 +527,15 @@ suite("Composer Test Suite", () => {
       assert.ok(html.includes("base-uri 'none'"));
     });
 
+    test("should include object-src 'none' in Content-Security-Policy", () => {
+      const html = getComposerHtml(
+        mockWebview,
+        { title: "Test" },
+        "nonce-123"
+      );
+      assert.ok(html.includes("object-src 'none'"));
+    });
+
     test("should set submitButton disabled state based on validation result", () => {
       const html = getComposerHtml(
         mockWebview,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: CSPで `object-src 'none'` が明示的に設定されておらず、フォールバックの `default-src 'none'` に依存しています。しかし、レガシーブラウザの挙動や特定のバイパスにより `<object>`, `<embed>`, `<applet>` タグを介したプラグイン実行のリスクが残存する可能性があります。
🎯 Impact: 万一 `default-src 'none'` が不十分だった場合やブラウザのバグにより、悪意のあるプラグイン（Flash等）が実行される可能性が理論上存在します。
🔧 Fix: `src/composer.ts` と `src/chatView.ts` のWebview HTML生成処理において、CSPメタタグへ `object-src 'none'` を明示的に追加しました。
✅ Verification: ユニットテストを追加し、HTML内に `object-src 'none'` が含まれていることを確認しました。

---
*PR created automatically by Jules for task [2875660862231910821](https://jules.google.com/task/2875660862231910821) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CSPの防御を明示化し、チャットおよびコンポーザーのWebviewでプラグイン形式のオブジェクト読み込みを禁止する変更です。
- `src/chatView.ts`と`src/composer.ts`のCSPへ`object-src 'none'`を追加
- 両Webviewの生成HTMLに当該ディレクティブが含まれることをユニットテストで確認
- Sentinelのセキュリティ履歴へ今回の対策を追記
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

CSPの変更は安全にマージできる内容ですが、Sentinelの追記はリポジトリ規約に合わせて日本語へ直すことを推奨します。

WebviewのCSP強化とテストには機能上の問題が見当たらず、残る指摘は追加ドキュメントの言語統一のみです。

**Files Needing Attention:** .jules/sentinel.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/chatView.ts | チャットWebviewの有効なCSPへ`object-src 'none'`を追加しており、既存の必要リソースを妨げる変更は見当たりません。 |
| src/composer.ts | コンポーザーWebviewのCSPへ正しく区切られた`object-src 'none'`を追加しています。 |
| src/test/chatView.unit.test.ts | 生成HTMLに新しいCSPディレクティブが含まれることを既存のセキュリティテストで検証しています。 |
| src/test/composer.unit.test.ts | コンポーザーの生成HTMLに`object-src 'none'`が含まれることを専用テストで検証しています。 |
| .jules/sentinel.md | 対策履歴の内容は変更と整合していますが、日本語で記述するリポジトリ規約に反して英語で追加されています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.jules/sentinel.md:38-41
**Sentinel記録の英語表記**

追加された見出しと説明が英語で記述されているため、日本語でドキュメントを記述するリポジトリ規約に反し、既存記録との一貫性と保守時の可読性が低下します。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[Enhancement\] CSPに object-..."](https://github.com/hiroki-org/jules-extension/commit/68cb418a33b5e8d5b686ce04849935fa31bcb369) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57575189)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/hiroki-org/jules-extension/blob/main/AGENTS.md))

<!-- /greptile_comment -->